### PR TITLE
Follow up to 3994 and Fix sprintf Warnings

### DIFF
--- a/dds/.gitignore
+++ b/dds/.gitignore
@@ -11,6 +11,7 @@
 /CharSeqS.h
 /CharSeqS.inl
 /DdsDcps.mpc.orig
+/DdsDcps_lem_stub_export.h
 /DdsDcpsC.cpp
 /DdsDcpsC.h
 /DdsDcpsC.inl
@@ -196,7 +197,6 @@
 /DdsDcpsTypeSupportExtS.cpp
 /DdsDcpsTypeSupportExtS.h
 /DdsDcpsTypeSupportExtS.inl
-/DdsDcps_lem_stub_export.h
 /DdsDynamicDataC.cpp
 /DdsDynamicDataC.h
 /DdsDynamicDataC.inl

--- a/dds/CORBA/tao/Exception.cpp
+++ b/dds/CORBA/tao/Exception.cpp
@@ -42,7 +42,7 @@ CORBA::Exception::Exception (const CORBA::Exception &src)
 // responsible for releasing any storage owned by the exception.  It
 // can do this because it's got the local name and the id.
 
-#if TAO_VERSION_CODE < TAO_MAKE_VERSION_CODE(3,0,1)
+#if TAO_MAJOR_VERSION == 2
 CORBA::Exception::Exception (void)
   : id_ (),
     name_ ()

--- a/tests/DCPS/ManyTopicTest/publisher.cpp
+++ b/tests/DCPS/ManyTopicTest/publisher.cpp
@@ -156,7 +156,7 @@ void t2_init(T2::Foo2& foo, int)
 
 void t2_next(T2::Foo2& foo, int i)
 {
-  static char buff[20];
+  char buff[32];
   ACE_OS::snprintf(buff, sizeof buff, "message %d", i + 1);
   foo.text = (const char*) buff;
 }
@@ -168,7 +168,7 @@ void t3_init(T3::Foo3& foo, int)
 
 void t3_next(T3::Foo3& foo, int i)
 {
-  static char buff[20];
+  char buff[32];
   ACE_OS::snprintf(buff, sizeof buff, "message %d", i + 1);
   foo.c = 'A' + (i % 26);
   foo.text = (const char*) buff;

--- a/tests/DCPS/PersistentInfoRepo/Publisher.cpp
+++ b/tests/DCPS/PersistentInfoRepo/Publisher.cpp
@@ -80,12 +80,9 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
           // Initialize samples
           ::Xyz::Foo message;
 
-          char number[20];
-
           std::cerr << pid << "Pub Stage " << stage << " sending id=" << id << "\n";
           for (int i = 0; i<msg_count; ++i) {
             // Prepare next sample
-            sprintf(number, "foo %d", i);
             message.key = msg_count;
             message.c = (char)i;
             message.x = id;

--- a/tests/DCPS/Reliability/pub/Publisher.cpp
+++ b/tests/DCPS/Reliability/pub/Publisher.cpp
@@ -1,20 +1,21 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
 
 #include "Boilerplate.h"
-#include <dds/DCPS/Service_Participant.h>
+
 #include <model/Sync.h>
+
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/SafetyProfileStreams.h>
+#include <dds/DCPS/StaticIncludes.h>
+#ifdef ACE_AS_STATIC_LIBS
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
+
 #include <stdexcept>
 #include <iostream>
-
-#include "dds/DCPS/StaticIncludes.h"
-#ifdef ACE_AS_STATIC_LIBS
-#include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
-#endif
 
 using namespace examples::boilerplate;
 
@@ -61,12 +62,10 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       // Initialize samples
       Reliability::Message message;
 
-      char number[20];
-
-      for (int i = 0; i<msg_count; ++i) {
+      for (int i = 0; i < msg_count; ++i) {
         // Prepare next sample
-        sprintf(number, "foo %d", i);
-        message.id = CORBA::string_dup(number);
+        const OpenDDS::DCPS::String number = "foo " + OpenDDS::DCPS::to_dds_string(i);
+        message.id = CORBA::string_dup(number.c_str());
         message.name = "foo";
         message.count = (long)i;
         message.expected = msg_count;

--- a/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
+++ b/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
@@ -1,29 +1,30 @@
 #include "TestMsgTypeSupportImpl.h"
 #include "DataReaderListenerImpl.h"
 
-#include "dds/DCPS/Service_Participant.h"
-#include "dds/DCPS/Marked_Default_Qos.h"
-#include "dds/DCPS/BuiltInTopicUtils.h"
-#include "dds/DCPS/WaitSet.h"
+#include <tests/Utils/StatusMatching.h>
 
-#include "dds/DCPS/transport/framework/TransportExceptions.h"
-#include "dds/DCPS/transport/framework/TransportRegistry.h"
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/Marked_Default_Qos.h>
+#include <dds/DCPS/BuiltInTopicUtils.h>
+#include <dds/DCPS/WaitSet.h>
+#include <dds/DCPS/SafetyProfileStreams.h>
+#include <dds/DCPS/GuidConverter.h>
+#include <dds/DCPS/DataReaderImpl.h>
+#include <dds/DCPS/DataWriterImpl.h>
+#include <dds/DCPS/transport/framework/TransportExceptions.h>
+#include <dds/DCPS/transport/framework/TransportRegistry.h>
 
-#include "dds/DdsDcpsInfrastructureC.h"
-#include "dds/DdsDcpsCoreTypeSupportImpl.h"
-#include "dds/DCPS/GuidConverter.h"
-#include "dds/DCPS/DataReaderImpl.h"
-#include "dds/DCPS/DataWriterImpl.h"
-#include "tests/Utils/StatusMatching.h"
+#include <dds/DdsDcpsInfrastructureC.h>
+#include <dds/DdsDcpsCoreTypeSupportImpl.h>
 
-#include "dds/DCPS/StaticIncludes.h"
+#include <dds/DCPS/StaticIncludes.h>
 #ifdef ACE_AS_STATIC_LIBS
-#include "dds/DCPS/transport/rtps_udp/RtpsUdp.h"
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
 #endif
 
-#include "ace/Arg_Shifter.h"
-#include "ace/OS_NS_stdlib.h"
-#include "ace/OS_NS_unistd.h"
+#include <ace/Arg_Shifter.h>
+#include <ace/OS_NS_stdlib.h>
+#include <ace/OS_NS_unistd.h>
 
 /*
   NOTE:  The messages may not be processed by the reader in this test.
@@ -91,9 +92,8 @@ public:
     unsigned long binary_id = static_cast<unsigned long>(fromhex(writers_[thread_id], 2))
                             + (256 * static_cast<unsigned long>(fromhex(writers_[thread_id], 1)))
                             + (256 * 256 * static_cast<unsigned long>(fromhex(writers_[thread_id], 0)));
-    char config_name_buffer[16];
-    sprintf(config_name_buffer, "Config%lu", binary_id);
-    OpenDDS::DCPS::TransportRegistry::instance()->bind_config(config_name_buffer, publisher);
+    const OpenDDS::DCPS::String config_name = "Config" + OpenDDS::DCPS::to_dds_string(binary_id);
+    OpenDDS::DCPS::TransportRegistry::instance()->bind_config(config_name.c_str(), publisher);
 
     DDS::DataWriterQos qos;
     publisher->get_default_datawriter_qos(qos);
@@ -350,9 +350,8 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       unsigned long binary_id = static_cast<unsigned long>(fromhex(*pos, 2))
                               + (256 * static_cast<unsigned long>(fromhex(*pos, 1)))
                               + (256 * 256 * static_cast<unsigned long>(fromhex(*pos, 0)));
-      char config_name_buffer[16];
-      sprintf(config_name_buffer, "Config%lu", binary_id);
-      OpenDDS::DCPS::TransportRegistry::instance()->bind_config(config_name_buffer, subscriber);
+      const OpenDDS::DCPS::String config_name = "Config" + OpenDDS::DCPS::to_dds_string(binary_id);
+      OpenDDS::DCPS::TransportRegistry::instance()->bind_config(config_name.c_str(), subscriber);
 
       DDS::DataReaderQos qos;
       subscriber->get_default_datareader_qos(qos);

--- a/tests/DCPS/XTypes/Subscriber.cpp
+++ b/tests/DCPS/XTypes/Subscriber.cpp
@@ -132,7 +132,7 @@ struct ReadTest {
     }
     // TODO: the duplicate shouldn't be required, but a direct assignment isn't
     // incrementing the reference count.
-    // http://bugzilla.dre.vanderbilt.edu/show_bug.cgi?id=3942
+    // https://github.com/DOCGroup/ACE_TAO/issues/2037
     dd = DDS::DynamicData::_duplicate(seq[0]);
     return true;
 #endif

--- a/tools/modeling/tests/MessengerMC/fs_signal.cpp
+++ b/tools/modeling/tests/MessengerMC/fs_signal.cpp
@@ -8,7 +8,7 @@
 
 FileSystemSignal::FileSystemSignal(int id)
 : _id(id)
-, _file_name("fs_signal_" + to_dds_string(id)
+, _file_name("fs_signal_" + OpenDDS::DCPS::to_dds_string(id))
 {
 }
 

--- a/tools/modeling/tests/MessengerMC/fs_signal.cpp
+++ b/tools/modeling/tests/MessengerMC/fs_signal.cpp
@@ -1,9 +1,15 @@
 #include "fs_signal.h"
-#include <fstream>
+
+#include <dds/DCPS/SafetyProfileStreams.h>
+
 #include <ace/OS_NS_unistd.h>
 
-FileSystemSignal::FileSystemSignal(int id) : _id(id) {
-  sprintf(_file_name, "fs_signal_%d", _id);
+#include <fstream>
+
+FileSystemSignal::FileSystemSignal(int id)
+: _id(id)
+, _file_name("fs_signal_" + to_dds_string(id)
+{
 }
 
 void FileSystemSignal::signal() {

--- a/tools/modeling/tests/MessengerMC/fs_signal.cpp
+++ b/tools/modeling/tests/MessengerMC/fs_signal.cpp
@@ -7,8 +7,7 @@
 #include <fstream>
 
 FileSystemSignal::FileSystemSignal(int id)
-: _id(id)
-, _file_name("fs_signal_" + OpenDDS::DCPS::to_dds_string(id))
+: _file_name("fs_signal_" + OpenDDS::DCPS::to_dds_string(id))
 {
 }
 

--- a/tools/modeling/tests/MessengerMC/fs_signal.h
+++ b/tools/modeling/tests/MessengerMC/fs_signal.h
@@ -1,6 +1,8 @@
 #ifndef FS_SIGNAL_H
 #define FS_SIGNAL_H
 
+#include <dds/DCPS/PoolAllocator.h>
+
 class FileSystemSignal {
   public:
     FileSystemSignal(int id);
@@ -10,7 +12,7 @@ class FileSystemSignal {
 
   private:
     int _id;
-    char _file_name[24];
+    OpenDDS::DCPS::String _file_name;
 
     bool exists();
 };

--- a/tools/modeling/tests/MessengerMC/fs_signal.h
+++ b/tools/modeling/tests/MessengerMC/fs_signal.h
@@ -4,17 +4,16 @@
 #include <dds/DCPS/PoolAllocator.h>
 
 class FileSystemSignal {
-  public:
-    FileSystemSignal(int id);
-    void signal();
-    void wait_timeout(int dur_sec);
-    void wait_forever();
+public:
+  FileSystemSignal(int id);
+  void signal();
+  void wait_timeout(int dur_sec);
+  void wait_forever();
 
-  private:
-    int _id;
-    OpenDDS::DCPS::String _file_name;
+private:
+  OpenDDS::DCPS::String _file_name;
 
-    bool exists();
+  bool exists();
 };
 
 #endif

--- a/tools/scripts/update_gitignore.pl
+++ b/tools/scripts/update_gitignore.pl
@@ -1,17 +1,32 @@
 #!/usr/bin/env perl
 
-use File::Basename;
 use strict;
+use warnings;
 
-my %dirs;
+use File::Basename;
+use FindBin;
+use Getopt::Long;
+
+my $root = "$FindBin::RealBin/../..";
+my $wildcard_replace = undef;
+my @sort_existing = ();
+GetOptions(
+  'r|root=s' => \$root,
+  'w|wildcard-replace=s' => \$wildcard_replace,
+  's|sort-existing=s' => \@sort_existing,
+) or die("Invalid options");
+
+chdir($root) or die("Couldn't chdir to $root: $!");
+
+my %dirs = map { $_ => [] } @sort_existing;
 
 open GIT, "git status --porcelain |";
 while (<GIT>) {
   chomp;
   next unless /^\?\?\s+(\S+)/;
   my @fp = fileparse $1;
-  if (scalar @ARGV) {
-    $fp[0] =~ s/$ARGV[0]/*/g;
+  if (defined($wildcard_replace)) {
+    $fp[0] =~ s/$wildcard_replace/*/g;
   }
   push(@{$dirs{$fp[1]}}, '/' . $fp[0]);
 }


### PR DESCRIPTION
https://github.com/OpenDDS/OpenDDS/pull/3994

- Fixed missing `TAO_VERSION_CODE` on TAO 2.2 by using `TAO_MAJOR_VERSION` instead.
- Replaced reference to bugzilla ticket with https://github.com/DOCGroup/ACE_TAO/issues/2037
- Cleaned up and added sorting option for `update_gitignore.pl` used in #3994
- Replaced sprintf usage to satisfy build_m12_i0_j_FM-1f GHA warnings
- [Attempting ASAN fix for ManyTopicTest.](https://github.com/OpenDDS/OpenDDS/actions/runs/4015514096/jobs/6899467008#logs) The string in Foo3 appears to be missing a null terminator. The fix is assuming that the static buffer is causing the issue because there can multiple threads using the function.