### PR TITLE
Add RcObject (et al.) Stress Test

### DIFF
--- a/dds/DCPS/Atomic.h
+++ b/dds/DCPS/Atomic.h
@@ -17,18 +17,18 @@ namespace OpenDDS {
 namespace DCPS {
 
 #ifdef ACE_HAS_CPP11
-    template <typename T>
-    using Atomic = std::atomic<T>;
+template <typename T>
+using Atomic = std::atomic<T>;
 #else
-    template <typename T>
-    class Atomic : public ACE_Atomic_Op<ACE_SYNCH_MUTEX, T>
-    {
-    public:
-      typedef ACE_Atomic_Op<ACE_SYNCH_MUTEX, T> Base;
-      Atomic() : Base() {}
-      Atomic(T desired) : Base(desired) {}
-      inline operator T() const { return Base::value(); }
-    };
+template <typename T>
+class Atomic : public ACE_Atomic_Op<ACE_SYNCH_MUTEX, T>
+{
+public:
+  typedef ACE_Atomic_Op<ACE_SYNCH_MUTEX, T> Base;
+  Atomic() : Base() {}
+  Atomic(T desired) : Base(desired) {}
+  inline operator T() const { return Base::value(); }
+};
 #endif
 
 } // DCPS

--- a/dds/DCPS/Atomic.h
+++ b/dds/DCPS/Atomic.h
@@ -1,0 +1,40 @@
+#ifndef OPENDDS_DCPS_ATOMIC_H
+#define OPENDDS_DCPS_ATOMIC_H
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+# pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+#ifdef ACE_HAS_CPP11
+#  include <atomic>
+#else
+#  include <ace/Atomic_Op.h>
+#endif
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+#ifdef ACE_HAS_CPP11
+    template <typename T>
+    using Atomic = std::atomic<T>;
+#else
+    template <typename T>
+    class Atomic : public ACE_Atomic_Op<ACE_SYNCH_MUTEX, T>
+    {
+    public:
+      typedef ACE_Atomic_Op<ACE_SYNCH_MUTEX, T> Base;
+      Atomic() : Base() {}
+      Atomic(T desired) : Base(desired) {}
+      inline operator T() const { return Base::value(); }
+    };
+#endif
+
+} // DCPS
+} // OPENDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* end of include guard: OPENDDS_DCPS_ATOMIC_H */
+

--- a/dds/DCPS/Atomic.h
+++ b/dds/DCPS/Atomic.h
@@ -9,6 +9,7 @@
 #  include <atomic>
 #else
 #  include <ace/Atomic_Op.h>
+#  include <ace/Thread_Mutex.h>
 #endif
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -21,10 +22,10 @@ template <typename T>
 using Atomic = std::atomic<T>;
 #else
 template <typename T>
-class Atomic : public ACE_Atomic_Op<ACE_SYNCH_MUTEX, T>
+class Atomic : public ACE_Atomic_Op<ACE_Thread_Mutex, T>
 {
 public:
-  typedef ACE_Atomic_Op<ACE_SYNCH_MUTEX, T> Base;
+  typedef ACE_Atomic_Op<ACE_Thread_Mutex, T> Base;
   Atomic() : Base() {}
   explicit Atomic(T desired) : Base(desired) {}
   inline operator T() const { return Base::value(); }

--- a/dds/DCPS/Atomic.h
+++ b/dds/DCPS/Atomic.h
@@ -26,7 +26,7 @@ class Atomic : public ACE_Atomic_Op<ACE_SYNCH_MUTEX, T>
 public:
   typedef ACE_Atomic_Op<ACE_SYNCH_MUTEX, T> Base;
   Atomic() : Base() {}
-  Atomic(T desired) : Base(desired) {}
+  explicit Atomic(T desired) : Base(desired) {}
   inline operator T() const { return Base::value(); }
 };
 #endif

--- a/dds/DCPS/Atomic.h
+++ b/dds/DCPS/Atomic.h
@@ -2,7 +2,7 @@
 #define OPENDDS_DCPS_ATOMIC_H
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
-# pragma once
+#  pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
 #ifdef ACE_HAS_CPP11

--- a/dds/DCPS/LocalObject.h
+++ b/dds/DCPS/LocalObject.h
@@ -28,10 +28,12 @@ class LocalObjectBase
   , public virtual RcObject
 {
 public:
-  virtual void _add_ref() {
+  virtual void _add_ref()
+  {
     RcObject::_add_ref();
   }
-  virtual void _remove_ref() {
+  virtual void _remove_ref()
+  {
     RcObject::_remove_ref();
   }
 };

--- a/dds/DCPS/RcHandle_T.h
+++ b/dds/DCPS/RcHandle_T.h
@@ -25,7 +25,8 @@ class RcHandle {
 public:
   RcHandle()
     : ptr_(0)
-  {}
+  {
+  }
 
   RcHandle(T* p, keep_count)
     : ptr_(p)
@@ -150,7 +151,6 @@ public:
     return retval;
   }
 
-
   operator bool() const
   {
     return in() != 0;
@@ -174,16 +174,16 @@ public:
 private:
   void bump_up()
   {
-    if (this->ptr_ != 0) {
-      this->ptr_->_add_ref();
+    if (ptr_ != 0) {
+      ptr_->_add_ref();
     }
   }
 
   void bump_down()
   {
-    if (this->ptr_ != 0) {
-      this->ptr_->_remove_ref();
-      this->ptr_ = 0;
+    if (ptr_ != 0) {
+      ptr_->_remove_ref();
+      ptr_ = 0;
     }
   }
 

--- a/tests/stress-tests/dds/DCPS/RcObject.cpp
+++ b/tests/stress-tests/dds/DCPS/RcObject.cpp
@@ -1,0 +1,81 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include <dds/DCPS/RcObject.h>
+#include <dds/DCPS/PoolAllocator.h>
+#include <dds/DCPS/ServiceEventDispatcher.h>
+
+#include <ace/Barrier.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+  struct TestObject : public virtual OpenDDS::DCPS::RcObject
+  {
+    TestObject(const std::string& payload)
+      : payload_(payload)
+    {}
+    const std::string payload_;
+  };
+  typedef OpenDDS::DCPS::RcHandle<TestObject> TestObject_rch;
+  typedef OpenDDS::DCPS::WeakRcHandle<TestObject> TestObject_wrch;
+
+  struct TestConfig_WrchLock_vs_RchReset : public virtual OpenDDS::DCPS::RcObject
+  {
+    const size_t test_size_;
+    OPENDDS_VECTOR(TestObject_rch) rch_vec_;
+    OPENDDS_VECTOR(TestObject_wrch) wrch_vec_;
+    ACE_Thread_Barrier barrier_;
+
+    TestConfig_WrchLock_vs_RchReset()
+      : test_size_(500000u)
+      , rch_vec_(test_size_)
+      , wrch_vec_(test_size_)
+      , barrier_(2)
+    {
+      for (size_t i = 0; i < test_size_; ++i) {
+        rch_vec_[i] = OpenDDS::DCPS::make_rch<TestObject>("payload");
+        wrch_vec_[i] = rch_vec_[i];
+      }
+    }
+
+    void do_locks()
+    {
+      barrier_.wait();
+      for (size_t i = 0; i < test_size_; ++i) {
+        {
+          TestObject_rch temp(wrch_vec_[i].lock());
+        }
+        barrier_.wait();
+      }
+    }
+
+    void do_resets()
+    {
+      barrier_.wait();
+      for (size_t i = 0; i < test_size_; ++i) {
+        {
+          rch_vec_[i].reset();
+        }
+        barrier_.wait();
+      }
+    }
+  };
+}
+
+TEST(dds_DCPS_RcObject, WRCH_lock_vs_RCH_reset)
+{
+  using namespace OpenDDS::DCPS;
+
+  RcHandle<TestConfig_WrchLock_vs_RchReset> config = make_rch<TestConfig_WrchLock_vs_RchReset>();
+  RcHandle<EventDispatcher> dispatcher = make_rch<ServiceEventDispatcher>(2);
+
+  dispatcher->dispatch(make_rch<PmfEvent<TestConfig_WrchLock_vs_RchReset> >(config, &TestConfig_WrchLock_vs_RchReset::do_locks));
+  dispatcher->dispatch(make_rch<PmfEvent<TestConfig_WrchLock_vs_RchReset> >(config, &TestConfig_WrchLock_vs_RchReset::do_resets));
+
+  dispatcher->shutdown();
+}

--- a/tests/stress-tests/dds/DCPS/RcObject.cpp
+++ b/tests/stress-tests/dds/DCPS/RcObject.cpp
@@ -58,9 +58,7 @@ namespace {
     {
       barrier_.wait();
       for (size_t i = 0; i < test_size_; ++i) {
-        {
-          rch_vec_[i].reset();
-        }
+        rch_vec_[i].reset();
         barrier_.wait();
       }
     }


### PR DESCRIPTION
### Problem
It appears as though there is a race condition between `WeakRcHandle::lock()` and `RcObject::_remove_ref()`, likely called from `RcHandle::~RcHandle()` or `RcHandle::reset()`.

### Solution
Create a stress test to expose the existing issue, then try to resolve it.