### PR TITLE
Added code to show get_instance_handles() and lookup_instance()

### DIFF
--- a/tests/DCPS/PersistentDurability/DataReaderListener.cpp
+++ b/tests/DCPS/PersistentDurability/DataReaderListener.cpp
@@ -30,17 +30,16 @@ DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
       exit(1);
     }
 
-    Messenger::Message message;
-    DDS::SampleInfo si ;
-    DDS::ReturnCode_t status = message_dr->take_next_sample(message, si) ;
+    Messenger::Message st_msg;
+    DDS::SampleInfo st_info;
+    DDS::ReturnCode_t status = message_dr->take_next_sample(st_msg, st_info) ;
 
     if (status == DDS::RETCODE_OK) {
-      cout << "Message: subject    = " << message.subject.in() << endl
-           << "         subject_id = " << message.subject_id   << endl
-           << "         from       = " << message.from.in()    << endl
-           << "         count      = " << message.count        << endl
-           << "         text       = " << message.text.in()    << endl;
-      cout << "SampleInfo.sample_rank = " << si.sample_rank << endl;
+      printf("--sub-- Msg:  rank: %2u  state: %u %u %u  subj_id: %3d  cnt: %2d  from: %-16s  subj: %-10s  text: %-20s\n",
+        st_info.sample_rank,
+        st_info.sample_state, st_info.view_state, st_info.instance_state,
+        st_msg.subject_id, st_msg.count, st_msg.from.in(), st_msg.subject.in(), st_msg.text.in());
+      fflush(stdout);
     } else if (status == DDS::RETCODE_NO_DATA) {
       cerr << "ERROR: reader received DDS::RETCODE_NO_DATA!" << endl;
     } else {

--- a/tests/DCPS/PersistentDurability/Writer.cpp
+++ b/tests/DCPS/PersistentDurability/Writer.cpp
@@ -42,7 +42,7 @@ Writer::svc ()
     i_subject = s_i_subject++;
   }
 
-  this->write_loop(i_subject, nullptr, nullptr, nullptr, s_i_msg_cnt);
+  this->write_loop(i_subject, NULL, NULL, NULL, s_i_msg_cnt);
 
   ACE_DEBUG ((LM_DEBUG, ACE_TEXT("(%P|%t) Writer::svc finished.\n")));
 
@@ -57,9 +57,9 @@ Writer::write_loop(int i_subject, char const *pc_from, char const *pc_subj, char
   static char const s_ac_subj[] = "Review";
   static char const s_ac_text[] = "Worst. Movie. Ever.";
 
-  if (nullptr == pc_from)  pc_from = s_ac_from;
-  if (nullptr == pc_subj)  pc_subj = s_ac_subj;
-  if (nullptr == pc_text)  pc_text = s_ac_text;
+  if (NULL == pc_from)  pc_from = s_ac_from;
+  if (NULL == pc_subj)  pc_subj = s_ac_subj;
+  if (NULL == pc_text)  pc_text = s_ac_text;
 
   try
   {

--- a/tests/DCPS/PersistentDurability/Writer.h
+++ b/tests/DCPS/PersistentDurability/Writer.h
@@ -17,15 +17,17 @@ public:
   Writer (::DDS::DataWriter_ptr writer);
   virtual ~Writer ();
   virtual int svc ();
-  bool start ();
+  bool start (int i_threads, int i_msg_cnt, int i_subject_1st);
   bool end ();
   int get_timeout_writes () const;
 
+  int write_loop(int i_subject, char const *pc_from, char const *pc_subj, char const *pc_text, int i_msgs);
+
+  int set_count(int i_count);
+
 private:
 
-  int write (Messenger::MessageDataWriter_ptr message_dw,
-             ::DDS::InstanceHandle_t& handle,
-             Messenger::Message& message);
+  ::DDS::ReturnCode_t write_one(Messenger::MessageDataWriter_ptr message_dw, ::DDS::InstanceHandle_t& handle, Messenger::Message& message, int i_count);
 
 private:
 

--- a/tests/DCPS/PersistentDurability/publisher.cpp
+++ b/tests/DCPS/PersistentDurability/publisher.cpp
@@ -308,7 +308,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           printf("--pub------- Call  write 1st subject\n");
           fflush(stdout);
           writer->set_count(s_i_writer_threads * s_i_writer_msgs - 1);
-          writer->write_loop(s_i_writer_subj_1st, nullptr, nullptr, nullptr, 1);
+          writer->write_loop(s_i_writer_subj_1st, NULL, NULL, NULL, 1);
           printf("--pub------- After write 1st subject\n");
           fflush(stdout);
           local_show_instances(dw.in());

--- a/tests/DCPS/PersistentDurability/run_test.pl
+++ b/tests/DCPS/PersistentDurability/run_test.pl
@@ -51,6 +51,7 @@ print $Publisher1->CommandLine() . "\n";
 print $Publisher2->CommandLine() . "\n";
 print $Subscriber->CommandLine() . "\n";
 
+print "INFO: start Repo\n";
 $DCPSREPO->Spawn ();
 if (PerlACE::waitforfile_timed ($dcpsrepo_ior, 30) == -1) {
     print STDERR "ERROR: waiting for Info Repo IOR file\n";
@@ -61,6 +62,7 @@ if (PerlACE::waitforfile_timed ($dcpsrepo_ior, 30) == -1) {
 $durability_cache = 'data';
 rmtree($durability_cache) if -d $durability_cache;
 
+print "INFO: start publisher 1\n";
 $Publisher1->Spawn ();
 
 # Wait for the publisher to end before starting the subscriber so that
@@ -77,10 +79,12 @@ else {
 
 # Now spawn the publisher that will actually wait for the DataReader
 # to complete its reads.
+print "INFO: start publisher 2\n";
 $Publisher2->Spawn ();
 
 sleep (1);
 
+print "INFO: start subscriber\n";
 $Subscriber->Spawn ();
 
 $PublisherResult = $Publisher2->WaitKill (300);
@@ -88,13 +92,18 @@ if ($PublisherResult != 0) {
     print STDERR "ERROR: publisher 2 returned $PublisherResult\n";
     $status = 1;
 }
+else {
+    print "INFO: publisher 2 completed\n";
+}
 
 $SubscriberResult = $Subscriber->WaitKill (15);
 if ($SubscriberResult != 0) {
     print STDERR "ERROR: subscriber returned $SubscriberResult\n";
     $status = 1;
 }
-
+else {
+    print "INFO: subscriber  completed\n";
+}
 
 rmtree($durability_cache) if -d $durability_cache;
 

--- a/tests/DCPS/PersistentDurability/subscriber.cpp
+++ b/tests/DCPS/PersistentDurability/subscriber.cpp
@@ -100,6 +100,8 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
       sub->get_default_datareader_qos(dr_qos);
       dr_qos.durability.kind = DDS::PERSISTENT_DURABILITY_QOS;
 
+      printf("--sub------- Call create_datareader()\n");
+      fflush(stdout);
       DDS::DataReader_var dr =
         sub->create_datareader(topic, dr_qos, listener,
                                OpenDDS::DCPS::DEFAULT_STATUS_MASK);
@@ -108,12 +110,22 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
         exit(1);
       }
 
-      int const expected = 10;
-      while (listener_servant->num_reads() < expected)
+      printf("--sub------- Wait for 12 msgs\n");
+      fflush(stdout);
+      for (int i_expected = 12;  listener_servant->num_reads() < i_expected;  /*empty*/)
       {
         ACE_OS::sleep (1);
       }
 
+      printf("--sub------- Wait for 4 secs\n");
+      fflush(stdout);
+      for (int i_max_secs = 4;  i_max_secs > 0;  --i_max_secs)
+      {
+        ACE_OS::sleep (1);
+      }
+
+      printf("--sub------- Delete and shutdown ...\n");
+      fflush(stdout);
       if (!CORBA::is_nil (participant.in ())) {
         participant->delete_contained_entities();
       }


### PR DESCRIPTION
  These changes are only to tests/DCPS/PersistentDurability.  These changes do not cause the test to fail, they only help illustrate issue 1641.
  They show that, after persistent messages are read into a DataWriter, those messages do not appear correctly when using get_instance_handles() and get_key_value().  Nor can lookup_instance() find anything using known key values.