### PR TITLE
Test Making RTPS the Default for the Future

### DIFF
--- a/DDS.mwc
+++ b/DDS.mwc
@@ -19,5 +19,6 @@ workspace {
     tools/modeling/tests
 
     dds/InfoRepo
+    tools/dcpsinfo_dump
   }
 }

--- a/DDS.mwc
+++ b/DDS.mwc
@@ -17,5 +17,7 @@ workspace {
     // Run tools/modeling/tests/setup.pl to generate
     // tools/modeling/tests/modeling_tests.mwc.
     tools/modeling/tests
+
+    dds/InfoRepo
   }
 }

--- a/DDS_TAOv2.mwc
+++ b/DDS_TAOv2.mwc
@@ -14,5 +14,6 @@ workspace {
     tools/modeling/tests
 
     dds/InfoRepo
+    tools/dcpsinfo_dump
   }
 }

--- a/DDS_TAOv2.mwc
+++ b/DDS_TAOv2.mwc
@@ -12,5 +12,7 @@ workspace {
     // Run tools/modeling/tests/setup.pl to generate
     // tools/modeling/tests/modeling_tests.mwc.
     tools/modeling/tests
+
+    dds/InfoRepo
   }
 }

--- a/DevGuideExamples/DCPS/Messenger.minimal/MessengerMinimal.mpc
+++ b/DevGuideExamples/DCPS/Messenger.minimal/MessengerMinimal.mpc
@@ -7,7 +7,7 @@ project(*idl): dcps {
   custom_only = 1
 }
 
-project(*publisher) : dcpsexe, dcps_tcp, dds_model {
+project(*publisher) : dcps, dcps_rtps_udp, dds_model {
   requires += no_opendds_safety_profile
   exename   = publisher
   after    += *idl
@@ -22,7 +22,7 @@ project(*publisher) : dcpsexe, dcps_tcp, dds_model {
   }
 }
 
-project(*subscriber) : dcpsexe, dcps_tcp, dds_model {
+project(*subscriber) : dcps, dcps_rtps_udp, dds_model {
   requires += no_opendds_safety_profile
   exename   = subscriber
   after    += *publisher

--- a/DevGuideExamples/DCPS/Messenger.minimal/run_test.pl
+++ b/DevGuideExamples/DCPS/Messenger.minimal/run_test.pl
@@ -18,25 +18,8 @@ my $pub_opts = "$common_opts -ORBLogFile publisher.log";
 my $sub_opts = "$common_opts -DCPSTransportDebugLevel 6 " .
                "-ORBLogFile subscriber.log";
 
-my $dcpsrepo_ior = "repo.ior";
-
-unlink $dcpsrepo_ior;
-
-my $DCPSREPO = PerlDDS::create_process ("$ENV{DDS_ROOT}/bin/DCPSInfoRepo",
-                                        "-ORBDebugLevel 10 " .
-                                        "-ORBLogFile DCPSInfoRepo.log " .
-                                        "-o $dcpsrepo_ior");
-
 my $Subscriber = PerlDDS::create_process ("subscriber", " $sub_opts");
 my $Publisher = PerlDDS::create_process ("publisher", " $pub_opts");
-
-print $DCPSREPO->CommandLine() . "\n";
-$DCPSREPO->Spawn ();
-if (PerlACE::waitforfile_timed ($dcpsrepo_ior, 30) == -1) {
-    print STDERR "ERROR: waiting for Info Repo IOR file\n";
-    $DCPSREPO->Kill ();
-    exit 1;
-}
 
 print $Publisher->CommandLine() . "\n";
 $Publisher->Spawn ();
@@ -55,13 +38,5 @@ if ($SubscriberResult != 0) {
     print STDERR "ERROR: subscriber returned $SubscriberResult\n";
     $status = 1;
 }
-
-my $ir = $DCPSREPO->TerminateWaitKill(5);
-if ($ir != 0) {
-    print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
-    $status = 1;
-}
-
-unlink $dcpsrepo_ior;
 
 exit $status;

--- a/DevGuideExamples/DCPS/Messenger/CMakeLists.txt
+++ b/DevGuideExamples/DCPS/Messenger/CMakeLists.txt
@@ -7,8 +7,8 @@ set(CMAKE_CXX_COMPILER ${OPENDDS_COMPILER})
 
 set(opendds_libs
   OpenDDS::Dcps # Core OpenDDS Library
-  OpenDDS::InfoRepoDiscovery OpenDDS::Tcp # For run_test.pl
-  OpenDDS::Rtps OpenDDS::Rtps_Udp # For run_test.pl --rtps
+  OpenDDS::Rtps OpenDDS::Rtps_Udp # For run_test.pl
+  OpenDDS::InfoRepoDiscovery # For run_test.pl --info-repo
 )
 
 # Publisher

--- a/DevGuideExamples/DCPS/Messenger/Messenger.mpc
+++ b/DevGuideExamples/DCPS/Messenger/Messenger.mpc
@@ -7,7 +7,7 @@ project(*idl): dcps {
   custom_only = 1
 }
 
-project(*publisher) : dcpsexe, dcps_tcp, dcps_rtps_udp {
+project(*publisher) : dcps, dcps_rtps_udp, dcps_inforepodiscovery {
   requires += no_opendds_safety_profile
   exename   = publisher
   after    += *idl
@@ -21,7 +21,7 @@ project(*publisher) : dcpsexe, dcps_tcp, dcps_rtps_udp {
   }
 }
 
-project(*subscriber) : dcpsexe, dcps_tcp, dcps_rtps_udp {
+project(*subscriber) : dcps, dcps_rtps_udp, dcps_inforepodiscovery {
   requires += no_opendds_safety_profile
   exename   = subscriber
   after    += *publisher

--- a/DevGuideExamples/DCPS/Messenger/README.md
+++ b/DevGuideExamples/DCPS/Messenger/README.md
@@ -4,9 +4,9 @@ A very basic OpenDDS example, covered in the OpenDDS Developer's Guide.
 
 If you just want to build and run this, it will be built along with OpenDDS and
 can be run using `perl run_test.pl` assuming the `setenv` file has been sourced
-(see [INSTALL.md](../../../INSTALL.md) for details). To have it use the DDS
-standard RTPS discovery and transport instead of the OpenDDS specific InfoRepo
-discovery and TCP transports, run `perl run_test.pl --rtps` instead.
+(see [INSTALL.md](../../../INSTALL.md) for details). To have it use the
+OpenDDS-specific InfoRepo discovery instead of the DDS standard RTPS discovery,
+run `perl run_test.pl --info-repo` instead.
 
 ## CMake
 
@@ -23,5 +23,4 @@ these are the recommend steps:
    "out-of-source" build.
  - Run `cmake ..` to generate the build and `cmake --build .` to build.
  - To run the example you can copy `run_test.pl` to the `build` directory and
-   use that or run `./publisher -DCPSConfigFile ../rtps.ini` and `./subscriber
-   -DCPSConfigFile ../rtps.ini` at the same time.
+   use that or run `./publisher` and `./subscriber` at the same time.

--- a/DevGuideExamples/DCPS/Messenger/info-repo.ini
+++ b/DevGuideExamples/DCPS/Messenger/info-repo.ini
@@ -1,0 +1,2 @@
+[common]
+DCPSDefaultDiscovery=DEFAULT_REPO

--- a/DevGuideExamples/DCPS/Messenger/rtps.ini
+++ b/DevGuideExamples/DCPS/Messenger/rtps.ini
@@ -1,6 +1,0 @@
-[common]
-DCPSDefaultDiscovery=DEFAULT_RTPS
-DCPSGlobalTransportConfig=$file
-
-[transport/the_rtps_transport]
-transport_type=rtps_udp

--- a/DevGuideExamples/DCPS/Messenger/run_test.pl
+++ b/DevGuideExamples/DCPS/Messenger/run_test.pl
@@ -16,12 +16,12 @@ use strict;
 
 my $status = 0;
 
-my $rtps = 0;
+my $info_repo = 0;
 my $help = 0;
 
-my $help_message = "usage: run_test.pl [-h|--help] [--rtps]\n";
+my $help_message = "usage: run_test.pl [-h|--help] [--info-repo]\n";
 if (not GetOptions(
-  "rtps" => \$rtps,
+  "info-repo" => \$info_repo,
   "help|h" => \$help
 )) {
   print STDERR ("Invalid Command Line Argument(s)\n$help_message");
@@ -36,8 +36,8 @@ unlink "publisher.log";
 
 my $common_opts = "-ORBDebugLevel 10 -DCPSDebugLevel 10";
 
-if ($rtps) {
-  $common_opts .= " -DCPSConfigFile rtps.ini";
+if ($info_repo) {
+  $common_opts .= " -DCPSConfigFile info-repo.ini";
 }
 
 my $pub_opts = "$common_opts -ORBLogFile publisher.log";
@@ -64,7 +64,7 @@ if (!(-e $subdir.$filename) && !(-e $subdir.$filename_exe)) {
 my $Subscriber = PerlDDS::create_process("subscriber", " $sub_opts");
 my $Publisher = PerlDDS::create_process("publisher", " $pub_opts");
 
-if (not $rtps) {
+if ($info_repo) {
   unlink $dcpsrepo_ior;
 
   $DCPSREPO = PerlDDS::create_process(
@@ -100,7 +100,7 @@ if ($SubscriberResult != 0) {
   $status = 1;
 }
 
-if (not $rtps) {
+if ($info_repo) {
   my $ir = $DCPSREPO->TerminateWaitKill(5);
   if ($ir != 0) {
     print STDERR "ERROR: DCPSInfoRepo returned $ir\n";

--- a/DevGuideExamples/DCPS/Messenger_ZeroCopy/Messenger_ZeroCopy.mpc
+++ b/DevGuideExamples/DCPS/Messenger_ZeroCopy/Messenger_ZeroCopy.mpc
@@ -10,7 +10,7 @@ project(*idl): dcps_test_idl_only_lib {
   }
 }
 
-project(*publisher) : dcpsexe, dcps_tcp {
+project(*publisher) : dcps_rtps_udp {
   requires += no_opendds_safety_profile
   exename   = publisher
   after    += *idl
@@ -24,7 +24,7 @@ project(*publisher) : dcpsexe, dcps_tcp {
   }
 }
 
-project(*subscriber) : dcpsexe, dcps_tcp {
+project(*subscriber) : dcps_rtps_udp {
   requires += no_opendds_safety_profile
   exename   = subscriber
   after    += *idl

--- a/DevGuideExamples/DCPS/Messenger_ZeroCopy/run_test.pl
+++ b/DevGuideExamples/DCPS/Messenger_ZeroCopy/run_test.pl
@@ -18,25 +18,8 @@ my $pub_opts = "$common_opts -ORBLogFile publisher.log";
 my $sub_opts = "$common_opts -DCPSTransportDebugLevel 6 " .
                "-ORBLogFile subscriber.log";
 
-my $dcpsrepo_ior = "repo.ior";
-
-unlink $dcpsrepo_ior;
-
-my $DCPSREPO = PerlDDS::create_process ("$ENV{DDS_ROOT}/bin/DCPSInfoRepo",
-                                        "$common_opts " .
-                                        "-ORBLogFile DCPSInfoRepo.log " .
-                                        "-o $dcpsrepo_ior ");
-
 my $Subscriber = PerlDDS::create_process ("subscriber", " $sub_opts");
 my $Publisher = PerlDDS::create_process ("publisher", " $pub_opts");
-
-print $DCPSREPO->CommandLine() . "\n";
-$DCPSREPO->Spawn ();
-if (PerlACE::waitforfile_timed ($dcpsrepo_ior, 30) == -1) {
-    print STDERR "ERROR: waiting for Info Repo IOR file\n";
-    $DCPSREPO->Kill ();
-    exit 1;
-}
 
 print $Publisher->CommandLine() . "\n";
 $Publisher->Spawn ();
@@ -55,13 +38,5 @@ if ($SubscriberResult != 0) {
     print STDERR "ERROR: subscriber returned $SubscriberResult\n";
     $status = 1;
 }
-
-my $ir = $DCPSREPO->TerminateWaitKill(5);
-if ($ir != 0) {
-    print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
-    $status = 1;
-}
-
-unlink $dcpsrepo_ior;
 
 exit $status;

--- a/MPC/config/dcps_default_discovery.mpb
+++ b/MPC/config/dcps_default_discovery.mpb
@@ -1,5 +1,2 @@
-feature(!no_opendds_safety_profile) : dcps_rtps {
-}
-
-feature(no_opendds_safety_profile) : dcps_inforepodiscovery, dcps_tcp {
+project: dcps_rtps {
 }

--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -321,7 +321,7 @@ sub new {
   $self->{info_repo}->{file} = "repo.ior";
   $self->{processes}->{process} = {};
   $self->{processes}->{order} = [];
-  $self->{discovery} = "info_repo";
+  $self->{discovery} = "rtps";
   $self->{test_verbose} = 0;
   $self->{add_transport_config} = 1;
   $self->{nobits} = 0;

--- a/dds/DCPS/Discovery.cpp
+++ b/dds/DCPS/Discovery.cpp
@@ -5,20 +5,18 @@
  * See: http://www.opendds.org/license.html
  */
 
-#include <DCPS/DdsDcps_pch.h> //Only the _pch include should start with DCPS/
-
+#include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
 #include "Discovery.h"
-
 #include "Service_Participant.h"
 #include "BuiltInTopicUtils.h"
 #include "Registered_Data_Types.h"
+#include "DdsDcpsCoreC.h"
 #include "Marked_Default_Qos.h"
 #include "SafetyProfileStreams.h"
 #include "DCPS_Utils.h"
 
-#include <dds/DdsDcpsCoreC.h>
 #ifndef DDS_HAS_MINIMUM_BIT
-#  include <dds/DdsDcpsCoreTypeSupportImpl.h>
+#include "DdsDcpsCoreTypeSupportImpl.h"
 #endif /* DDS_HAS_MINIMUM_BIT */
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -26,9 +24,9 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-const char* const Discovery::DEFAULT_REPO = "DEFAULT_REPO";
-const char* const Discovery::DEFAULT_RTPS = "DEFAULT_RTPS";
-const char* const Discovery::DEFAULT_STATIC = "DEFAULT_STATIC";
+const char* Discovery::DEFAULT_REPO = "DEFAULT_REPO";
+const char* Discovery::DEFAULT_RTPS = "DEFAULT_RTPS";
+const char* Discovery::DEFAULT_STATIC = "DEFAULT_STATIC";
 
 DDS::ReturnCode_t
 Discovery::create_bit_topics(DomainParticipantImpl* participant)

--- a/dds/DCPS/Discovery.cpp
+++ b/dds/DCPS/Discovery.cpp
@@ -5,18 +5,20 @@
  * See: http://www.opendds.org/license.html
  */
 
-#include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
+#include <DCPS/DdsDcps_pch.h> //Only the _pch include should start with DCPS/
+
 #include "Discovery.h"
+
 #include "Service_Participant.h"
 #include "BuiltInTopicUtils.h"
 #include "Registered_Data_Types.h"
-#include "DdsDcpsCoreC.h"
 #include "Marked_Default_Qos.h"
 #include "SafetyProfileStreams.h"
 #include "DCPS_Utils.h"
 
+#include <dds/DdsDcpsCoreC.h>
 #ifndef DDS_HAS_MINIMUM_BIT
-#include "DdsDcpsCoreTypeSupportImpl.h"
+#  include <dds/DdsDcpsCoreTypeSupportImpl.h>
 #endif /* DDS_HAS_MINIMUM_BIT */
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -24,9 +26,9 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-const char* Discovery::DEFAULT_REPO = "DEFAULT_REPO";
-const char* Discovery::DEFAULT_RTPS = "DEFAULT_RTPS";
-const char* Discovery::DEFAULT_STATIC = "DEFAULT_STATIC";
+const char* const Discovery::DEFAULT_REPO = "DEFAULT_REPO";
+const char* const Discovery::DEFAULT_RTPS = "DEFAULT_RTPS";
+const char* const Discovery::DEFAULT_STATIC = "DEFAULT_STATIC";
 
 DDS::ReturnCode_t
 Discovery::create_bit_topics(DomainParticipantImpl* participant)

--- a/dds/DCPS/Discovery.h
+++ b/dds/DCPS/Discovery.h
@@ -8,26 +8,28 @@
 #ifndef OPENDDS_DCPS_DISCOVERY_H
 #define OPENDDS_DCPS_DISCOVERY_H
 
+#include "dds/DdsDcpsInfoUtilsC.h"
 #include "RcObject.h"
 #include "RcHandle_T.h"
 #include "unique_ptr.h"
 #include "XTypes/TypeObject.h"
 #include "XTypes/TypeLookupService.h"
+
 #include "DataReaderCallbacks.h"
 #include "DataWriterCallbacks.h"
 #include "TopicCallbacks.h"
+#include "dds/DdsDcpsSubscriptionC.h"
+
 #include "PoolAllocator.h"
 #include "PoolAllocationBase.h"
 
-#include <dds/DdsDcpsSubscriptionC.h>
-#include <dds/DdsDcpsInfoUtilsC.h>
 #ifdef OPENDDS_SECURITY
-#  include <dds/DdsSecurityCoreC.h>
+#include "dds/DdsSecurityCoreC.h"
 #endif
 
-#ifndef ACE_LACKS_PRAGMA_ONCE
-#  pragma once
-#endif
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 class ACE_Configuration_Heap;
@@ -55,14 +57,14 @@ class OpenDDS_Dcps_Export Discovery : public RcObject {
 public:
   /// Key type for storing discovery objects.
   /// Probably should just be Discovery::Key
-  typedef String RepoKey;
+  typedef OPENDDS_STRING RepoKey;
 
   explicit Discovery(const RepoKey& key) : key_(key) { }
 
-  // Possible values for key
-  static const char* const DEFAULT_REPO;
-  static const char* const DEFAULT_RTPS;
-  static const char* const DEFAULT_STATIC;
+  /// Key value for the default repository IOR.
+  static const char* DEFAULT_REPO;
+  static const char* DEFAULT_RTPS;
+  static const char* DEFAULT_STATIC;
 
   // TODO: NEED TO REMOVE THIS once Service_Participant::repository_lost has been refactored
   virtual bool active() { return true; }
@@ -262,7 +264,7 @@ protected:
   DDS::ReturnCode_t create_bit_topics(DomainParticipantImpl* participant);
 
 private:
-  RepoKey key_;
+  RepoKey        key_;
 
 };
 

--- a/dds/DCPS/Discovery.h
+++ b/dds/DCPS/Discovery.h
@@ -8,28 +8,26 @@
 #ifndef OPENDDS_DCPS_DISCOVERY_H
 #define OPENDDS_DCPS_DISCOVERY_H
 
-#include "dds/DdsDcpsInfoUtilsC.h"
 #include "RcObject.h"
 #include "RcHandle_T.h"
 #include "unique_ptr.h"
 #include "XTypes/TypeObject.h"
 #include "XTypes/TypeLookupService.h"
-
 #include "DataReaderCallbacks.h"
 #include "DataWriterCallbacks.h"
 #include "TopicCallbacks.h"
-#include "dds/DdsDcpsSubscriptionC.h"
-
 #include "PoolAllocator.h"
 #include "PoolAllocationBase.h"
 
+#include <dds/DdsDcpsSubscriptionC.h>
+#include <dds/DdsDcpsInfoUtilsC.h>
 #ifdef OPENDDS_SECURITY
-#include "dds/DdsSecurityCoreC.h"
+#  include <dds/DdsSecurityCoreC.h>
 #endif
 
-#if !defined (ACE_LACKS_PRAGMA_ONCE)
-#pragma once
-#endif /* ACE_LACKS_PRAGMA_ONCE */
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 class ACE_Configuration_Heap;
@@ -57,14 +55,14 @@ class OpenDDS_Dcps_Export Discovery : public RcObject {
 public:
   /// Key type for storing discovery objects.
   /// Probably should just be Discovery::Key
-  typedef OPENDDS_STRING RepoKey;
+  typedef String RepoKey;
 
   explicit Discovery(const RepoKey& key) : key_(key) { }
 
-  /// Key value for the default repository IOR.
-  static const char* DEFAULT_REPO;
-  static const char* DEFAULT_RTPS;
-  static const char* DEFAULT_STATIC;
+  // Possible values for key
+  static const char* const DEFAULT_REPO;
+  static const char* const DEFAULT_RTPS;
+  static const char* const DEFAULT_STATIC;
 
   // TODO: NEED TO REMOVE THIS once Service_Participant::repository_lost has been refactored
   virtual bool active() { return true; }
@@ -264,7 +262,7 @@ protected:
   DDS::ReturnCode_t create_bit_topics(DomainParticipantImpl* participant);
 
 private:
-  RepoKey        key_;
+  RepoKey key_;
 
 };
 

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -150,13 +150,6 @@ static bool got_pending_timeout = false;
 static bool got_persistent_data_dir = false;
 #endif
 static bool got_default_discovery = false;
-#ifndef DDS_DEFAULT_DISCOVERY_METHOD
-# ifdef OPENDDS_SAFETY_PROFILE
-#  define DDS_DEFAULT_DISCOVERY_METHOD Discovery::DEFAULT_RTPS
-# else
-#  define DDS_DEFAULT_DISCOVERY_METHOD Discovery::DEFAULT_REPO
-# endif
-#endif
 static bool got_log_fname = false;
 static bool got_log_verbose = false;
 static bool got_default_address = false;
@@ -170,7 +163,7 @@ Service_Participant::Service_Participant()
     ORB_argv_(false /*substitute_env_args*/),
 #endif
     reactor_task_(false),
-    defaultDiscovery_(DDS_DEFAULT_DISCOVERY_METHOD),
+    defaultDiscovery_(Discovery::DEFAULT_RTPS),
     n_chunks_(DEFAULT_NUM_CHUNKS),
     association_chunk_multiplier_(DEFAULT_CHUNK_MULTIPLIER),
     liveliness_factor_(80),

--- a/dds/DCPS/transport/framework/TransportRegistry.cpp
+++ b/dds/DCPS/transport/framework/TransportRegistry.cpp
@@ -5,23 +5,24 @@
  * See: http://www.opendds.org/license.html
  */
 
-#include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
+#include <DCPS/DdsDcps_pch.h> //Only the _pch include should start with DCPS/
+
 #include "TransportRegistry.h"
 #include "TransportDebug.h"
 #include "TransportInst.h"
 #include "TransportExceptions.h"
 #include "TransportType.h"
-#include "dds/DCPS/GuidConverter.h"
-#include "dds/DCPS/Util.h"
-#include "dds/DCPS/Service_Participant.h"
-#include "dds/DCPS/EntityImpl.h"
-#include "dds/DCPS/SafetyProfileStreams.h"
+
+#include <dds/DCPS/GuidConverter.h>
+#include <dds/DCPS/Util.h>
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/EntityImpl.h>
+#include <dds/DCPS/SafetyProfileStreams.h>
 #include <dds/DdsDcpsInfrastructureC.h>
 
-
-#include "ace/Singleton.h"
-#include "ace/OS_NS_strings.h"
-#include "ace/Service_Config.h"
+#include <ace/Singleton.h>
+#include <ace/OS_NS_strings.h>
+#include <ace/Service_Config.h>
 
 #if !defined (__ACE_INLINE__)
 #include "TransportRegistry.inl"
@@ -35,13 +36,6 @@ namespace {
   {
     return lhs->name() < rhs->name();
   }
-
-  // transport type to try loading if none are loaded when DCPS attempts to use
-#ifdef OPENDDS_SAFETY_PROFILE
-  const char FALLBACK_TYPE[] = "rtps_udp";
-#else
-  const char FALLBACK_TYPE[] = "tcp";
-#endif
 }
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -714,7 +708,7 @@ TransportRegistry::fix_empty_default()
   }
   TransportConfig_rch global_config = global_config_;
 #if !defined(ACE_AS_STATIC_LIBS)
-  load_transport_lib_i(FALLBACK_TYPE);
+  load_transport_lib_i("rtps_udp");
 #endif
   return global_config;
 }

--- a/dds/DCPS/transport/framework/TransportRegistry.cpp
+++ b/dds/DCPS/transport/framework/TransportRegistry.cpp
@@ -5,24 +5,23 @@
  * See: http://www.opendds.org/license.html
  */
 
-#include <DCPS/DdsDcps_pch.h> //Only the _pch include should start with DCPS/
-
+#include "DCPS/DdsDcps_pch.h" //Only the _pch include should start with DCPS/
 #include "TransportRegistry.h"
 #include "TransportDebug.h"
 #include "TransportInst.h"
 #include "TransportExceptions.h"
 #include "TransportType.h"
-
-#include <dds/DCPS/GuidConverter.h>
-#include <dds/DCPS/Util.h>
-#include <dds/DCPS/Service_Participant.h>
-#include <dds/DCPS/EntityImpl.h>
-#include <dds/DCPS/SafetyProfileStreams.h>
+#include "dds/DCPS/GuidConverter.h"
+#include "dds/DCPS/Util.h"
+#include "dds/DCPS/Service_Participant.h"
+#include "dds/DCPS/EntityImpl.h"
+#include "dds/DCPS/SafetyProfileStreams.h"
 #include <dds/DdsDcpsInfrastructureC.h>
 
-#include <ace/Singleton.h>
-#include <ace/OS_NS_strings.h>
-#include <ace/Service_Config.h>
+
+#include "ace/Singleton.h"
+#include "ace/OS_NS_strings.h"
+#include "ace/Service_Config.h"
 
 #if !defined (__ACE_INLINE__)
 #include "TransportRegistry.inl"

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpLoader.cpp
@@ -46,17 +46,12 @@ void RtpsUdpLoader::load()
   }
 
   registry->register_type(type);
-  // Don't create a default for RTPS.  At least for the initial implementation,
-  // the user needs to explicitly configure it...
-#ifdef OPENDDS_SAFETY_PROFILE
-  // ...except for Safety Profile where RTPS is the only option.
   TransportInst_rch default_inst =
     registry->create_inst(TransportRegistry::DEFAULT_INST_PREFIX +
                           OPENDDS_STRING("0600_RTPS_UDP"),
                           RTPS_UDP_NAME, false);
   registry->get_config(TransportRegistry::DEFAULT_CONFIG_NAME)
     ->sorted_insert(default_inst);
-#endif
 }
 
 ACE_FACTORY_DEFINE(OpenDDS_Rtps_Udp, RtpsUdpLoader);

--- a/dds/DCPS/transport/tcp/TcpLoader.cpp
+++ b/dds/DCPS/transport/tcp/TcpLoader.cpp
@@ -6,15 +6,14 @@
  */
 
 #include "Tcp_pch.h"
-
 #include "TcpLoader.h"
 #include "TcpInst.h"
-#include "dds/DCPS/transport/framework/TransportRegistry.h"
-#include "dds/DCPS/transport/framework/TransportType.h"
-#include "dds/DCPS/transport/framework/EntryExit.h"
 
-#include "tao/debug.h"
-#include "ace/OS_NS_strings.h"
+#include <dds/DCPS/transport/framework/TransportRegistry.h>
+#include <dds/DCPS/transport/framework/TransportType.h>
+#include <dds/DCPS/transport/framework/EntryExit.h>
+
+#include <ace/OS_NS_strings.h>
 
 namespace {
   const char TCP_NAME[] = "tcp";

--- a/dds/DCPS/transport/tcp/TcpLoader.cpp
+++ b/dds/DCPS/transport/tcp/TcpLoader.cpp
@@ -6,14 +6,15 @@
  */
 
 #include "Tcp_pch.h"
+
 #include "TcpLoader.h"
 #include "TcpInst.h"
+#include "dds/DCPS/transport/framework/TransportRegistry.h"
+#include "dds/DCPS/transport/framework/TransportType.h"
+#include "dds/DCPS/transport/framework/EntryExit.h"
 
-#include <dds/DCPS/transport/framework/TransportRegistry.h>
-#include <dds/DCPS/transport/framework/TransportType.h>
-#include <dds/DCPS/transport/framework/EntryExit.h>
-
-#include <ace/OS_NS_strings.h>
+#include "tao/debug.h"
+#include "ace/OS_NS_strings.h"
 
 namespace {
   const char TCP_NAME[] = "tcp";

--- a/dds/InfoRepo/DCPSInfoRepoServ.cpp
+++ b/dds/InfoRepo/DCPSInfoRepoServ.cpp
@@ -304,6 +304,9 @@ InfoRepo::init()
   CORBA::String_var objref_str =
     orb_->object_to_string(info_repo);
 
+  // RTPS discovery is the default, change it to InfoRepo
+  TheServiceParticipant->set_default_discovery(OpenDDS::DCPS::Discovery::DEFAULT_REPO);
+
   // Initialize the DomainParticipantFactory
   DDS::DomainParticipantFactory_var dpf =
     TheParticipantFactoryWithArgs(argc, args.argv());

--- a/performance-tests/DCPS/InfoRepo_population/InfoRepo_population.mpc
+++ b/performance-tests/DCPS/InfoRepo_population/InfoRepo_population.mpc
@@ -30,7 +30,7 @@ project(*SyncServer) : taoexe, portableserver, iortable, coverage_optional, dds_
   }
 }
 
-project(*Publisher) : dcpsexe, dcps_test, dcps_tcp {
+project(*Publisher) : dcps_test, dcps_inforepodiscovery, dcps_tcp {
   requires += no_opendds_safety_profile
   exename   = publisher
   libs     += SyncClient
@@ -50,7 +50,7 @@ project(*Publisher) : dcpsexe, dcps_test, dcps_tcp {
   }
 }
 
-project(*Subscriber) : dcpsexe, dcps_test, dcps_tcp {
+project(*Subscriber) : dcps_test, dcps_inforepodiscovery, dcps_tcp {
   requires += no_opendds_safety_profile
   exename   = subscriber
   libs     += SyncClient

--- a/performance-tests/DCPS/InfoRepo_population/pub.ini
+++ b/performance-tests/DCPS/InfoRepo_population/pub.ini
@@ -1,4 +1,5 @@
 [common]
+DCPSDefaultDiscovery=DEFAULT_REPO
 DCPSDebugLevel=0
 DCPSInfoRepo=file://repo.ior
 DCPSChunks=20

--- a/performance-tests/DCPS/InfoRepo_population/sub.ini
+++ b/performance-tests/DCPS/InfoRepo_population/sub.ini
@@ -1,4 +1,5 @@
 [common]
+DCPSDefaultDiscovery=DEFAULT_REPO
 DCPSDebugLevel=0
 DCPSInfoRepo=file://repo.ior
 DCPSChunks=20

--- a/tests/DCPS/BuiltInTopicTest/info_repo.ini
+++ b/tests/DCPS/BuiltInTopicTest/info_repo.ini
@@ -1,0 +1,2 @@
+[common]
+DCPSDefaultDiscovery=DEFAULT_REPO

--- a/tests/DCPS/BuiltInTopicTest/prst_repo_run_test.pl
+++ b/tests/DCPS/BuiltInTopicTest/prst_repo_run_test.pl
@@ -70,6 +70,7 @@ my $repo_args = "$common_args"
   . " -o $dcpsrepo_ior"
   . " -ORBSvcConf mySvc.conf"
   . " -orbendpoint iiop://$orb_address:$SRV_PORT"
+  . " -DCPSConfigFile info_repo.ini"
 ;
 
 my $repo1_log = 'repo1.log';

--- a/tests/DCPS/DCPSInfoRepo/dcpsinfo_test.mpc
+++ b/tests/DCPS/DCPSInfoRepo/dcpsinfo_test.mpc
@@ -1,4 +1,4 @@
-project(*pubsub): dcpsexe, dcps_test, dcps_rtps_udp {
+project(*pubsub): dcps_test, dcps_inforepodiscovery, dcps_rtps_udp {
   requires += no_opendds_safety_profile
   exename  = pubsub
 }

--- a/tests/DCPS/DCPSInfoRepo/pubsub.cpp
+++ b/tests/DCPS/DCPSInfoRepo/pubsub.cpp
@@ -417,6 +417,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         rtpsDisc->sedp_multicast(false);
         disc = rtpsDisc;
       } else {
+        TheServiceParticipant->set_default_discovery(OpenDDS::DCPS::Discovery::DEFAULT_REPO);
+
         CORBA::Object_var tmp =
           orb->string_to_object (ACE_TEXT_ALWAYS_CHAR(ior));
         OpenDDS::DCPS::DCPSInfo_var info =

--- a/tests/DCPS/Messenger/run_test.pl
+++ b/tests/DCPS/Messenger/run_test.pl
@@ -25,7 +25,6 @@ my $sub_opts = "$dbg_lvl";
 my $repo_bit_opt = "";
 my $stack_based = 0;
 my $is_rtps_disc = 0;
-my $DCPSREPO;
 
 my $thread_per_connection = "";
 if ($test->flag('thread_per')) {
@@ -131,8 +130,7 @@ $test->report_unused_flags(!$flag_found);
 
 $pub_opts .= $thread_per_connection;
 
-$test->setup_discovery("-ORBDebugLevel 1 -ORBLogFile DCPSInfoRepo.log " .
-                       "$repo_bit_opt") unless $is_rtps_disc;
+$test->setup_discovery("-ORBDebugLevel 1 -ORBLogFile DCPSInfoRepo.log $repo_bit_opt");
 
 $test->process("publisher", "publisher", $pub_opts);
 my $sub_exe = ($stack_based ? 'stack_' : '') . "subscriber";

--- a/tests/DCPS/MultiRepoTest/MultiRepoTest.mpc
+++ b/tests/DCPS/MultiRepoTest/MultiRepoTest.mpc
@@ -1,4 +1,4 @@
-project(*Monitor): dcpsexe, dcps_test, dcps_transports_for_test {
+project(*Monitor): dcps_test, dcps_inforepodiscovery, dcps_transports_for_test {
   exename   = monitor
   libpaths += ../FooType5
   libs     +=  DcpsFooType5
@@ -13,7 +13,7 @@ project(*Monitor): dcpsexe, dcps_test, dcps_transports_for_test {
   }
 }
 
-project(*System): dcpsexe, dcps_test, dcps_transports_for_test {
+project(*System): dcps_test, dcps_inforepodiscovery, dcps_transports_for_test {
   exename   = system
   libpaths += ../FooType5
   libs     +=  DcpsFooType5

--- a/tests/DCPS/MultiRepoTest/TestMonitor.cpp
+++ b/tests/DCPS/MultiRepoTest/TestMonitor.cpp
@@ -26,6 +26,7 @@ TestMonitor::TestMonitor( int argc, ACE_TCHAR** argv, char** envp)
   // passes the arguments to the ORB initialization first, then strips
   // the DCPS arguments.
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) %T INFO: initializing the monitor.\n")));
+  TheServiceParticipant->set_default_discovery(OpenDDS::DCPS::Discovery::DEFAULT_REPO);
   ::DDS::DomainParticipantFactory_var factory = TheParticipantFactoryWithArgs( argc, argv);
 
   this->subscriberParticipant_.resize(

--- a/tests/DCPS/MultiRepoTest/TestSystem.cpp
+++ b/tests/DCPS/MultiRepoTest/TestSystem.cpp
@@ -31,6 +31,7 @@ TestSystem::TestSystem( int argc, ACE_TCHAR** argv, char** envp)
   // passes the arguments to the ORB initialization first, then strips
   // the DCPS arguments.
   ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) %T INFO: initializing the service.%d\n"), this->config_.infoRepoIorSize()));
+  TheServiceParticipant->set_default_discovery(OpenDDS::DCPS::Discovery::DEFAULT_REPO);
   ::DDS::DomainParticipantFactory_var factory = TheParticipantFactoryWithArgs( argc, argv);
 
   // We only need to do loading and binding if we receive InfoRepo IOR

--- a/tests/auto_run_tests.pl
+++ b/tests/auto_run_tests.pl
@@ -15,6 +15,8 @@ use Cwd;
 use Env qw(DDS_ROOT PATH);
 use strict;
 
+push(@PerlACE::ConfigList::Configs, 'NO_INFO_REPO');
+
 ################################################################################
 
 my ($opt_h, $opt_d, $opt_a, $opt_x, $opt_s, @opt_l);

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -15,8 +15,8 @@ tests/DCPS/Prst_delayed_subscriber/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFIL
 tests/DCPS/ZeroCopyRead/run_test.pl: !DCPS_MIN
 tests/DCPS/ZeroCopyRead/run_test.pl by_instance: !DCPS_MIN
 tests/DCPS/ZeroCopyDataReaderListener/run_test.pl: !DCPS_MIN
-tests/DCPS/DCPSInfoRepo/run_test.pl: !OPENDDS_SAFETY_PROFILE
-tests/DCPS/DCPSInfoRepo/run_test.pl rtps_disc: !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/DCPSInfoRepo/run_test.pl: !NO_INFO_REPO !OPENDDS_SAFETY_PROFILE
+tests/DCPS/DCPSInfoRepo/run_test.pl rtps_disc: !NO_INFO_REPO !DCPS_MIN !NO_MCAST RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/unit/run_test.pl
 tests/DCPS/DestinationOrder/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/DestinationOrder/run_test.pl source: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
@@ -120,8 +120,8 @@ tests/DCPS/TransientLocalTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DD
 tests/DCPS/TransientLocalTest/run_test.pl rtps: !DCPS_MIN RTPS !STATIC !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/DelayedDurable/run_test.pl: !DCPS_MIN RTPS
 tests/DCPS/DelayedDurable/run_test.pl --large-samples: !DCPS_MIN RTPS
-tests/DCPS/MultiRepoTest/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/MultiRepoTest/run_test.pl fileconfig: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/MultiRepoTest/run_test.pl: !NO_INFO_REPO !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/MultiRepoTest/run_test.pl fileconfig: !NO_INFO_REPO !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Presentation/run_test.pl: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/ReaderDataLifecycle/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/ReaderDataLifecycle/run_test.pl rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_PROFILE
@@ -142,7 +142,7 @@ tests/DCPS/BuiltInTopic/run_test.pl ignore_topic: !DCPS_MIN !NO_BUILT_IN_TOPICS 
 tests/DCPS/BuiltInTopic/run_test.pl ignore_pub: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/BuiltInTopic/run_test.pl ignore_sub: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/BuiltInTopicTest/run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !DDS_NO_OWNERSHIP_PROFILE !TARGET !GH_ACTIONS
-tests/DCPS/BuiltInTopicTest/prst_repo_run_test.pl: !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
+tests/DCPS/BuiltInTopicTest/prst_repo_run_test.pl: !NO_INFO_REPO !DCPS_MIN !NO_BUILT_IN_TOPICS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
 
 tests/DCPS/CorbaSeq/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/ViewState/run_test.pl: !DCPS_MIN !DDS_NO_OWNERSHIP_PROFILE
@@ -167,7 +167,7 @@ tests/transport/simple/run_test.pl shmem: !NO_DDS_TRANSPORT !DCPS_MIN !NO_SHMEM 
 
 tests/transport/error_handling/run_test.pl: !NO_DDS_TRANSPORT !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 
-performance-tests/DCPS/InfoRepo_population/run_test.pl: !DCPS_MIN !MIN_CORBA !OPENDDS_SAFETY_PROFILE
+performance-tests/DCPS/InfoRepo_population/run_test.pl: !NO_INFO_REPO !DCPS_MIN !MIN_CORBA !OPENDDS_SAFETY_PROFILE
 
 performance-tests/DCPS/TCPListenerTest/run_test.pl -p 1 -s 1: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 performance-tests/DCPS/TCPListenerTest/run_test.pl -p 1 -s 1 -c: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
@@ -187,8 +187,8 @@ performance-tests/DCPS/TCPListenerTest/run_test.pl -p 4 -s 1: !DCPS_MIN !OPENDDS
 #performance-tests/DCPS/MulticastListenerTest/run_test.pl -p 1 -s 4: !DCPS_MIN !NO_MCAST
 #performance-tests/DCPS/MulticastListenerTest/run_test.pl -p 2 -s 3: !DCPS_MIN !NO_MCAST
 
-DevGuideExamples/DCPS/Messenger/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
-DevGuideExamples/DCPS/Messenger/run_test.pl --rtps: !DCPS_MIN !OPENDDS_SAFETY_PROFILE RTPS
+DevGuideExamples/DCPS/Messenger/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE REPO
+DevGuideExamples/DCPS/Messenger/run_test.pl --info-repo: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !NO_INFO_REPO
 DevGuideExamples/DCPS/Messenger_ZeroCopy/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 
 tests/DCPS/Messenger/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
@@ -212,9 +212,9 @@ tests/DCPS/Messenger/run_test.pl rtps_disc_half_sec_pub: !DCPS_MIN !NO_MCAST RTP
 tests/DCPS/Messenger/run_test.pl rtps_disc_half_sec_sub: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Messenger/run_test.pl rtps_disc_sec: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE !GH_ACTIONS
 
-tests/DCPS/Messenger/run_corbaloc_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Messenger/run_corbaloc_test.pl host_port_only: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
-tests/DCPS/Messenger/run_ns_test.pl: !DCPS_MIN !DDS_NO_ORBSVCS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Messenger/run_corbaloc_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_INFO_REPO
+tests/DCPS/Messenger/run_corbaloc_test.pl host_port_only: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_INFO_REPO
+tests/DCPS/Messenger/run_ns_test.pl: !DCPS_MIN !DDS_NO_ORBSVCS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_INFO_REPO
 
 tests/DCPS/UnionTopic/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE RTPS
 
@@ -394,7 +394,7 @@ tests/DCPS/ManyToMany/run_test.pl shmem 1to1 small: !DCPS_MIN !OPENDDS_SAFETY_PR
 tests/DCPS/ManyToMany/run_test.pl shmem 1to1 large: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_SHMEM
 tests/DCPS/ManyToMany/run_test.pl tcp 20to20 small orb_csdtp: !DCPS_MIN !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 
-tests/DCPS/PersistentInfoRepo/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
+tests/DCPS/PersistentInfoRepo/run_test.pl: !NO_INFO_REPO !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 
 tests/DCPS/Instances/run_test.pl single_instance single_datawriter keyed: !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Instances/run_test.pl single_instance single_datawriter nokey: !DDS_NO_OWNERSHIP_PROFILE


### PR DESCRIPTION
Currently, when not using safety profile, the default discovery is InfoRepo and the default transport is tcp. This attempts to change the default discovery to rtps and the default transport to rtps_udp.