### PR TITLE
Minor Improvements For Reader-Side Locking

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -1973,6 +1973,7 @@ DataReaderImpl::release_instance(DDS::InstanceHandle_t handle)
 void
 DataReaderImpl::state_updated(DDS::InstanceHandle_t handle)
 {
+  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, sample_lock_);
   state_updated_i(handle);
 }
 

--- a/dds/DCPS/transport/framework/ReceiveListenerSet.cpp
+++ b/dds/DCPS/transport/framework/ReceiveListenerSet.cpp
@@ -28,7 +28,7 @@ ReceiveListenerSet::~ReceiveListenerSet()
 bool
 ReceiveListenerSet::exist(const GUID_t& local_id, bool& last)
 {
-  GuardType guard(this->lock_);
+  GuardType guard(lock_);
 
   last = true;
 
@@ -61,7 +61,7 @@ ReceiveListenerSet::exist(const GUID_t& local_id, bool& last)
 void
 ReceiveListenerSet::get_keys(ReaderIdSeq & ids)
 {
-  GuardType guard(this->lock_);
+  GuardType guard(lock_);
 
   for (MapType::iterator iter = map_.begin();
        iter != map_.end(); ++ iter) {
@@ -72,15 +72,15 @@ ReceiveListenerSet::get_keys(ReaderIdSeq & ids)
 bool
 ReceiveListenerSet::exist(const GUID_t& local_id)
 {
-  GuardType guard(this->lock_);
+  GuardType guard(lock_);
   return map_.count(local_id) > 0;
 }
 
 void
 ReceiveListenerSet::clear()
 {
-  GuardType guard(this->lock_);
-  this->map_.clear();
+  GuardType guard(lock_);
+  map_.clear();
 }
 
 void
@@ -91,7 +91,8 @@ ReceiveListenerSet::data_received(const ReceivedDataSample& sample,
   DBG_ENTRY_LVL("ReceiveListenerSet", "data_received", 6);
   OPENDDS_VECTOR(TransportReceiveListener_wrch) handles;
   {
-    GuardType guard(this->lock_);
+    GuardType guard(lock_);
+    handles.reserve(map_.size());
     for (MapType::iterator itr = map_.begin(); itr != map_.end(); ++itr) {
       if (constrain == ReceiveListenerSet::SET_EXCLUDED) {
         if (itr->second && incl_excl.count(itr->first) == 0) {
@@ -129,7 +130,7 @@ ReceiveListenerSet::data_received(const ReceivedDataSample& sample,
   DBG_ENTRY_LVL("ReceiveListenerSet", "data_received(sample, readerId)", 6);
   TransportReceiveListener_wrch h;
   {
-    GuardType guard(this->lock_);
+    GuardType guard(lock_);
     MapType::iterator itr = map_.find(readerId);
     if (itr != map_.end() && itr->second) {
       h = itr->second;

--- a/dds/DCPS/transport/framework/ReceiveListenerSet.h
+++ b/dds/DCPS/transport/framework/ReceiveListenerSet.h
@@ -73,7 +73,7 @@ private:
   /// This lock will protect the map.
   mutable LockType lock_;
 
-  MapType  map_;
+  MapType map_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/framework/ReceiveListenerSet.inl
+++ b/dds/DCPS/transport/framework/ReceiveListenerSet.inl
@@ -26,26 +26,30 @@ ACE_INLINE
 ReceiveListenerSet::ReceiveListenerSet(const ReceiveListenerSet& rhs)
   : RcObject()
   , lock_()
-  , map_(rhs.map_)
+  , map_()
 {
   DBG_ENTRY_LVL("ReceiveListenerSet", "ReceiveListenerSet(rhs)", 6);
+  *this = rhs;
 }
 
 ACE_INLINE ReceiveListenerSet&
 ReceiveListenerSet::operator=(const ReceiveListenerSet& rhs)
 {
   DBG_ENTRY_LVL("ReceiveListenerSet", "operator=", 6);
-  map_ = rhs.map_;
+  if (&rhs != this) {
+    GuardType guard_lt(&lock_ < &rhs.lock_ ? lock_ : rhs.lock_);
+    GuardType guard_gt(&lock_ < &rhs.lock_ ? rhs.lock_ : lock_);
+    map_ = rhs.map_;
+  }
   return *this;
 }
-
 
 ACE_INLINE int
 ReceiveListenerSet::insert(GUID_t subscriber_id,
                            const TransportReceiveListener_wrch& listener)
 {
   DBG_ENTRY_LVL("ReceiveListenerSet", "insert", 6);
-  GuardType guard(this->lock_);
+  GuardType guard(lock_);
 
   std::pair<MapType::iterator,bool> r = map_.insert(std::make_pair(subscriber_id,listener));
   if (!r.second) {
@@ -59,12 +63,11 @@ ReceiveListenerSet::insert(GUID_t subscriber_id,
   return 0;
 }
 
-
 ACE_INLINE int
 ReceiveListenerSet::remove(GUID_t subscriber_id)
 {
   DBG_ENTRY_LVL("ReceiveListenerSet", "remove", 6);
-  GuardType guard(this->lock_);
+  GuardType guard(lock_);
 
   if (unbind(map_, subscriber_id) != 0) {
     ACE_ERROR_RETURN((LM_ERROR,
@@ -80,7 +83,7 @@ ACE_INLINE void
 ReceiveListenerSet::remove_all(const GUIDSeq& to_remove)
 {
   DBG_ENTRY_LVL("ReceiveListenerSet", "remove_all", 6);
-  GuardType guard(this->lock_);
+  GuardType guard(lock_);
   const CORBA::ULong len = to_remove.length();
   for (CORBA::ULong i(0); i < len; ++i) {
     unbind(map_, to_remove[i]);
@@ -91,20 +94,20 @@ ACE_INLINE ssize_t
 ReceiveListenerSet::size() const
 {
   DBG_ENTRY_LVL("ReceiveListenerSet", "size", 6);
-  GuardType guard(this->lock_);
+  GuardType guard(lock_);
   return map_.size();
 }
 
 ACE_INLINE ReceiveListenerSet::MapType&
 ReceiveListenerSet::map()
 {
-  return this->map_;
+  return map_;
 }
 
 ACE_INLINE const ReceiveListenerSet::MapType&
 ReceiveListenerSet::map() const
 {
-  return this->map_;
+  return map_;
 }
 
 } // namespace DCPS


### PR DESCRIPTION
### Problem
`DataReaderImpl::state_update()` and the `ReceiveListenerSet` are inconsistent in how they apply their locking (the lock sometimes being applied, but not others).

### Solution
Assuming these locks are serving a real purpose, we ought to be consistent / careful in how they are applied to avoid future thread safety issues.