### PR TITLE
RtpsUdpTransport has data race from `relay_stun_mutex_`

### DIFF
--- a/dds/DCPS/ConnectionRecords.h
+++ b/dds/DCPS/ConnectionRecords.h
@@ -22,7 +22,7 @@ namespace DCPS {
 typedef std::pair<bool, ConnectionRecord> ActionConnectionRecord;
 typedef OPENDDS_VECTOR(ActionConnectionRecord) ConnectionRecords;
 
-class OpenDDS_Dcps_Export WriteConnectionRecords : public DCPS::JobQueue::Job {
+class OpenDDS_Dcps_Export WriteConnectionRecords : public DCPS::Job {
  public:
   WriteConnectionRecords(WeakRcHandle<BitSubscriber> bit_sub,
                          const ConnectionRecords& records)

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -1053,7 +1053,7 @@ protected:
   EncodingKinds decoding_modes_;
 
 public:
-  class OpenDDS_Dcps_Export OnDataOnReaders : public JobQueue::Job {
+  class OpenDDS_Dcps_Export OnDataOnReaders : public Job {
   public:
     OnDataOnReaders(WeakRcHandle<SubscriberImpl> subscriber,
                     DDS::SubscriberListener_var sub_listener,
@@ -1077,7 +1077,7 @@ public:
     const bool set_reader_status_;
   };
 
-  class OpenDDS_Dcps_Export OnDataAvailable : public JobQueue::Job {
+  class OpenDDS_Dcps_Export OnDataAvailable : public Job {
   public:
     OnDataAvailable(DDS::DataReaderListener_var listener,
                     WeakRcHandle<DataReaderImpl> data_reader,

--- a/dds/DCPS/InternalDataReaderListener.h
+++ b/dds/DCPS/InternalDataReaderListener.h
@@ -30,11 +30,11 @@ public:
   typedef RcHandle<InternalDataReader<T> > InternalDataReader_rch;
 
   InternalDataReaderListener()
-    : job_(make_rch<Job>(rchandle_from(this)))
+    : job_(make_rch<ListenerJob>(rchandle_from(this)))
   {}
 
   explicit InternalDataReaderListener(JobQueue_rch job_queue)
-    : job_(make_rch<Job>(rchandle_from(this)))
+    : job_(make_rch<ListenerJob>(rchandle_from(this)))
     , job_queue_(job_queue)
   {}
 
@@ -62,9 +62,9 @@ public:
   /// @}
 
 private:
-  class Job : public JobQueue::Job {
+  class ListenerJob : public Job {
   public:
-    explicit Job(RcHandle<InternalDataReaderListener> listener)
+    explicit ListenerJob(RcHandle<InternalDataReaderListener> listener)
       : listener_(listener)
     {}
 
@@ -80,7 +80,7 @@ private:
     WeakRcHandle<InternalDataReaderListener> listener_;
   };
 
-  JobQueue::JobPtr job_;
+  JobPtr job_;
   JobQueue_wrch job_queue_;
   typedef WeakRcHandle<InternalDataReader<T> > Reader;
   typedef OPENDDS_SET(Reader) ReaderSet;

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -556,7 +556,7 @@ private:
   DCPS::RcHandle<SpdpTransport> tport_;
 
 #ifdef OPENDDS_SECURITY
-  class SendStun : public DCPS::JobQueue::Job {
+  class SendStun : public DCPS::Job {
   public:
     SendStun(const DCPS::RcHandle<SpdpTransport>& tport,
              const ACE_INET_Addr& address,
@@ -573,7 +573,7 @@ private:
   };
 
 #ifndef DDS_HAS_MINIMUM_BIT
-  class IceConnect : public DCPS::JobQueue::Job {
+  class IceConnect : public DCPS::Job {
   public:
     IceConnect(DCPS::RcHandle<Spdp> spdp,
                const ICE::GuidSetType& guids,

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -245,6 +245,7 @@ public:
   bool requires_inline_qos(const GUIDSeq_var& peers);
 
   EventDispatcher_rch event_dispatcher() { return event_dispatcher_; }
+  RcHandle<JobQueue> get_job_queue() const { return job_queue_; }
 
 private:
   void on_data_available(RcHandle<InternalDataReader<NetworkInterfaceAddress> > reader);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -107,7 +107,10 @@ private:
                         const NetworkAddress& remote_addr);
 
   virtual int start_i();
+  void register_handlers();
   virtual void stop_i();
+  void remove_handlers();
+  typedef PmfJob<RtpsUdpReceiveStrategy> RURSJob;
 
   virtual bool check_header(const RtpsTransportHeader& header);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -157,34 +157,17 @@ RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
 #endif
   }
 
+#if defined(OPENDDS_SECURITY)
+  if (cfg->use_ice()) {
+    job_queue_->enqueue(make_rch<RUTJob>(rchandle_from(this), &RtpsUdpTransport::remove_handlers));
+  }
+#endif
+
   RtpsUdpDataLink_rch link = make_rch<RtpsUdpDataLink>(rchandle_from(this), local_prefix, config(), reactor_task(), ref(transport_statistics_), ref(transport_statistics_mutex_));
 
 #if defined(OPENDDS_SECURITY)
   link->local_crypto_handle(local_crypto_handle_);
 #endif
-
-  if (cfg->use_ice()) {
-    if (reactor()->remove_handler(unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK) != 0) {
-      ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("(%P|%t) ERROR: ")
-                        ACE_TEXT("RtpsUdpTransport::make_datalink: ")
-                        ACE_TEXT("failed to unregister handler for unicast ")
-                        ACE_TEXT("socket %d\n"),
-                        unicast_socket_.get_handle()),
-                       RtpsUdpDataLink_rch());
-    }
-#ifdef ACE_HAS_IPV6
-    if (reactor()->remove_handler(ipv6_unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK) != 0) {
-      ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("(%P|%t) ERROR: ")
-                        ACE_TEXT("RtpsUdpTransport::make_datalink: ")
-                        ACE_TEXT("failed to unregister handler for ipv6 unicast ")
-                        ACE_TEXT("socket %d\n"),
-                        ipv6_unicast_socket_.get_handle()),
-                       RtpsUdpDataLink_rch());
-    }
-#endif
-  }
 
   if (!link->open(unicast_socket_
 #ifdef ACE_HAS_IPV6
@@ -976,28 +959,36 @@ RtpsUdpTransport::start_ice()
 
   ice_agent_->add_endpoint(static_rchandle_cast<ICE::Endpoint>(ice_endpoint_));
 
+  GuardThreadType guard_links(links_lock_);
+
   if (!link_) {
-    if (reactor()->register_handler(unicast_socket_.get_handle(), ice_endpoint_.get(),
-                                    ACE_Event_Handler::READ_MASK) != 0) {
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: ")
-                 ACE_TEXT("RtpsUdpTransport::start_ice: ")
-                 ACE_TEXT("failed to register handler for unicast ")
-                 ACE_TEXT("socket %d\n"),
-                 unicast_socket_.get_handle()));
-    }
-#ifdef ACE_HAS_IPV6
-    if (reactor()->register_handler(ipv6_unicast_socket_.get_handle(), ice_endpoint_.get(),
-                                    ACE_Event_Handler::READ_MASK) != 0) {
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: ")
-                 ACE_TEXT("RtpsUdpTransport::start_ice: ")
-                 ACE_TEXT("failed to register handler for ipv6 unicast ")
-                 ACE_TEXT("socket %d\n"),
-                 ipv6_unicast_socket_.get_handle()));
-    }
-#endif
+    job_queue_->enqueue(make_rch<RUTJob>(rchandle_from(this), &RtpsUdpTransport::register_handlers));
   }
+}
+
+void
+RtpsUdpTransport::register_handlers()
+{
+  if (reactor()->register_handler(unicast_socket_.get_handle(), ice_endpoint_.get(),
+                                  ACE_Event_Handler::READ_MASK) != 0) {
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("(%P|%t) ERROR: ")
+               ACE_TEXT("RtpsUdpTransport::register_handlers: ")
+               ACE_TEXT("failed to register handler for unicast ")
+               ACE_TEXT("socket %d\n"),
+               unicast_socket_.get_handle()));
+  }
+#ifdef ACE_HAS_IPV6
+  if (reactor()->register_handler(ipv6_unicast_socket_.get_handle(), ice_endpoint_.get(),
+                                  ACE_Event_Handler::READ_MASK) != 0) {
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("(%P|%t) ERROR: ")
+               ACE_TEXT("RtpsUdpTransport::register_handlers: ")
+               ACE_TEXT("failed to register handler for ipv6 unicast ")
+               ACE_TEXT("socket %d\n"),
+               ipv6_unicast_socket_.get_handle()));
+  }
+#endif
 }
 
 void
@@ -1007,34 +998,42 @@ RtpsUdpTransport::stop_ice()
     ACE_DEBUG((LM_INFO, "(%P|%t) RtpsUdpTransport::stop_ice\n"));
   }
 
+  GuardThreadType guard_links(links_lock_);
+
   if (!link_) {
-    if (reactor()->remove_handler(unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK) != 0) {
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: ")
-                 ACE_TEXT("RtpsUdpTransport::stop_ice: ")
-                 ACE_TEXT("failed to unregister handler for unicast ")
-                 ACE_TEXT("socket %d\n"),
-                 unicast_socket_.get_handle()));
-    }
-#ifdef ACE_HAS_IPV6
-    if (reactor()->remove_handler(ipv6_unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK) != 0) {
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: ")
-                 ACE_TEXT("RtpsUdpTransport::stop_ice: ")
-                 ACE_TEXT("failed to unregister handler for ipv6 unicast ")
-                 ACE_TEXT("socket %d\n"),
-                 ipv6_unicast_socket_.get_handle()));
-    }
-#endif
+    job_queue_->enqueue(make_rch<RUTJob>(rchandle_from(this), &RtpsUdpTransport::remove_handlers));
   }
 
   ice_agent_->remove_endpoint(static_rchandle_cast<ICE::Endpoint>(ice_endpoint_));
 }
 
 void
+RtpsUdpTransport::remove_handlers()
+{
+  if (reactor()->remove_handler(unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK) != 0) {
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("(%P|%t) ERROR: ")
+               ACE_TEXT("RtpsUdpTransport::remove_handlers: ")
+               ACE_TEXT("failed to unregister handler for unicast ")
+               ACE_TEXT("socket %d\n"),
+               unicast_socket_.get_handle()));
+  }
+#ifdef ACE_HAS_IPV6
+  if (reactor()->remove_handler(ipv6_unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK) != 0) {
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("(%P|%t) ERROR: ")
+               ACE_TEXT("RtpsUdpTransport::remove_handlers: ")
+               ACE_TEXT("failed to unregister handler for ipv6 unicast ")
+               ACE_TEXT("socket %d\n"),
+               ipv6_unicast_socket_.get_handle()));
+  }
+#endif
+}
+
+void
 RtpsUdpTransport::relay_stun_task(const DCPS::MonotonicTimePoint& /*now*/)
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, relay_stun_mutex_);
+  GuardThreadType guard_links(links_lock_);
 
   RtpsUdpInst_rch cfg = config();
   if (!cfg) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -150,11 +150,9 @@ private:
 
   JobQueue_rch job_queue_;
 
-#if defined(OPENDDS_SECURITY)
-  DDS::Security::ParticipantCryptoHandle local_crypto_handle_;
-#endif
-
 #ifdef OPENDDS_SECURITY
+
+  DDS::Security::ParticipantCryptoHandle local_crypto_handle_;
 
 #ifndef DDS_HAS_MINIMUM_BIT
   ConnectionRecords deferred_connection_records_;
@@ -186,10 +184,13 @@ private:
   ThreadLockType relay_stun_task_falloff_mutex_;
   ICE::ServerReflexiveStateMachine relay_srsm_;
 
-  mutable ACE_Thread_Mutex relay_stun_mutex_;
-
   void start_ice();
   void stop_ice();
+
+  typedef PmfJob<RtpsUdpTransport> RUTJob;
+
+  void register_handlers();
+  void remove_handlers();
 
   RcHandle<ICE::Agent> ice_agent_;
 #endif


### PR DESCRIPTION
Problem
-------

ASAN reports a data race stemming from the use of the data link from the `relay_stun_task` in RtpsUdpTransport.

Solution
--------

Replace the existing mutex in `relay_stun_task` with the data link mutex.