### PR TITLE
Socket handles invalid in RtpsUdpTransport

### DIFF
--- a/.github/workflows/build_u14_gcc4.Dockerfile
+++ b/.github/workflows/build_u14_gcc4.Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && apt-get install -y \
     make \
     libxerces-c-dev \
     libssl-dev \
-    perl
+    perl \
+    git
 
 ADD . /opt/OpenDDS
 

--- a/dds/DCPS/ReactorInterceptor.cpp
+++ b/dds/DCPS/ReactorInterceptor.cpp
@@ -119,6 +119,28 @@ ACE_Reactor* ReactorInterceptor::reactor() const
   return ACE_Event_Handler::reactor();
 }
 
+void RegisterHandler::execute()
+{
+  if (reactor()->register_handler(io_handle_, event_handler_, mask_) != 0) {
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR,
+                 "(%P|%t) ERROR: RegisterHandler::execute: failed to register handler for socket %d\n",
+                 io_handle_));
+    }
+  }
+}
+
+void RemoveHandler::execute()
+{
+  if (reactor()->remove_handler(io_handle_, mask_) != 0) {
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR,
+                 "(%P|%t) ERROR: UnregisterHandler::execute: failed to remove handler for socket %d\n",
+                 io_handle_));
+    }
+  }
+}
+
 }
 }
 

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -80,6 +80,39 @@ protected:
 typedef RcHandle<ReactorInterceptor> ReactorInterceptor_rch;
 typedef WeakRcHandle<ReactorInterceptor> ReactorInterceptor_wrch;
 
+class RegisterHandler : public ReactorInterceptor::Command {
+public:
+  RegisterHandler(ACE_HANDLE io_handle,
+                  ACE_Event_Handler* event_handler,
+                  ACE_Reactor_Mask mask)
+    : io_handle_(io_handle)
+    , event_handler_(event_handler)
+    , mask_(mask)
+  {}
+
+private:
+  ACE_HANDLE io_handle_;
+  ACE_Event_Handler* event_handler_;
+  ACE_Reactor_Mask mask_;
+
+  void execute();
+};
+
+class RemoveHandler : public ReactorInterceptor::Command {
+public:
+  RemoveHandler(ACE_HANDLE io_handle,
+                ACE_Reactor_Mask mask)
+    : io_handle_(io_handle)
+    , mask_(mask)
+  {}
+
+private:
+  ACE_HANDLE io_handle_;
+  ACE_Reactor_Mask mask_;
+
+  void execute();
+};
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/ReactorInterceptor.h
+++ b/dds/DCPS/ReactorInterceptor.h
@@ -80,7 +80,7 @@ protected:
 typedef RcHandle<ReactorInterceptor> ReactorInterceptor_rch;
 typedef WeakRcHandle<ReactorInterceptor> ReactorInterceptor_wrch;
 
-class RegisterHandler : public ReactorInterceptor::Command {
+class OpenDDS_Dcps_Export RegisterHandler : public ReactorInterceptor::Command {
 public:
   RegisterHandler(ACE_HANDLE io_handle,
                   ACE_Event_Handler* event_handler,
@@ -98,7 +98,7 @@ private:
   void execute();
 };
 
-class RemoveHandler : public ReactorInterceptor::Command {
+class OpenDDS_Dcps_Export RemoveHandler : public ReactorInterceptor::Command {
 public:
   RemoveHandler(ACE_HANDLE io_handle,
                 ACE_Reactor_Mask mask)

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -109,6 +109,7 @@ public:
   RtpsUdpInst_rch config() const;
 
   ACE_Reactor* get_reactor();
+  ReactorInterceptor_rch get_reactor_interceptor() const;
   bool reactor_is_shut_down();
 
   ACE_SOCK_Dgram& unicast_socket();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.inl
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.inl
@@ -19,6 +19,13 @@ RtpsUdpDataLink::get_reactor()
   return reactor_task_->get_reactor();
 }
 
+ACE_INLINE ReactorInterceptor_rch
+RtpsUdpDataLink::get_reactor_interceptor() const
+{
+  if (!reactor_task_) return ReactorInterceptor_rch();
+  return reactor_task_->interceptor();
+}
+
 ACE_INLINE bool
 RtpsUdpDataLink::reactor_is_shut_down()
 {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -979,9 +979,9 @@ int
 RtpsUdpReceiveStrategy::start_i()
 {
   ReactorInterceptor_rch ri = link_->get_reactor_interceptor();
-  ri->execute_or_enqueue(make_rch<RegisterHandler>(link_->unicast_socket().get_handle(), this, ACE_Event_Handler::READ_MASK));
+  ri->execute_or_enqueue(make_rch<RegisterHandler>(link_->unicast_socket().get_handle(), this, static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #ifdef ACE_HAS_IPV6
-  ri->execute_or_enqueue(make_rch<RegisterHandler>(link_->ipv6_unicast_socket().get_handle(), this, ACE_Event_Handler::READ_MASK));
+  ri->execute_or_enqueue(make_rch<RegisterHandler>(link_->ipv6_unicast_socket().get_handle(), this, static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #endif
 
   return 0;
@@ -991,16 +991,16 @@ void
 RtpsUdpReceiveStrategy::stop_i()
 {
   ReactorInterceptor_rch ri = link_->get_reactor_interceptor();
-  ri->execute_or_enqueue(make_rch<RemoveHandler>(link_->unicast_socket().get_handle(), ACE_Event_Handler::READ_MASK));
+  ri->execute_or_enqueue(make_rch<RemoveHandler>(link_->unicast_socket().get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #ifdef ACE_HAS_IPV6
-  ri->execute_or_enqueue(make_rch<RemoveHandler>(link_->ipv6_unicast_socket().get_handle(), ACE_Event_Handler::READ_MASK));
+  ri->execute_or_enqueue(make_rch<RemoveHandler>(link_->ipv6_unicast_socket().get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #endif
 
   RtpsUdpInst_rch cfg = link_->config();
   if (cfg && cfg->use_multicast_) {
-    ri->execute_or_enqueue(make_rch<RemoveHandler>(link_->multicast_socket().get_handle(), ACE_Event_Handler::READ_MASK));
+    ri->execute_or_enqueue(make_rch<RemoveHandler>(link_->multicast_socket().get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #ifdef ACE_HAS_IPV6
-    ri->execute_or_enqueue(make_rch<RemoveHandler>(link_->ipv6_multicast_socket().get_handle(), ACE_Event_Handler::READ_MASK);
+    ri->execute_or_enqueue(make_rch<RemoveHandler>(link_->ipv6_multicast_socket().get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #endif
   }
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.h
@@ -107,10 +107,7 @@ private:
                         const NetworkAddress& remote_addr);
 
   virtual int start_i();
-  void register_handlers();
   virtual void stop_i();
-  void remove_handlers();
-  typedef PmfJob<RtpsUdpReceiveStrategy> RURSJob;
 
   virtual bool check_header(const RtpsTransportHeader& header);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -159,7 +159,11 @@ RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
 
 #if defined(OPENDDS_SECURITY)
   if (cfg->use_ice()) {
-    job_queue_->enqueue(make_rch<RUTJob>(rchandle_from(this), &RtpsUdpTransport::remove_handlers));
+    ReactorInterceptor_rch ri = reactor_task_->interceptor();
+    ri->execute_or_enqueue(make_rch<RemoveHandler>(unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK));
+#ifdef ACE_HAS_IPV6
+    ri->execute_or_enqueue(make_rch<RemoveHandler>(ipv6_unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK));
+#endif
   }
 #endif
 
@@ -962,33 +966,12 @@ RtpsUdpTransport::start_ice()
   GuardThreadType guard_links(links_lock_);
 
   if (!link_) {
-    job_queue_->enqueue(make_rch<RUTJob>(rchandle_from(this), &RtpsUdpTransport::register_handlers));
-  }
-}
-
-void
-RtpsUdpTransport::register_handlers()
-{
-  if (reactor()->register_handler(unicast_socket_.get_handle(), ice_endpoint_.get(),
-                                  ACE_Event_Handler::READ_MASK) != 0) {
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: ")
-               ACE_TEXT("RtpsUdpTransport::register_handlers: ")
-               ACE_TEXT("failed to register handler for unicast ")
-               ACE_TEXT("socket %d\n"),
-               unicast_socket_.get_handle()));
-  }
+    ReactorInterceptor_rch ri = reactor_task_->interceptor();
+    ri->execute_or_enqueue(make_rch<RegisterHandler>(unicast_socket_.get_handle(), ice_endpoint_.get(), ACE_Event_Handler::READ_MASK));
 #ifdef ACE_HAS_IPV6
-  if (reactor()->register_handler(ipv6_unicast_socket_.get_handle(), ice_endpoint_.get(),
-                                  ACE_Event_Handler::READ_MASK) != 0) {
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: ")
-               ACE_TEXT("RtpsUdpTransport::register_handlers: ")
-               ACE_TEXT("failed to register handler for ipv6 unicast ")
-               ACE_TEXT("socket %d\n"),
-               ipv6_unicast_socket_.get_handle()));
-  }
+    ri->execute_or_enqueue(make_rch<RegisterHandler>(ipv6_unicast_socket_.get_handle(), ice_endpoint_.get(), ACE_Event_Handler::READ_MASK));
 #endif
+  }
 }
 
 void
@@ -1001,33 +984,14 @@ RtpsUdpTransport::stop_ice()
   GuardThreadType guard_links(links_lock_);
 
   if (!link_) {
-    job_queue_->enqueue(make_rch<RUTJob>(rchandle_from(this), &RtpsUdpTransport::remove_handlers));
+    ReactorInterceptor_rch ri = reactor_task_->interceptor();
+    ri->execute_or_enqueue(make_rch<RemoveHandler>(unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK));
+#ifdef ACE_HAS_IPV6
+    ri->execute_or_enqueue(make_rch<RemoveHandler>(ipv6_unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK));
+#endif
   }
 
   ice_agent_->remove_endpoint(static_rchandle_cast<ICE::Endpoint>(ice_endpoint_));
-}
-
-void
-RtpsUdpTransport::remove_handlers()
-{
-  if (reactor()->remove_handler(unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK) != 0) {
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: ")
-               ACE_TEXT("RtpsUdpTransport::remove_handlers: ")
-               ACE_TEXT("failed to unregister handler for unicast ")
-               ACE_TEXT("socket %d\n"),
-               unicast_socket_.get_handle()));
-  }
-#ifdef ACE_HAS_IPV6
-  if (reactor()->remove_handler(ipv6_unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK) != 0) {
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: ")
-               ACE_TEXT("RtpsUdpTransport::remove_handlers: ")
-               ACE_TEXT("failed to unregister handler for ipv6 unicast ")
-               ACE_TEXT("socket %d\n"),
-               ipv6_unicast_socket_.get_handle()));
-  }
-#endif
 }
 
 void

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -160,9 +160,9 @@ RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
 #if defined(OPENDDS_SECURITY)
   if (cfg->use_ice()) {
     ReactorInterceptor_rch ri = reactor_task_->interceptor();
-    ri->execute_or_enqueue(make_rch<RemoveHandler>(unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK));
+    ri->execute_or_enqueue(make_rch<RemoveHandler>(unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #ifdef ACE_HAS_IPV6
-    ri->execute_or_enqueue(make_rch<RemoveHandler>(ipv6_unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK));
+    ri->execute_or_enqueue(make_rch<RemoveHandler>(ipv6_unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #endif
   }
 #endif
@@ -967,9 +967,9 @@ RtpsUdpTransport::start_ice()
 
   if (!link_) {
     ReactorInterceptor_rch ri = reactor_task_->interceptor();
-    ri->execute_or_enqueue(make_rch<RegisterHandler>(unicast_socket_.get_handle(), ice_endpoint_.get(), ACE_Event_Handler::READ_MASK));
+    ri->execute_or_enqueue(make_rch<RegisterHandler>(unicast_socket_.get_handle(), ice_endpoint_.get(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #ifdef ACE_HAS_IPV6
-    ri->execute_or_enqueue(make_rch<RegisterHandler>(ipv6_unicast_socket_.get_handle(), ice_endpoint_.get(), ACE_Event_Handler::READ_MASK));
+    ri->execute_or_enqueue(make_rch<RegisterHandler>(ipv6_unicast_socket_.get_handle(), ice_endpoint_.get(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #endif
   }
 }
@@ -985,9 +985,9 @@ RtpsUdpTransport::stop_ice()
 
   if (!link_) {
     ReactorInterceptor_rch ri = reactor_task_->interceptor();
-    ri->execute_or_enqueue(make_rch<RemoveHandler>(unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK));
+    ri->execute_or_enqueue(make_rch<RemoveHandler>(unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #ifdef ACE_HAS_IPV6
-    ri->execute_or_enqueue(make_rch<RemoveHandler>(ipv6_unicast_socket_.get_handle(), ACE_Event_Handler::READ_MASK));
+    ri->execute_or_enqueue(make_rch<RemoveHandler>(ipv6_unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #endif
   }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.h
@@ -187,11 +187,6 @@ private:
   void start_ice();
   void stop_ice();
 
-  typedef PmfJob<RtpsUdpTransport> RUTJob;
-
-  void register_handlers();
-  void remove_handlers();
-
   RcHandle<ICE::Agent> ice_agent_;
 #endif
 


### PR DESCRIPTION
Problem
-------

The changes from #3990 created a race where the socket handles are nulled out as part of the transfer to the data link before the `remove_handler` call.

Solution
--------

Capture the inputs to `register_handler` and `remove_handler` in ReactorInterceptor Commands.