### PR TITLE
Add PublicationMatchedStatus Current Count To RtpsRelay Statistics

### DIFF
--- a/tools/dds/rtpsrelaylib/Relay.idl
+++ b/tools/dds/rtpsrelaylib/Relay.idl
@@ -161,6 +161,14 @@ module RtpsRelay {
     unsigned long local_participants;
     unsigned long local_writers;
     unsigned long local_readers;
+    unsigned long handler_statistics_sub_count;
+    unsigned long relay_statistics_sub_count;
+    unsigned long participant_statistics_sub_count;
+    unsigned long relay_partitions_sub_count;
+    unsigned long relay_participant_status_sub_count;
+    unsigned long spdp_replay_sub_count;
+    unsigned long relay_address_sub_count;
+    unsigned long relay_status_sub_count;
     unsigned long relay_partitions_pub_count;
     unsigned long relay_address_pub_count;
     unsigned long spdp_replay_pub_count;

--- a/tools/rtpsrelay/ParticipantListener.h
+++ b/tools/rtpsrelay/ParticipantListener.h
@@ -1,14 +1,14 @@
 #ifndef RTPSRELAY_PARTICIPANT_LISTENER_H_
 #define RTPSRELAY_PARTICIPANT_LISTENER_H_
 
-#include "ListenerBase.h"
+#include "ReaderListenerBase.h"
 #include "RelayParticipantStatusReporter.h"
 
 #include <dds/DCPS/DomainParticipantImpl.h>
 
 namespace RtpsRelay {
 
-class ParticipantListener : public ListenerBase {
+class ParticipantListener : public ReaderListenerBase {
 public:
   ParticipantListener(OpenDDS::DCPS::DomainParticipantImpl* participant,
                       GuidAddrSet& guid_addr_set,

--- a/tools/rtpsrelay/PublicationListener.h
+++ b/tools/rtpsrelay/PublicationListener.h
@@ -3,14 +3,14 @@
 
 #include "RelayStatisticsReporter.h"
 #include "GuidPartitionTable.h"
-#include "ListenerBase.h"
+#include "ReaderListenerBase.h"
 #include "RelayHandler.h"
 
 #include <dds/DCPS/DomainParticipantImpl.h>
 
 namespace RtpsRelay {
 
-class PublicationListener : public ListenerBase {
+class PublicationListener : public ReaderListenerBase {
 public:
   PublicationListener(const Config& config,
                       GuidAddrSet& guid_addr_set,

--- a/tools/rtpsrelay/ReaderListenerBase.h
+++ b/tools/rtpsrelay/ReaderListenerBase.h
@@ -1,11 +1,11 @@
-#ifndef RTPSRELAY_LISTENER_BASE_H_
-#define RTPSRELAY_LISTENER_BASE_H_
+#ifndef RTPSRELAY_READER_LISTENER_BASE_H_
+#define RTPSRELAY_READER_LISTENER_BASE_H_
 
 #include <dds/DdsDcpsSubscriptionC.h>
 
 namespace RtpsRelay {
 
-class ListenerBase : public DDS::DataReaderListener {
+class ReaderListenerBase : public DDS::DataReaderListener {
 public:
 
 private:
@@ -26,4 +26,4 @@ private:
 
 }
 
-#endif // RTPSRELAY_LISTENER_BASE_H_
+#endif // RTPSRELAY_READER_LISTENER_BASE_H_

--- a/tools/rtpsrelay/RelayAddressListener.h
+++ b/tools/rtpsrelay/RelayAddressListener.h
@@ -1,13 +1,13 @@
 #ifndef RTPSRELAY_RELAY_ADDRESS_LISTENER_H_
 #define RTPSRELAY_RELAY_ADDRESS_LISTENER_H_
 
-#include "ListenerBase.h"
+#include "ReaderListenerBase.h"
 #include "RelayPartitionTable.h"
 #include "RelayStatisticsReporter.h"
 
 namespace RtpsRelay {
 
-class RelayAddressListener : public ListenerBase {
+class RelayAddressListener : public ReaderListenerBase {
 public:
   RelayAddressListener(RelayPartitionTable& relay_partition_table,
     RelayStatisticsReporter& relay_statistics_reporter);

--- a/tools/rtpsrelay/RelayPartitionsListener.h
+++ b/tools/rtpsrelay/RelayPartitionsListener.h
@@ -1,13 +1,13 @@
 #ifndef RTPSRELAY_RELAY_PARTITIONS_LISTENER_H_
 #define RTPSRELAY_RELAY_PARTITIONS_LISTENER_H_
 
-#include "ListenerBase.h"
+#include "ReaderListenerBase.h"
 #include "RelayPartitionTable.h"
 #include "RelayStatisticsReporter.h"
 
 namespace RtpsRelay {
 
-class RelayPartitionsListener : public ListenerBase {
+class RelayPartitionsListener : public ReaderListenerBase {
 public:
   RelayPartitionsListener(RelayPartitionTable& relay_partition_table,
     RelayStatisticsReporter& relay_statistics_reporter);

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -143,6 +143,78 @@ public:
     report(guard, now);
   }
 
+  //handler_statistics_sub_count
+  void handler_statistics_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    log_relay_statistics_.handler_statistics_sub_count() = count;
+    publish_relay_statistics_.handler_statistics_sub_count() = count;
+    report(guard, now);
+  }
+
+  //relay_statistics_sub_count
+  void relay_statistics_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    log_relay_statistics_.relay_statistics_sub_count() = count;
+    publish_relay_statistics_.relay_statistics_sub_count() = count;
+    report(guard, now);
+  }
+
+  //participant_statistics_sub_count
+  void participant_statistics_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    log_relay_statistics_.participant_statistics_sub_count() = count;
+    publish_relay_statistics_.participant_statistics_sub_count() = count;
+    report(guard, now);
+  }
+
+  //relay_partitions_sub_count
+  void relay_partitions_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    log_relay_statistics_.relay_partitions_sub_count() = count;
+    publish_relay_statistics_.relay_partitions_sub_count() = count;
+    report(guard, now);
+  }
+
+  //relay_participant_status_sub_count
+  void relay_participant_status_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    log_relay_statistics_.relay_participant_status_sub_count() = count;
+    publish_relay_statistics_.relay_participant_status_sub_count() = count;
+    report(guard, now);
+  }
+
+  //spdp_replay_sub_count
+  void spdp_replay_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    log_relay_statistics_.spdp_replay_sub_count() = count;
+    publish_relay_statistics_.spdp_replay_sub_count() = count;
+    report(guard, now);
+  }
+
+  //relay_address_sub_count
+  void relay_address_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    log_relay_statistics_.relay_address_sub_count() = count;
+    publish_relay_statistics_.relay_address_sub_count() = count;
+    report(guard, now);
+  }
+
+  //relay_status_sub_count
+  void relay_status_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    log_relay_statistics_.relay_status_sub_count() = count;
+    publish_relay_statistics_.relay_status_sub_count() = count;
+    report(guard, now);
+  }
+
   void relay_partitions_pub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);

--- a/tools/rtpsrelay/RelayThreadMonitor.h
+++ b/tools/rtpsrelay/RelayThreadMonitor.h
@@ -2,7 +2,7 @@
 #define RTPSRELAY_RELAY_THREAD_MONITOR_H_
 
 #include "Config.h"
-#include "ListenerBase.h"
+#include "ReaderListenerBase.h"
 
 #include <dds/OpenddsDcpsExtTypeSupportImpl.h>
 #include <dds/DCPS/ConditionVariable.h>
@@ -11,7 +11,7 @@
 
 namespace RtpsRelay {
 
-class RelayThreadMonitor : public virtual ACE_Task_Base, public ListenerBase {
+class RelayThreadMonitor : public virtual ACE_Task_Base, public ReaderListenerBase {
 public:
   explicit RelayThreadMonitor(const Config& config)
     : config_(config)

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -18,6 +18,7 @@
 #include "RelayStatusReporter.h"
 #include "RelayThreadMonitor.h"
 #include "SpdpReplayListener.h"
+#include "StatisticsWriterListener.h"
 #include "SubscriptionListener.h"
 
 #include <dds/DCPS/BuiltInTopicUtils.h>
@@ -525,18 +526,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   reader_qos.reader_data_lifecycle.autopurge_disposed_samples_delay = one_minute;
 
   // Setup statistics publishing.
-  DDS::DataWriter_var handler_statistics_writer_var = relay_publisher->create_datawriter(handler_statistics_topic, writer_qos, nullptr, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-  if (!handler_statistics_writer_var) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Handler Statistics data writer\n")));
-    return EXIT_FAILURE;
-  }
-
-  HandlerStatisticsDataWriter_var handler_statistics_writer = HandlerStatisticsDataWriter::_narrow(handler_statistics_writer_var);
-  if (!handler_statistics_writer) {
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to narrow Handler Statistics data writer\n")));
-    return EXIT_FAILURE;
-  }
-
   DDS::DataWriter_var relay_statistics_writer_var = relay_publisher->create_datawriter(relay_statistics_topic, writer_qos, nullptr, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
   if (!relay_statistics_writer_var) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Relay Statistics data writer\n")));
@@ -549,9 +538,31 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     return EXIT_FAILURE;
   }
 
-  auto participant_statistics_writer_qos = writer_qos;
+  RelayStatisticsReporter relay_statistics_reporter(config, relay_statistics_writer);
+
+  DDS::DataWriterListener_var relay_statistics_writer_listener =
+    new StatisticsWriterListener(relay_statistics_reporter, &RelayStatisticsReporter::relay_statistics_sub_count);
+  relay_statistics_writer->set_listener(relay_statistics_writer_listener, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  DDS::DataWriterListener_var handler_statistics_writer_listener =
+    new StatisticsWriterListener(relay_statistics_reporter, &RelayStatisticsReporter::handler_statistics_sub_count);
+  DDS::DataWriter_var handler_statistics_writer_var = relay_publisher->create_datawriter(handler_statistics_topic, writer_qos, handler_statistics_writer_listener, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  if (!handler_statistics_writer_var) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Handler Statistics data writer\n")));
+    return EXIT_FAILURE;
+  }
+
+  HandlerStatisticsDataWriter_var handler_statistics_writer = HandlerStatisticsDataWriter::_narrow(handler_statistics_writer_var);
+  if (!handler_statistics_writer) {
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to narrow Handler Statistics data writer\n")));
+    return EXIT_FAILURE;
+  }
+
+  DDS::DataWriterQos participant_statistics_writer_qos = writer_qos;
   participant_statistics_writer_qos.writer_data_lifecycle.autodispose_unregistered_instances = false;
-  auto participant_statistics_writer_var = relay_publisher->create_datawriter(participant_statistics_topic, participant_statistics_writer_qos, nullptr, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  DDS::DataWriterListener_var participant_statistics_writer_listener =
+    new StatisticsWriterListener(relay_statistics_reporter, &RelayStatisticsReporter::participant_statistics_sub_count);
+  DDS::DataWriter_var participant_statistics_writer_var = relay_publisher->create_datawriter(participant_statistics_topic, participant_statistics_writer_qos, participant_statistics_writer_listener, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
   if (!participant_statistics_writer_var) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Participant Statistics data writer\n")));
     return EXIT_FAILURE;
@@ -652,8 +663,10 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 #endif
 
 
+  DDS::DataWriterListener_var relay_partitions_writer_listener =
+    new StatisticsWriterListener(relay_statistics_reporter, &RelayStatisticsReporter::relay_partitions_sub_count);
   DDS::DataWriter_var relay_partitions_writer_var =
-    relay_publisher->create_datawriter(relay_partitions_topic, writer_qos, nullptr,
+    relay_publisher->create_datawriter(relay_partitions_topic, writer_qos, relay_partitions_writer_listener,
                                        OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
   if (!relay_partitions_writer_var) {
@@ -670,8 +683,10 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 
   auto relay_participant_status_writer_qos = writer_qos;
   relay_participant_status_writer_qos.writer_data_lifecycle.autodispose_unregistered_instances = false;
+  DDS::DataWriterListener_var relay_participant_status_writer_listener =
+    new StatisticsWriterListener(relay_statistics_reporter, &RelayStatisticsReporter::relay_participant_status_sub_count);
   DDS::DataWriter_var relay_participant_status_writer_var =
-    relay_publisher->create_datawriter(relay_participant_status_topic, relay_participant_status_writer_qos, nullptr,
+    relay_publisher->create_datawriter(relay_participant_status_topic, relay_participant_status_writer_qos, relay_participant_status_writer_listener,
                                        OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
   if (!relay_participant_status_writer_var) {
@@ -693,8 +708,10 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   replay_writer_qos.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
   replay_writer_qos.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
 
+  DDS::DataWriterListener_var spdp_replay_writer_listener =
+    new StatisticsWriterListener(relay_statistics_reporter, &RelayStatisticsReporter::spdp_replay_sub_count);
   DDS::DataWriter_var spdp_replay_writer_var =
-    relay_publisher->create_datawriter(spdp_replay_topic, replay_writer_qos, nullptr,
+    relay_publisher->create_datawriter(spdp_replay_topic, replay_writer_qos, spdp_replay_writer_listener,
                                        OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
   if (!spdp_replay_writer_var) {
@@ -709,7 +726,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     return EXIT_FAILURE;
   }
 
-  RelayStatisticsReporter relay_statistics_reporter(config, relay_statistics_writer);
   RelayParticipantStatusReporter relay_participant_status_reporter(config, relay_participant_status_writer, relay_statistics_reporter);
   RelayThreadMonitor* relay_thread_monitor = new RelayThreadMonitor(config);
   GuidAddrSet guid_addr_set(config, rtps_discovery, relay_participant_status_reporter, relay_statistics_reporter, *relay_thread_monitor);
@@ -868,7 +884,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: Data Vertical listening on %C\n"), OpenDDS::DCPS::LogAddr(data_vertical_addr).c_str()));
 
   // Write about the relay.
-  DDS::DataWriter_var relay_address_writer_var = relay_publisher->create_datawriter(relay_addresses_topic, writer_qos, nullptr, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  DDS::DataWriterListener_var relay_address_writer_listener =
+    new StatisticsWriterListener(relay_statistics_reporter, &RelayStatisticsReporter::relay_address_sub_count);
+  DDS::DataWriter_var relay_address_writer_var = relay_publisher->create_datawriter(relay_addresses_topic, writer_qos, relay_address_writer_listener, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
   if (!relay_address_writer_var) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Relay Address data writer\n")));
     return EXIT_FAILURE;
@@ -916,7 +934,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     relay_status_writer_qos.liveliness.kind = DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS;
   }
 
-  DDS::DataWriter_var relay_status_writer_var = relay_publisher->create_datawriter(relay_statuss_topic, relay_status_writer_qos, nullptr, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  DDS::DataWriterListener_var relay_status_writer_listener =
+    new StatisticsWriterListener(relay_statistics_reporter, &RelayStatisticsReporter::relay_status_sub_count);
+  DDS::DataWriter_var relay_status_writer_var = relay_publisher->create_datawriter(relay_statuss_topic, relay_status_writer_qos, relay_status_writer_listener, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
   if (!relay_status_writer_var) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: failed to create Relay Status data writer\n")));
     return EXIT_FAILURE;

--- a/tools/rtpsrelay/SpdpReplayListener.h
+++ b/tools/rtpsrelay/SpdpReplayListener.h
@@ -1,13 +1,13 @@
 #ifndef RTPSRELAY_SPDP_REPLAY_LISTENER_H_
 #define RTPSRELAY_SPDP_REPLAY_LISTENER_H_
 
-#include "ListenerBase.h"
+#include "ReaderListenerBase.h"
 #include "RelayHandler.h"
 #include "RelayStatisticsReporter.h"
 
 namespace RtpsRelay {
 
-class SpdpReplayListener : public ListenerBase {
+class SpdpReplayListener : public ReaderListenerBase {
 public:
   SpdpReplayListener(SpdpHandler& spdp_handler,
     RelayStatisticsReporter& relay_statistics_reporter);

--- a/tools/rtpsrelay/StatisticsWriterListener.h
+++ b/tools/rtpsrelay/StatisticsWriterListener.h
@@ -1,0 +1,32 @@
+#ifndef RTPSRELAY_STATISTICS_WRITER_LISTENER_H_
+#define RTPSRELAY_STATISTICS_WRITER_LISTENER_H_
+
+#include "RelayStatisticsReporter.h"
+#include "WriterListenerBase.h"
+
+namespace RtpsRelay {
+
+class StatisticsWriterListener: public WriterListenerBase {
+public:
+
+  typedef void (RelayStatisticsReporter::*ReporterMemFun)(uint32_t, const OpenDDS::DCPS::MonotonicTimePoint&);
+
+  StatisticsWriterListener(RelayStatisticsReporter& relay_statistics_reporter, ReporterMemFun update)
+    : relay_statistics_reporter_(relay_statistics_reporter)
+    , update_(update)
+  {}
+
+  void on_publication_matched(DDS::DataWriter_ptr /*writer*/,
+                              const DDS::PublicationMatchedStatus & status) override
+  {
+    (relay_statistics_reporter_.*update_)(status.current_count, OpenDDS::DCPS::MonotonicTimePoint::now());
+  }
+
+private:
+  RelayStatisticsReporter& relay_statistics_reporter_;
+  ReporterMemFun update_;
+};
+
+}
+
+#endif // RTPSRELAY_STATISTICS_WRITER_LISTENER_H_

--- a/tools/rtpsrelay/SubscriptionListener.h
+++ b/tools/rtpsrelay/SubscriptionListener.h
@@ -3,14 +3,14 @@
 
 #include "RelayStatisticsReporter.h"
 #include "GuidPartitionTable.h"
-#include "ListenerBase.h"
+#include "ReaderListenerBase.h"
 #include "RelayHandler.h"
 
 #include <dds/DCPS/DomainParticipantImpl.h>
 
 namespace RtpsRelay {
 
-class SubscriptionListener : public ListenerBase {
+class SubscriptionListener : public ReaderListenerBase {
 public:
   SubscriptionListener(const Config& config,
                        GuidAddrSet& guid_addr_set,

--- a/tools/rtpsrelay/WriterListenerBase.h
+++ b/tools/rtpsrelay/WriterListenerBase.h
@@ -1,0 +1,18 @@
+#ifndef RTPSRELAY_WRITER_LISTENER_BASE_H_
+#define RTPSRELAY_WRITER_LISTENER_BASE_H_
+
+#include <dds/DdsDcpsPublicationC.h>
+
+namespace RtpsRelay {
+
+class WriterListenerBase : public DDS::DataWriterListener {
+public:
+  void on_publication_matched(DDS::DataWriter_ptr, const DDS::PublicationMatchedStatus&) override {}
+  void on_offered_deadline_missed(DDS::DataWriter_ptr, const DDS::OfferedDeadlineMissedStatus&) override {}
+  void on_offered_incompatible_qos(DDS::DataWriter_ptr, const DDS::OfferedIncompatibleQosStatus&) override {}
+  void on_liveliness_lost(DDS::DataWriter_ptr, const DDS::LivelinessLostStatus&) override {}
+};
+
+}
+
+#endif // RTPSRELAY_WRITER_LISTENER_BASE_H_


### PR DESCRIPTION
### Problem
Relay cluster fragmentation is difficult to detect.

### Solution
Ensure RtpsRelay's entities are tracking publication and subscription match counts, and writing them to the various relay statistics channels.