### PR TITLE
Relay STUN task dies during transient configuration

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -1048,12 +1048,11 @@ RtpsUdpTransport::relay_stun_task(const DCPS::MonotonicTimePoint& /*now*/)
       !equal_guid_prefixes(local_prefix_, GUIDPREFIX_UNKNOWN)) {
     process_relay_sra(relay_srsm_.send(relay_address, ICE::Configuration::instance()->server_reflexive_indication_count(), local_prefix_));
     ice_endpoint_->send(relay_address, relay_srsm_.message());
-    {
-      ACE_Guard<ThreadLockType> guard(relay_stun_task_falloff_mutex_);
-      relay_stun_task_falloff_.advance(ICE::Configuration::instance()->server_reflexive_address_period());
-      relay_stun_task_->schedule(relay_stun_task_falloff_.get());
-    }
   }
+
+  ACE_Guard<ThreadLockType> guard(relay_stun_task_falloff_mutex_);
+  relay_stun_task_falloff_.advance(ICE::Configuration::instance()->server_reflexive_address_period());
+  relay_stun_task_->schedule(relay_stun_task_falloff_.get());
 }
 
 void


### PR DESCRIPTION
Problem
-------

Users can clear the RtpsRelay address at any time.  If the relay stun task in the RtpsUdpTransport executes during this time period, the task will not reschedule itself.  Setting the address to a new value does not schedule the task.

Solution
--------

Always reschedule the task.