### PR TITLE
`rtps_relay_address_change` deadlocks

### DIFF
--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -149,7 +149,7 @@ TransportClient::enable_transport_using_config(bool reliable, bool durable,
     TransportInst_rch inst = tc->instances_[i];
 
     if (check_transport_qos(*inst)) {
-      TransportImpl_rch impl = inst->impl();
+      TransportImpl_rch impl = inst->get_or_create_impl();
 
       if (impl) {
         impls_.push_back(impl);
@@ -180,7 +180,7 @@ TransportClient::populate_connection_info()
   for (size_t i = 0; i < n; ++i) {
     TransportInst_rch inst = config_->instances_[i];
     if (check_transport_qos(*inst)) {
-      TransportImpl_rch impl = inst->impl();
+      TransportImpl_rch impl = inst->get_or_create_impl();
       if (impl) {
         const CORBA::ULong idx = DCPS::grow(conn_info_) - 1;
         impl->connection_info(conn_info_[idx], CONNINFO_ALL);

--- a/dds/DCPS/transport/framework/TransportInst.cpp
+++ b/dds/DCPS/transport/framework/TransportInst.cpp
@@ -149,10 +149,7 @@ OpenDDS::DCPS::TransportImpl_rch
 OpenDDS::DCPS::TransportInst::get_impl()
 {
   ACE_GUARD_RETURN(ACE_SYNCH_MUTEX, g, lock_, TransportImpl_rch());
-  if (!shutting_down_) {
-    return impl_;
-  }
-  return TransportImpl_rch();
+  return impl_;
 }
 
 void

--- a/dds/DCPS/transport/framework/TransportInst.cpp
+++ b/dds/DCPS/transport/framework/TransportInst.cpp
@@ -132,7 +132,7 @@ OpenDDS::DCPS::TransportInst::shutdown()
 }
 
 OpenDDS::DCPS::TransportImpl_rch
-OpenDDS::DCPS::TransportInst::impl()
+OpenDDS::DCPS::TransportInst::get_or_create_impl()
 {
   ACE_GUARD_RETURN(ACE_SYNCH_MUTEX, g, lock_, TransportImpl_rch());
   if (!impl_ && !shutting_down_) {
@@ -143,6 +143,16 @@ OpenDDS::DCPS::TransportInst::impl()
     }
   }
   return impl_;
+}
+
+OpenDDS::DCPS::TransportImpl_rch
+OpenDDS::DCPS::TransportInst::get_impl()
+{
+  ACE_GUARD_RETURN(ACE_SYNCH_MUTEX, g, lock_, TransportImpl_rch());
+  if (!shutting_down_) {
+    return impl_;
+  }
+  return TransportImpl_rch();
 }
 
 void
@@ -174,14 +184,14 @@ OpenDDS::DCPS::TransportInst::set_port_in_addr_string(OPENDDS_STRING& addr_str, 
 OpenDDS::DCPS::WeakRcHandle<OpenDDS::ICE::Endpoint>
 OpenDDS::DCPS::TransportInst::get_ice_endpoint()
 {
-  const OpenDDS::DCPS::TransportImpl_rch temp = impl();
+  const OpenDDS::DCPS::TransportImpl_rch temp = get_or_create_impl();
   return temp ? temp->get_ice_endpoint() : OpenDDS::DCPS::WeakRcHandle<OpenDDS::ICE::Endpoint>();
 }
 
 void
 OpenDDS::DCPS::TransportInst::rtps_relay_only_now(bool flag)
 {
-  const OpenDDS::DCPS::TransportImpl_rch temp = impl();
+  const OpenDDS::DCPS::TransportImpl_rch temp = get_or_create_impl();
   if (temp) {
     temp->rtps_relay_only_now(flag);
   }
@@ -190,7 +200,7 @@ OpenDDS::DCPS::TransportInst::rtps_relay_only_now(bool flag)
 void
 OpenDDS::DCPS::TransportInst::use_rtps_relay_now(bool flag)
 {
-  const OpenDDS::DCPS::TransportImpl_rch temp = impl();
+  const OpenDDS::DCPS::TransportImpl_rch temp = get_or_create_impl();
   if (temp) {
     temp->use_rtps_relay_now(flag);
   }
@@ -199,7 +209,7 @@ OpenDDS::DCPS::TransportInst::use_rtps_relay_now(bool flag)
 void
 OpenDDS::DCPS::TransportInst::use_ice_now(bool flag)
 {
-  const OpenDDS::DCPS::TransportImpl_rch temp = impl();
+  const OpenDDS::DCPS::TransportImpl_rch temp = get_or_create_impl();
   if (temp) {
     temp->use_ice_now(flag);
   }
@@ -208,14 +218,14 @@ OpenDDS::DCPS::TransportInst::use_ice_now(bool flag)
 OpenDDS::DCPS::ReactorTask_rch
 OpenDDS::DCPS::TransportInst::reactor_task()
 {
-  const OpenDDS::DCPS::TransportImpl_rch temp = impl();
+  const OpenDDS::DCPS::TransportImpl_rch temp = get_or_create_impl();
   return temp ? temp->reactor_task() : OpenDDS::DCPS::ReactorTask_rch();
 }
 
 OpenDDS::DCPS::EventDispatcher_rch
 OpenDDS::DCPS::TransportInst::event_dispatcher()
 {
-  const TransportImpl_rch temp = impl();
+  const TransportImpl_rch temp = get_or_create_impl();
   return temp ? temp->event_dispatcher() : EventDispatcher_rch();
 }
 

--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -241,7 +241,8 @@ private:
 
   friend class TransportClient;
  protected:
-  TransportImpl_rch impl();
+  TransportImpl_rch get_or_create_impl();
+  TransportImpl_rch get_impl();
  private:
   virtual TransportImpl_rch new_impl() = 0;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -287,7 +287,7 @@ void
 RtpsUdpInst::update_locators(const GUID_t& remote_id,
                              const TransportLocatorSeq& locators)
 {
-  TransportImpl_rch imp = impl();
+  TransportImpl_rch imp = get_or_create_impl();
   if (imp) {
     RtpsUdpTransport_rch rtps_impl = static_rchandle_cast<RtpsUdpTransport>(imp);
     rtps_impl->update_locators(remote_id, locators);
@@ -298,7 +298,7 @@ void
 RtpsUdpInst::get_last_recv_locator(const GUID_t& remote_id,
                                    TransportLocator& locator)
 {
-  TransportImpl_rch imp = impl();
+  TransportImpl_rch imp = get_or_create_impl();
   if (imp) {
     RtpsUdpTransport_rch rtps_impl = static_rchandle_cast<RtpsUdpTransport>(imp);
     rtps_impl->get_last_recv_locator(remote_id, locator);
@@ -308,7 +308,7 @@ RtpsUdpInst::get_last_recv_locator(const GUID_t& remote_id,
 void
 RtpsUdpInst::rtps_relay_address_change()
 {
-  TransportImpl_rch imp = impl();
+  TransportImpl_rch imp = get_impl();
   if (imp) {
     RtpsUdpTransport_rch rtps_impl = static_rchandle_cast<RtpsUdpTransport>(imp);
     rtps_impl->rtps_relay_address_change();
@@ -318,7 +318,7 @@ RtpsUdpInst::rtps_relay_address_change()
 void
 RtpsUdpInst::append_transport_statistics(TransportStatisticsSequence& seq)
 {
-  TransportImpl_rch imp = impl();
+  TransportImpl_rch imp = get_or_create_impl();
   if (imp) {
     RtpsUdpTransport_rch rtps_impl = static_rchandle_cast<RtpsUdpTransport>(imp);
     rtps_impl->append_transport_statistics(seq);


### PR DESCRIPTION
Problem
-------

`rtps_relay_address_change` deadlocks if it causes the impl to be created.

Solution
--------

Don't create the impl.

There is no downside here, that is, when the impl is created, it will have the correct configuration.