### PR TITLE
Avoid Duplicate Test Names In Test Lists

### DIFF
--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -476,7 +476,7 @@ tests/DCPS/UnregisterType/run_test.pl: !DCPS_MIN
 
 performance-tests/bench/run_test.pl ci-disco --show-worker-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON !GH_ACTIONS_ASAN !Win32
 performance-tests/bench/run_test.pl ci-disco-long --show-worker-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON GH_ACTIONS_ASAN
-performance-tests/bench/run_test.pl ci-disco-long --show-worker-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON Win32
+performance-tests/bench/run_test.pl ci-disco-long --show-worker-logs --ignored: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON Win32
 performance-tests/bench/run_test.pl ci-disco-repo --show-worker-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl ci-echo --show-worker-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON
 performance-tests/bench/run_test.pl ci-echo-frag --show-worker-logs: !DCPS_MIN !NO_MCAST RTPS !DDS_NO_OWNERSHIP_PROFILE CXX11 RAPIDJSON


### PR DESCRIPTION
Problem: Duplicate test names cause PerlACE to overwrite the configuration parameter lists and produce undesired / unexpected behaviors when running tests. The bench `ci-disco-long` test is currently duplicated for GitHub Actions ASAN builds and Win32 builds.

Solution: Add an extra, unused parameter