### PR TITLE
Fixes for `auto_run_tests.pl`

### DIFF
--- a/docs/internal/running_tests.rst
+++ b/docs/internal/running_tests.rst
@@ -90,3 +90,8 @@ To manually configure what tests to run:
 * Assuming they were built, CMake tests are ran if ``--cmake`` is passed.
   This uses CTest, which is a system that is separate from the one previously described.
 * See ``--help`` for all the available options.
+
+.. note:: For those editing and creating test list files:
+  The ``ConfigList`` code in ACE can't properly handle mutiple test list entries with the same command.
+  It will run all those entries if the last one will run, even if based on the configs only one entry should run.
+  ``auto_run_tests.pl`` will warn about this if it's using a test list file that has this problem.

--- a/tools/scripts/modules/command_utils.pm
+++ b/tools/scripts/modules/command_utils.pm
@@ -281,7 +281,7 @@ sub run_command {
 
   my $name = $args{name} // $command_list[0];
   my @capture_directives = process_capture_arguments($args{capture});
-  my $verbose = $args{verbose} // $args{dry_run};
+  my $verbose = $args{verbose};
   my $verbose_fh = $args{verbose_fh};
   my $dry_run = $args{dry_run};
   my $script_name = $args{script_name} ? "$args{script_name}: " : "";
@@ -300,8 +300,8 @@ sub run_command {
     else {
       print $verbose_fh ("(string): \"$command_str\"\n");
     }
-    return 0 if ($dry_run);
   }
+  return 0 if ($dry_run);
 
   # Start captures
   for my $capture_directive (@capture_directives) {


### PR DESCRIPTION
- `ConfigList` in PerlACE can't properly handle multiple entries with the same commands and run all the entries based on the last one's configs. This adds a warning to detect when that can happen. The particular case itself
  will be fixed by: https://github.com/OpenDDS/OpenDDS/pull/3969
- `--dry-run`/`-z` was being ignored because inside `run_command` the `dry_run` option was dependent on the `verbose` option. Changed this so they can be set separately, which is what `configure` is trying to do. `auto_run_test.pl` will still set them both based on `--dry-run`/`-z`.
- Builtin test list options were being ignored with `--no-auto-config`.