### PR TITLE
Fix index increment in GuidPartitionTable::prepare_relay_partitions

### DIFF
--- a/tools/rtpsrelay/GuidPartitionTable.h
+++ b/tools/rtpsrelay/GuidPartitionTable.h
@@ -188,6 +188,7 @@ private:
       relay_partitions[idx].relay_id(config_.relay_id());
       relay_partitions[idx].slot(static_cast<CORBA::ULong>(slot));
       relay_partitions[idx].partitions().assign(slots_[slot].begin(), slots_[slot].end());
+      ++idx;
     }
   }
 


### PR DESCRIPTION
### Problem
The index variable `idx` in `GuidPartitionTable::prepare_relay_partitions()` is not currently being incremented, even though it appears as though the code is set up to expect that.

### Solution
Increment the index.