### PR TITLE
"Proxy" code duplicated between SingleSendBuffer and GuidAddrSet

### DIFF
--- a/dds/DCPS/Claimable.h
+++ b/dds/DCPS/Claimable.h
@@ -1,0 +1,64 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_CLAIMABLE_H
+#define OPENDDS_DCPS_CLAIMABLE_H
+
+#include "Definitions.h"
+
+#include "ace/Thread_Mutex.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+template <typename T> class Claim;
+
+template <typename T>
+class Claimable {
+public:
+  typedef Claim<T> Claim;
+
+  explicit Claimable(const T& data)
+    : core_(data)
+  {}
+
+private:
+  friend Claim;
+  T core_;
+  mutable ACE_Thread_Mutex mutex_;
+};
+
+template <typename T>
+class Claim {
+public:
+  Claim(Claimable<T>& claimable)
+    : claimable_(claimable)
+  {
+    claimable_.mutex_.acquire();
+  }
+
+  ~Claim() {
+    claimable_.mutex_.release();
+  }
+
+  T* operator->() const {
+    return &claimable_.core_;
+  }
+
+private:
+  Claimable<T>& claimable_;
+  OPENDDS_DELETED_COPY_MOVE_CTOR_ASSIGN(Claim)
+};
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif  /* OPENDDS_DCPS_CLAIMABLE_H */

--- a/tools/rtpsrelay/ParticipantListener.cpp
+++ b/tools/rtpsrelay/ParticipantListener.cpp
@@ -8,7 +8,7 @@
 namespace RtpsRelay {
 
 ParticipantListener::ParticipantListener(const Config& config,
-                                         GuidAddrSet& guid_addr_set,
+                                         ClaimableGuidAddrSet& guid_addr_set,
                                          OpenDDS::DCPS::DomainParticipantImpl* participant,
                                          DomainStatisticsReporter& stats_reporter)
   : config_(config)
@@ -47,7 +47,8 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
       if (info.valid_data) {
         const auto repoid = participant_->get_repoid(info.instance_handle);
 
-        guid_addr_set_.remove_pending(repoid);
+        ClaimableGuidAddrSet::Claim claim(guid_addr_set_);
+        claim->remove_pending(repoid);
 
         if (config_.log_discovery()) {
           ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: ParticipantListener::on_data_available add local participant %C %C\n"), guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str()));
@@ -61,7 +62,8 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
       {
         const auto repoid = participant_->get_repoid(info.instance_handle);
 
-        guid_addr_set_.remove(repoid);
+        ClaimableGuidAddrSet::Claim claim(guid_addr_set_);
+        claim->remove(repoid);
 
         if (config_.log_discovery()) {
           ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: ParticipantListener::on_data_available remove local participant %C\n"), guid_to_string(repoid).c_str()));

--- a/tools/rtpsrelay/ParticipantListener.h
+++ b/tools/rtpsrelay/ParticipantListener.h
@@ -12,7 +12,7 @@ namespace RtpsRelay {
 class ParticipantListener : public ListenerBase {
 public:
   ParticipantListener(const Config& config,
-                      GuidAddrSet& guid_addr_set,
+                      ClaimableGuidAddrSet& guid_addr_set,
                       OpenDDS::DCPS::DomainParticipantImpl* participant,
                       DomainStatisticsReporter& stats_reporter);
 
@@ -20,7 +20,7 @@ private:
   void on_data_available(DDS::DataReader_ptr reader) override;
 
   const Config& config_;
-  GuidAddrSet& guid_addr_set_;
+  ClaimableGuidAddrSet& guid_addr_set_;
   OpenDDS::DCPS::DomainParticipantImpl* participant_;
   DomainStatisticsReporter& stats_reporter_;
 };


### PR DESCRIPTION
Problem
-------

SingleSendBuffer and GuidAddrSet have the same problem in that some
sequences of operations on an instance must be atomic.  An operation
involving iterators is one example where the methods used to acquire
the iterators and the code that uses the iterators should be atomic.

Solution
--------

The starting point for a solution is to expose the mutex and create a
scoped lock (ACE_GUARD).  The object-lock pair can then be passed to
functions that are part of the atomic transaction.  Combining the
object and lock into a single object is the first improvement.  This
combination is called a *claim*.

A *claimable* object is "locked" by declaring a claim on that object.
The claim implements indirection `->` so that code seeing the claim
can conveniently invoke methods on the claimed object.  In general,
these methods should accept a claim as one argument and check that the
claim is for `this`.  This informs users that the method expects that
a claim has already been made.

It is quite easy to generate a deadlock with claims.  First, one claim
cannot be created while another one exists.  Fortunately, this tends
to be easy to spot, i.e., a method is claiming an object when a claim
has already been passed in.  Second, a method that doesn't take a
claim argument is invoked when a claim already exists.  In this case,
the method should be refactored to take a claim (and not lock).