### PR TITLE
Relax Best-Effort Requirements For SharedTransport Test

### DIFF
--- a/tests/DCPS/TestFramework/TestFramework_T.h
+++ b/tests/DCPS/TestFramework/TestFramework_T.h
@@ -133,10 +133,10 @@ protected:
   DDS::Subscriber_var create_subscriber();
   DDS::DataReader_var create_datareader();
 
-  DDS::DomainParticipant_var&
+  DDS::DomainParticipant_var
   get_participant() { return test_.get_participant(); }
 
-  DDS::Topic_var&
+  DDS::Topic_var
   get_topic() { return test_.get_topic(); }
 };
 


### PR DESCRIPTION
### Problem
The way the SharedTransport test is structured and the test assertions it makes really only make sense for reliable QoS and reliable transports. As such, the udp transport sometimes falls short (drops messages and/or has nothing to read) of the test expecations even though that's acceptable DDS behavior.

### Solution
Make sure the test only enforces the strict requirements for reliable transports / entities.