### PR TITLE
Prefer New OpenDDS::DCPS::Atomic To ACE_Atomic_Op

### DIFF
--- a/dds/DCPS/Atomic.h
+++ b/dds/DCPS/Atomic.h
@@ -5,6 +5,8 @@
 #  pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
+#include <dds/Versioned_Namespace.h>
+
 #ifdef ACE_HAS_CPP11
 #  include <atomic>
 #else
@@ -29,6 +31,7 @@ public:
   Atomic() : Base() {}
   explicit Atomic(T desired) : Base(desired) {}
   inline operator T() const { return Base::value(); }
+  inline T load() const { return Base::value(); }
 };
 #endif
 

--- a/dds/DCPS/Atomic.h
+++ b/dds/DCPS/Atomic.h
@@ -24,14 +24,31 @@ template <typename T>
 using Atomic = std::atomic<T>;
 #else
 template <typename T>
-class Atomic : public ACE_Atomic_Op<ACE_Thread_Mutex, T>
+class Atomic
 {
 public:
+  Atomic() : impl_() {}
+  Atomic(T desired) : impl_(desired) {}
+
+  inline T load() const { return impl_.value(); }
+  inline void store(T desired) const { impl_ = desired; }
+  inline T exchange(const T& desired) { return impl_.exchange(desired); }
+
+  inline operator T() const { return impl_.value(); }
+  inline T operator=(const T& desired) { impl_ = desired; return desired; }
+
+  inline T operator++() { return ++impl_; }
+  inline T operator++(int) { return impl_++; }
+
+  inline T operator--() { return --impl_; }
+  inline T operator--(int) { return impl_--; }
+
+  inline T operator+=(T arg) { return impl_ += arg; }
+  inline T operator-=(T arg) { return impl_ -= arg; }
+
+private:
   typedef ACE_Atomic_Op<ACE_Thread_Mutex, T> Base;
-  Atomic() : Base() {}
-  explicit Atomic(T desired) : Base(desired) {}
-  inline operator T() const { return Base::value(); }
-  inline T load() const { return Base::value(); }
+  Base impl_;
 };
 #endif
 

--- a/dds/DCPS/AtomicBool.h
+++ b/dds/DCPS/AtomicBool.h
@@ -6,8 +6,6 @@
 
 #include <dds/Versioned_Namespace.h>
 
-#include <ace/config.h>
-
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {

--- a/dds/DCPS/AtomicBool.h
+++ b/dds/DCPS/AtomicBool.h
@@ -1,16 +1,12 @@
 #ifndef OPENDDS_DCPS_ATOMIC_BOOL_H
 #define OPENDDS_DCPS_ATOMIC_BOOL_H
 
+#include "Atomic.h"
 #include "SafeBool_T.h"
 
 #include <dds/Versioned_Namespace.h>
 
 #include <ace/config.h>
-#ifdef ACE_HAS_CPP11
-#  include <atomic>
-#else
-#  include <ace/Atomic_Op.h>
-#endif
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -26,11 +22,7 @@ public:
 
   bool boolean_test() const
   {
-    return impl_
-#ifndef ACE_HAS_CPP11
-      .value()
-#endif
-      ;
+    return impl_;
   }
 
   AtomicBool& operator=(bool value)
@@ -40,12 +32,7 @@ public:
   }
 
 private:
-#ifdef ACE_HAS_CPP11
-  std::atomic<bool>
-#else
-  ACE_Atomic_Op<ACE_Thread_Mutex, bool>
-#endif
-    impl_;
+  Atomic<bool> impl_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/DataBlockLockPool.h
+++ b/dds/DCPS/DataBlockLockPool.h
@@ -8,16 +8,13 @@
 #ifndef OPENDDS_DCPS_DATABLOCKLOCKPOOL_H
 #define OPENDDS_DCPS_DATABLOCKLOCKPOOL_H
 
-#include "ace/Lock_Adapter_T.h"
-#include "ace/Thread_Mutex.h"
-#include "ace/Containers_T.h"
-#ifdef ACE_HAS_CPP11
-#  include <atomic>
-#else
-#  include <ace/Atomic_Op.h>
-#endif
+#include "Atomic.h"
 #include "dcps_export.h"
 #include "PoolAllocationBase.h"
+
+#include <ace/Lock_Adapter_T.h>
+#include <ace/Thread_Mutex.h>
+#include <ace/Containers_T.h>
 
 /**
  * @class DataBlockLockPool
@@ -51,14 +48,10 @@ public:
 private:
   typedef ACE_Array<DataBlockLock> Pool;
 
-  Pool   pool_;
+  Pool pool_;
   const unsigned long size_;
   /// Counter used to track which lock to give out next (modulus size_)
-#ifdef ACE_HAS_CPP11
-  std::atomic<unsigned long> iterator_;
-#else
-  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> iterator_;
-#endif
+  OpenDDS::DCPS::Atomic<unsigned long> iterator_;
 };
 
 #endif /* DATABLOCKLOCKPOOL_H  */

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -6,6 +6,7 @@
 #ifndef OPENDDS_DCPS_DATAWRITERIMPL_H
 #define OPENDDS_DCPS_DATAWRITERIMPL_H
 
+#include "Atomic.h"
 #include "Sample.h"
 #include "DataWriterCallbacks.h"
 #include "transport/framework/TransportSendListener.h"
@@ -422,8 +423,8 @@ public:
   void notify_publication_lost(const ReaderIdSeq& subids);
 
   /// Statistics counter.
-  ACE_Atomic_Op<ACE_Thread_Mutex, int> data_dropped_count_;
-  ACE_Atomic_Op<ACE_Thread_Mutex, int> data_delivered_count_;
+  Atomic<int> data_dropped_count_;
+  Atomic<int> data_delivered_count_;
 
   MessageTracker controlTracker;
 

--- a/dds/DCPS/Dynamic_Cached_Allocator_With_Overflow_T.h
+++ b/dds/DCPS/Dynamic_Cached_Allocator_With_Overflow_T.h
@@ -9,9 +9,9 @@
 #define OPENDDS_DCPS_DYNAMIC_CACHED_ALLOCATOR_WITH_OVERFLOW_T_H
 
 #include "debug.h"
+#include "Atomic.h"
 #include "PoolAllocationBase.h"
 
-#include <ace/Atomic_Op.h>
 #include <ace/Free_List.h>
 #include <ace/Guard_T.h>
 #include <ace/Malloc_Allocator.h>
@@ -65,7 +65,7 @@ public:
          c++) {
       void* placement = begin_ + c * chunk_size_;
 
-      this->free_list_.add(new(placement) ACE_Cached_Mem_Pool_Node<char>);
+      free_list_.add(new(placement) ACE_Cached_Mem_Pool_Node<char>);
     }
   }
 
@@ -89,7 +89,7 @@ public:
 
     // addr() call is really not absolutely necessary because of the way
     // ACE_Cached_Mem_Pool_Node's internal structure arranged.
-    void* rtn = this->free_list_.remove()->addr();
+    void* rtn = free_list_.remove()->addr();
 
     if (0 == rtn) {
       rtn = ACE_Allocator::instance()->malloc(chunk_size_);
@@ -100,29 +100,29 @@ public:
           ACE_DEBUG((LM_DEBUG,
                      "(%P|%t) Dynamic_Cached_Allocator_With_Overflow::malloc %x"
                      " %d heap allocs with %d outstanding\n",
-                     this, this->allocs_from_heap_.value(),
-                     this->allocs_from_heap_.value() - this->frees_to_heap_.value()));
+                     this, allocs_from_heap_.load(),
+                     allocs_from_heap_.load() - frees_to_heap_.load()));
 
         if (DCPS_debug_level >= 6)
-          if (allocs_from_heap_.value() % 500 == 0)
+          if (allocs_from_heap_ % 500 == 0)
             ACE_DEBUG((LM_DEBUG,
                        "(%P|%t) Dynamic_Cached_Allocator_With_Overflow::malloc %@"
                        " %Lu heap allocs with %Lu outstanding\n",
-                       this, this->allocs_from_heap_.value(),
-                       this->allocs_from_heap_.value() - this->frees_to_heap_.value()));
+                       this, allocs_from_heap_.load(),
+                       allocs_from_heap_.load() - frees_to_heap_.load()));
       }
 
     } else {
       allocs_from_pool_++;
 
       if (DCPS_debug_level >= 6)
-        if (allocs_from_pool_.value() % 500 == 0)
+        if (allocs_from_pool_ % 500 == 0)
           ACE_DEBUG((LM_DEBUG,
                      "(%P|%t) Dynamic_Cached_Allocator_With_Overflow::malloc %x"
                      " %d pool allocs %d pool free with %d available\n",
-                     this, this->allocs_from_pool_.value(),
-                     this->frees_to_pool_.value(),
-                     this->available()));
+                     this, allocs_from_pool_.load(),
+                     frees_to_pool_.load(),
+                     available()));
     }
 
     return rtn;
@@ -155,54 +155,54 @@ public:
       ACE_Allocator::instance()->free(tmp);
       frees_to_heap_ ++;
 
-      if (frees_to_heap_.value() > allocs_from_heap_.value()) {
+      if (frees_to_heap_ > allocs_from_heap_) {
         ACE_ERROR((LM_ERROR,
                    "(%P|%t) ERROR: Dynamic_Cached_Allocator_With_Overflow::free %x"
                    " more deletes %d than allocs %d to the heap\n",
                    this,
-                   this->frees_to_heap_.value(),
-                   this->allocs_from_heap_.value()));
+                   frees_to_heap_.load(),
+                   allocs_from_heap_.load()));
       }
 
       if (DCPS_debug_level >= 6) {
-        if (frees_to_heap_.value() % 500 == 0) {
+        if (frees_to_heap_ % 500 == 0) {
           ACE_DEBUG((LM_DEBUG,
                      "(%P|%t) Dynamic_Cached_Allocator_With_Overflow::free %@"
                      " %Lu heap allocs with %Lu outstanding\n",
-                     this, this->allocs_from_heap_.value(),
-                     this->allocs_from_heap_.value() - this->frees_to_heap_.value()));
+                     this, allocs_from_heap_.load(),
+                     allocs_from_heap_.load() - frees_to_heap_.load()));
         }
       }
 
       return;
 
     } else if (ptr != 0) {
-      this->frees_to_pool_ ++;
+      frees_to_pool_ ++;
 
-      if (frees_to_pool_.value() > allocs_from_pool_.value()) {
+      if (frees_to_pool_ > allocs_from_pool_) {
         ACE_ERROR((LM_ERROR,
                    "(%P|%t) ERROR: Dynamic_Cached_Allocator_With_Overflow::free %x"
                    " more deletes %d than allocs %d from the pool\n",
                    this,
-                   this->frees_to_pool_.value(),
-                   this->allocs_from_pool_.value()));
+                   frees_to_pool_.load(),
+                   allocs_from_pool_.load()));
       }
 
-      this->free_list_.add((ACE_Cached_Mem_Pool_Node<char> *) ptr) ;
+      free_list_.add((ACE_Cached_Mem_Pool_Node<char> *) ptr) ;
 
       if (DCPS_debug_level >= 6)
-        if (this->available() % 500 == 0)
+        if (available() % 500 == 0)
           ACE_DEBUG((LM_DEBUG,
                      "(%P|%t) Dynamic_Cached_Allocator_With_Overflow::malloc %x"
                      " %d pool allocs %d pool frees with %d available\n",
-                     this, this->allocs_from_pool_.value(), this->frees_to_pool_.value(),
-                     this->available()));
+                     this, allocs_from_pool_.load(), frees_to_pool_.load(),
+                     available()));
     }
   }
 
   /// Return the number of chunks available in the cache.
   size_t pool_depth() {
-    return this->free_list_.size() ;
+    return free_list_.size() ;
   }
 
   // -- for debug
@@ -214,13 +214,13 @@ public:
   };
 
   /// number of allocations from the heap.
-  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> allocs_from_heap_;
+  Atomic<unsigned long> allocs_from_heap_;
   /// number of allocations from the pool.
-  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> allocs_from_pool_;
+  Atomic<unsigned long> allocs_from_pool_;
   /// number of frees returned to the heap
-  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> frees_to_heap_ ;
+  Atomic<unsigned long> frees_to_heap_ ;
   /// number of frees returned to the pool
-  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> frees_to_pool_;
+  Atomic<unsigned long> frees_to_pool_;
 private:
   /// Remember how we allocate the memory in the first place so
   /// we can clear things up later.

--- a/dds/DCPS/GuardCondition.cpp
+++ b/dds/DCPS/GuardCondition.cpp
@@ -14,7 +14,7 @@ namespace DDS {
 
 CORBA::Boolean GuardCondition::get_trigger_value()
 {
-  return trigger_value_.value();
+  return trigger_value_;
 }
 
 ReturnCode_t GuardCondition::set_trigger_value(CORBA::Boolean value)

--- a/dds/DCPS/GuardCondition.h
+++ b/dds/DCPS/GuardCondition.h
@@ -14,6 +14,7 @@
 #pragma once
 #endif /* ACE_LACKS_PRAGMA_ONCE */
 
+#include "Atomic.h"
 #include "ConditionImpl.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -45,7 +46,7 @@ public:
   static GuardCondition_ptr _narrow(CORBA::Object_ptr obj);
 
 private:
-  ACE_Atomic_Op<ACE_Thread_Mutex, CORBA::Boolean> trigger_value_;
+  OpenDDS::DCPS::Atomic<CORBA::Boolean> trigger_value_;
 };
 
 } // namespace DDS

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h
@@ -8,24 +8,20 @@
 #ifndef OPENDDS_DCPS_INFOREPODISCOVERY_INFOREPODISCOVERY_H
 #define OPENDDS_DCPS_INFOREPODISCOVERY_INFOREPODISCOVERY_H
 
-#include "dds/DCPS/Discovery.h"
-#include "dds/DdsDcpsInfoUtilsC.h"
-#include "dds/DCPS/GuidUtils.h"
 #include "DataReaderRemoteC.h"
-#include "InfoC.h"
-#include "dds/DCPS/transport/framework/TransportConfig_rch.h"
-#include "dds/DCPS/XTypes/TypeObject.h"
-#include "dds/DCPS/TypeSupportImpl.h"
-#include "ace/Task.h"
-
 #include "InfoRepoDiscovery_Export.h"
+#include "InfoC.h"
 
-#include "ace/Thread_Mutex.h"
-#ifdef ACE_HAS_CPP11
-#  include <atomic>
-#else
-#  include <ace/Atomic_Op_T.h>
-#endif /* ACE_HAS_CPP11 */
+#include <dds/DdsDcpsInfoUtilsC.h>
+#include <dds/DCPS/Atomic.h>
+#include <dds/DCPS/Discovery.h>
+#include <dds/DCPS/GuidUtils.h>
+#include <dds/DCPS/transport/framework/TransportConfig_rch.h>
+#include <dds/DCPS/XTypes/TypeObject.h>
+#include <dds/DCPS/TypeSupportImpl.h>
+
+#include <ace/Task.h>
+#include <ace/Thread_Mutex.h>
 
 #include <string>
 
@@ -250,11 +246,7 @@ private:
     void shutdown();
 
     CORBA::ORB_var orb_;
-#ifdef ACE_HAS_CPP11
-    std::atomic<unsigned long> use_count_;
-#else
-    ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> use_count_;
-#endif
+    Atomic<unsigned long> use_count_;
   private:
     OrbRunner(const OrbRunner&);
     OrbRunner& operator=(const OrbRunner&);

--- a/dds/DCPS/InstanceHandle.h
+++ b/dds/DCPS/InstanceHandle.h
@@ -8,16 +8,10 @@
 #ifndef OPENDDS_DCPS_INSTANCEHANDLE_H
 #define OPENDDS_DCPS_INSTANCEHANDLE_H
 
-#ifdef ACE_HAS_CPP11
-#  include <atomic>
-#else
-#  include <ace/Atomic_Op_T.h>
-#  include <ace/Thread_Mutex.h>
-#endif /* ACE_HAS_CPP11 */
-
-#include "dds/DdsDcpsInfrastructureC.h"
-
 #include "dcps_export.h"
+#include "Atomic.h"
+
+#include <dds/DdsDcpsInfrastructureC.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -35,11 +29,7 @@ public:
   DDS::InstanceHandle_t next();
 
 private:
-#ifdef ACE_HAS_CPP11
-  std::atomic<long> sequence_;
-#else
-  ACE_Atomic_Op<ACE_Thread_Mutex, long> sequence_;
-#endif
+  Atomic<long> sequence_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/ReceivedDataElementList.cpp
+++ b/dds/DCPS/ReceivedDataElementList.cpp
@@ -201,11 +201,7 @@ bool
 OpenDDS::DCPS::ReceivedDataElementList::has_zero_copies() const
 {
   for (ReceivedDataElement* item = head_; item != 0; item = item->next_data_sample_) {
-#ifdef ACE_HAS_CPP11
     if (item->zero_copy_cnt_) {
-#else
-    if (item->zero_copy_cnt_.value()) {
-#endif
       return true;
     }
   }

--- a/dds/DCPS/ReceivedDataElementList.h
+++ b/dds/DCPS/ReceivedDataElementList.h
@@ -8,13 +8,7 @@
 #ifndef OPENDDS_DCPS_RECEIVEDDATAELEMENTLIST_H
 #define OPENDDS_DCPS_RECEIVEDDATAELEMENTLIST_H
 
-#ifdef ACE_HAS_CPP11
-#  include <atomic>
-#else
-#  include <ace/Atomic_Op_T.h>
-#endif
-#include "ace/Thread_Mutex.h"
-
+#include "Atomic.h"
 #include "dcps_export.h"
 #include "DataSampleHeader.h"
 #include "Definitions.h"
@@ -23,7 +17,9 @@
 #include "Time_Helper.h"
 #include "unique_ptr.h"
 
-#include "dds/DdsDcpsInfrastructureC.h"
+#include <dds/DdsDcpsInfrastructureC.h>
+
+#include "ace/Thread_Mutex.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -73,23 +69,19 @@ public:
 
   void dec_ref()
   {
-    if (0 == --this->ref_count_) {
+    if (0 == --ref_count_) {
       delete this;
     }
   }
 
   void inc_ref()
   {
-    ++this->ref_count_;
+    ++ref_count_;
   }
 
   long ref_count()
   {
-#ifdef ACE_HAS_CPP11
-    return this->ref_count_;
-#else
-    return this->ref_count_.value();
-#endif
+    return ref_count_;
   }
 
   GUID_t pub_;
@@ -134,11 +126,7 @@ public:
 
   /// This is needed to know if delete DataReader should fail with
   /// PRECONDITION_NOT_MET because there are outstanding loans.
-#ifdef ACE_HAS_CPP11
-  std::atomic<long> zero_copy_cnt_;
-#else
-  ACE_Atomic_Op<ACE_Thread_Mutex, long> zero_copy_cnt_;
-#endif
+  Atomic<long> zero_copy_cnt_;
 
   /// The data sample's sequence number
   SequenceNumber sequence_;
@@ -154,11 +142,7 @@ public:
   void operator delete(void* memory, ACE_New_Allocator& pool);
 
 private:
-#ifdef ACE_HAS_CPP11
-  std::atomic<long> ref_count_;
-#else
-  ACE_Atomic_Op<ACE_Thread_Mutex, long> ref_count_;
-#endif
+  Atomic<long> ref_count_;
 protected:
   ACE_Recursive_Thread_Mutex* mx_;
 }; // class ReceivedDataElement
@@ -182,7 +166,7 @@ public:
   ~ReceivedDataElementWithType() {
     ACE_GUARD(ACE_Recursive_Thread_Mutex,
               guard,
-              *this->mx_)
+              *mx_)
     delete static_cast<DataTypeWithAllocator*> (registered_data_);
   }
 };

--- a/dds/DCPS/TopicDescriptionImpl.h
+++ b/dds/DCPS/TopicDescriptionImpl.h
@@ -8,16 +8,14 @@
 #ifndef OPENDDS_DCPS_TOPIC_DESCRIPTION_IMPL_H
 #define OPENDDS_DCPS_TOPIC_DESCRIPTION_IMPL_H
 
-#include "dds/DdsDcpsTopicC.h"
-#include "dds/DdsDcpsTypeSupportExtC.h"
+#include "Atomic.h"
 #include "Definitions.h"
-#include "ace/SString.h"
-#ifdef ACE_HAS_CPP11
-#  include <atomic>
-#else
-#  include <ace/Atomic_Op.h>
-#endif
 #include "LocalObject.h"
+
+#include <dds/DdsDcpsTopicC.h>
+#include <dds/DdsDcpsTypeSupportExtC.h>
+
+#include <ace/SString.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
 #pragma once
@@ -88,11 +86,7 @@ protected:
   OpenDDS::DCPS::TypeSupport_var type_support_;
 
   /// The number of entities using this topic
-#ifdef ACE_HAS_CPP11
-  std::atomic<uint32_t> entity_refs_;
-#else
-  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> entity_refs_;
-#endif
+  Atomic<uint32_t> entity_refs_;
 };
 
 template <typename Topic>

--- a/dds/DCPS/WriterInfo.h
+++ b/dds/DCPS/WriterInfo.h
@@ -9,23 +9,18 @@
 #ifndef OPENDDS_DCPS_WRITERINFO_H
 #define OPENDDS_DCPS_WRITERINFO_H
 
+#include "Atomic.h"
+#include "CoherentChangeControl.h"
+#include "ConditionVariable.h"
+#include "Definitions.h"
+#include "DisjointSequence.h"
 #include "PoolAllocator.h"
 #include "RcObject.h"
-#include "Definitions.h"
-#include "ConditionVariable.h"
-#include "CoherentChangeControl.h"
-#include "DisjointSequence.h"
 #include "TimeTypes.h"
 #include "transport/framework/ReceivedDataSample.h"
 
 #include <dds/DdsDcpsInfoUtilsC.h>
 #include <dds/DdsDcpsCoreC.h>
-
-#ifdef ACE_HAS_CPP11
-#  include <atomic>
-#else
-#  include <ace/Atomic_Op.h>
-#endif
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 class ACE_Reactor;
@@ -243,11 +238,7 @@ private:
   DDS::InstanceHandle_t handle_;
 
   /// Number of received coherent changes in active change set.
-#ifdef ACE_HAS_CPP11
-  std::atomic<uint32_t> coherent_samples_;
-#else
-  ACE_Atomic_Op<ACE_Thread_Mutex, ACE_UINT32> coherent_samples_;
-#endif
+  Atomic<uint32_t> coherent_samples_;
 
   /// Is this writer evaluated for owner ?
   typedef OPENDDS_MAP(DDS::InstanceHandle_t, bool) OwnerEvaluateFlags;

--- a/dds/DCPS/transport/framework/TransportImpl.cpp
+++ b/dds/DCPS/transport/framework/TransportImpl.cpp
@@ -33,7 +33,6 @@ namespace DCPS {
 TransportImpl::TransportImpl(TransportInst_rch config)
   : config_(config)
   , event_dispatcher_(make_rch<ServiceEventDispatcher>(1))
-  , last_link_(0)
   , is_shut_down_(false)
 {
   DBG_ENTRY_LVL("TransportImpl", "TransportImpl", 6);

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -320,7 +320,6 @@ public:
 
 protected:
   /// Id of the last link established.
-  ACE_Atomic_Op<ACE_Thread_Mutex, size_t> last_link_;
   AtomicBool is_shut_down_;
 };
 

--- a/dds/DCPS/transport/framework/TransportQueueElement.h
+++ b/dds/DCPS/transport/framework/TransportQueueElement.h
@@ -10,17 +10,14 @@
 
 #include "dds/DCPS/dcps_export.h"
 
-#include "dds/DCPS/Cached_Allocator_With_Overflow_T.h"
-#include "dds/DCPS/Definitions.h"
-#include "dds/DCPS/GuidUtils.h"
-#include "dds/DCPS/PoolAllocationBase.h"
-#include "dds/DCPS/SequenceNumber.h"
+#include <dds/DCPS/Atomic.h>
+#include <dds/DCPS/Cached_Allocator_With_Overflow_T.h>
+#include <dds/DCPS/Definitions.h>
+#include <dds/DCPS/GuidUtils.h>
+#include <dds/DCPS/PoolAllocationBase.h>
+#include <dds/DCPS/SequenceNumber.h>
+
 #include <utility>
-#ifdef ACE_HAS_CPP11
-#  include <atomic>
-#else
-#  include <ace/Atomic_Op.h>
-#endif
 
 ACE_BEGIN_VERSIONED_NAMESPACE_DECL
 class ACE_Message_Block;
@@ -206,11 +203,7 @@ private:
   friend class TransportCustomizedElement;
 
   /// Counts the number of outstanding sub-loans.
-#ifdef ACE_HAS_CPP11
-  std::atomic<unsigned long> sub_loan_count_;
-#else
-  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> sub_loan_count_;
-#endif
+  Atomic<unsigned long> sub_loan_count_;
 
   /// Flag flipped to true if any DataLink dropped the sample.
   bool dropped_;

--- a/dds/DCPS/transport/framework/TransportQueueElement.inl
+++ b/dds/DCPS/transport/framework/TransportQueueElement.inl
@@ -48,11 +48,8 @@ TransportQueueElement::decision_made(bool dropped_by_transport)
 {
   DBG_ENTRY_LVL("TransportQueueElement", "decision_made", 6);
 
-#ifdef ACE_HAS_CPP11
   OPENDDS_ASSERT(sub_loan_count_);
-#else
-  OPENDDS_ASSERT(sub_loan_count_.value());
-#endif
+
   const unsigned long new_count = --sub_loan_count_;
   if (new_count == 0) {
     // All interested subscriptions have been satisfied.

--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -139,7 +139,7 @@ TransportSendStrategy::perform_work()
   { // scope for the guard(lock_);
     GuardType guard(lock_);
 
-    VDBG_LVL((LM_DEBUG, "(%P|%t) DBG: perform_work mode: %C\n", mode_as_str(mode_.value())), 5);
+    VDBG_LVL((LM_DEBUG, "(%P|%t) DBG: perform_work mode: %C\n", mode_as_str(mode_)), 5);
 
     if (mode_ == MODE_TERMINATED) {
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
@@ -168,7 +168,7 @@ TransportSendStrategy::perform_work()
     if (mode_ != MODE_QUEUE && mode_ != MODE_SUSPEND) {
       VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                 "Entered perform_work() and mode_ is %C - just return "
-                "WORK_OUTCOME_NO_MORE_TO_DO.\n", mode_as_str(mode_.value())), 5);
+                "WORK_OUTCOME_NO_MORE_TO_DO.\n", mode_as_str(mode_)), 5);
       return WORK_OUTCOME_NO_MORE_TO_DO;
     }
 
@@ -992,7 +992,7 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
       if (mode_ == MODE_QUEUE || mode_ == MODE_SUSPEND) {
         VDBG_LVL((LM_DEBUG, "(%P|%t) DBG:   "
                   "mode_ == %C, so queue elem and leave.\n",
-                  mode_as_str(mode_.value())), 5);
+                  mode_as_str(mode_)), 5);
 
         queue_.put(element);
 
@@ -1273,7 +1273,7 @@ TransportSendStrategy::send_stop(GUID_t /*repoId*/)
       VDBG((LM_DEBUG, "(%P|%t) DBG:   "
             "But since we are in %C, we don't have to do "
             "anything more in this important send_stop().\n",
-            mode_as_str(mode_.value())));
+            mode_as_str(mode_)));
       // We don't do anything if we are in MODE_QUEUE.  Just leave.
       return;
     }
@@ -1520,7 +1520,7 @@ TransportSendStrategy::direct_send(bool do_relink)
                 "Now flip to MODE_SUSPEND before we try to reconnect.\n"), 5);
 
       if (mode_ != MODE_SUSPEND) {
-        mode_before_suspend_ = mode_.value();
+        mode_before_suspend_ = mode_;
         mode_ = MODE_SUSPEND;
       }
 
@@ -1934,7 +1934,7 @@ TransportSendStrategy::add_delayed_notification(TransportQueueElement* element)
     }
   }
 
-  delayed_delivered_notification_queue_.push_back(std::make_pair(element, mode_.value()));
+  delayed_delivered_notification_queue_.push_back(std::make_pair(element, mode_.load()));
 }
 
 void TransportSendStrategy::deliver_ack_request(TransportQueueElement* element)

--- a/dds/DCPS/transport/framework/TransportSendStrategy.h
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.h
@@ -8,21 +8,22 @@
 #ifndef OPENDDS_DCPS_TRANSPORT_FRAMEWORK_TRANSPORTSENDSTRATEGY_H
 #define OPENDDS_DCPS_TRANSPORT_FRAMEWORK_TRANSPORTSENDSTRATEGY_H
 
+#include "BasicQueue_T.h"
+#include "ThreadSynchStrategy_rch.h"
 #include "ThreadSynchWorker.h"
 #include "TransportDefs.h"
-#include "BasicQueue_T.h"
 #include "TransportImpl_rch.h"
 #include "TransportHeader.h"
 #include "TransportReplacedElement.h"
 #include "TransportRetainedElement.h"
-#include "ThreadSynchStrategy_rch.h"
 
 #include <dds/DCPS/dcps_export.h>
-#include <dds/DCPS/Definitions.h>
-#include <dds/DCPS/RcObject.h>
-#include <dds/DCPS/PoolAllocator.h>
+#include "dds/DCPS/Atomic.h"
 #include <dds/DCPS/DataBlockLockPool.h>
+#include <dds/DCPS/Definitions.h>
 #include <dds/DCPS/Dynamic_Cached_Allocator_With_Overflow_T.h>
+#include <dds/DCPS/PoolAllocator.h>
+#include <dds/DCPS/RcObject.h>
 
 #if defined(OPENDDS_SECURITY)
 #include <dds/DdsSecurityCoreC.h>
@@ -386,7 +387,7 @@ private:
   unsigned start_counter_;
 
   /// This mode determines how send() calls will be handled.
-  ACE_Atomic_Op<ACE_Thread_Mutex, SendMode> mode_;
+  Atomic<SendMode> mode_;
 
   /// This mode remembers the mode before send is suspended and is
   /// used after the send is resumed because the connection is

--- a/dds/DCPS/transport/framework/TransportSendStrategy.inl
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.inl
@@ -17,7 +17,7 @@ TransportSendStrategy::SendMode TransportSendStrategy::mode() const
 {
   DBG_ENTRY_LVL("TransportSendStrategy","mode",6);
 
-  return mode_.value();
+  return mode_;
 }
 
 ACE_INLINE
@@ -69,7 +69,7 @@ void TransportSendStrategy::suspend_send()
   GuardType guard(this->lock_);
 
   if (this->mode_ != MODE_TERMINATED && this->mode_ != MODE_SUSPEND) {
-    this->mode_before_suspend_ = this->mode_.value();
+    this->mode_before_suspend_ = this->mode_;
     this->mode_ = MODE_SUSPEND;
   }
 }

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -36,6 +36,7 @@ namespace DCPS {
 TcpTransport::TcpTransport(const TcpInst_rch& inst)
   : TransportImpl(inst)
   , acceptor_(new TcpAcceptor(RcHandle<TcpTransport>(this, inc_count())))
+  , last_link_(0)
 {
   DBG_ENTRY_LVL("TcpTransport","TcpTransport",6);
 
@@ -690,13 +691,13 @@ TcpTransport::connect_tcp_datalink(TcpDataLink& link,
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("(%P|%t) TcpTransport::connect_tcp_datalink() [%d] - ")
                ACE_TEXT("creating send strategy with priority %d.\n"),
-               last_link_.value(), link.transport_priority()));
+               last_link_.load(), link.transport_priority()));
   }
 
-  connection->id() = last_link_.value();
+  connection->id() = last_link_;
 
   TcpSendStrategy_rch send_strategy (
-    make_rch<TcpSendStrategy>(last_link_.value(), ref(link),
+    make_rch<TcpSendStrategy>(last_link_.load(), ref(link),
                              new TcpSynchResource(link,
                                                   cfg->max_output_pause_period_),
                              this->reactor_task(), link.transport_priority()));

--- a/dds/DCPS/transport/tcp/TcpTransport.h
+++ b/dds/DCPS/transport/tcp/TcpTransport.h
@@ -14,6 +14,7 @@
 #include "TcpConnection.h"
 #include "TcpConnection_rch.h"
 
+#include <dds/DCPS/Atomic.h>
 #include <dds/DCPS/ReactorTask_rch.h>
 #include <dds/DCPS/transport/framework/PriorityKey.h>
 #include <dds/DCPS/transport/framework/TransportImpl.h>
@@ -164,6 +165,7 @@ private:
   /// This protects the connections_ and the pending_connections_
   /// data members.
   LockType connections_lock_;
+  Atomic<size_t> last_link_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/unique_ptr.h
+++ b/dds/DCPS/unique_ptr.h
@@ -17,8 +17,7 @@
 #ifdef OPENDDS_HAS_STD_UNIQUE_PTR
 #  include <memory>
 #else
-#  include "ace/Atomic_Op.h"
-#  include "ace/Synch_Traits.h"
+#  include "Atomic.h"
 #  ifdef ACE_HAS_CPP11
 #    include <utility>
 #  else
@@ -175,18 +174,18 @@ public:
   container_supported_unique_ptr(const container_supported_unique_ptr<U>& other)
     : ptr_(other.get())
   {
-    this->bump_up();
+    bump_up();
   }
 
   container_supported_unique_ptr(const container_supported_unique_ptr& b)
     : ptr_(b.ptr_)
   {
-    this->bump_up();
+    bump_up();
   }
 
   ~container_supported_unique_ptr()
   {
-    this->bump_down();
+    bump_down();
   }
 
   template <typename U>
@@ -227,30 +226,30 @@ public:
 
   void swap(container_supported_unique_ptr& rhs)
   {
-    T* t = this->ptr_;
-    this->ptr_ = rhs.ptr_;
+    T* t = ptr_;
+    ptr_ = rhs.ptr_;
     rhs.ptr_ = t;
   }
 
   T* operator->() const
   {
-    return this->ptr_;
+    return ptr_;
   }
 
   T& operator*() const
   {
-    return *this->ptr_;
+    return *ptr_;
   }
 
   T* get() const
   {
-    return this->ptr_;
+    return ptr_;
   }
 
   T* release()
   {
-    T* retval = this->ptr_;
-    this->ptr_ = 0;
+    T* retval = ptr_;
+    ptr_ = 0;
     return retval;
   }
 
@@ -278,16 +277,16 @@ private:
 
   void bump_up()
   {
-    if (this->ptr_ != 0) {
-      this->ptr_->_add_ref();
+    if (ptr_ != 0) {
+      ptr_->_add_ref();
     }
   }
 
   void bump_down()
   {
-    if (this->ptr_ != 0) {
-      this->ptr_->_remove_ref();
-      this->ptr_ = 0;
+    if (ptr_ != 0) {
+      ptr_->_remove_ref();
+      ptr_ = 0;
     }
   }
 
@@ -316,20 +315,20 @@ protected:
   friend typename unique_ptr<U>::rv_reference move(container_supported_unique_ptr<U>& ptr);
 
   void _add_ref() {
-    ++this->ref_count_;
+    ++ref_count_;
   }
 
   void _remove_ref(){
-    const long new_count = --this->ref_count_;
+    const long new_count = --ref_count_;
 
     if (new_count == 0) {
       delete static_cast<T*>(this);
     }
   }
-  long ref_count() const { return ref_count_.value(); }
+  long ref_count() const { return ref_count_; }
 
 private:
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, long> ref_count_;
+  Atomic<long> ref_count_;
 };
 
 template <typename T>

--- a/dds/InfoRepo/DCPS_IR_Domain.cpp
+++ b/dds/InfoRepo/DCPS_IR_Domain.cpp
@@ -857,7 +857,7 @@ int DCPS_IR_Domain::init_built_in_topics_transport(bool persistent)
 int DCPS_IR_Domain::cleanup_built_in_topics()
 {
 #ifndef DDS_HAS_MINIMUM_BIT
-  if (useBIT_.value() && bitParticipant_) {
+  if (useBIT_ && bitParticipant_) {
     useBIT_ = false;
     using OpenDDS::DCPS::retcode_to_string;
 
@@ -1024,7 +1024,7 @@ void DCPS_IR_Domain::publish_participant_bit(DCPS_IR_Participant* participant)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_.value() && !participant->isBitPublisher()) {
+  if (useBIT_ && !participant->isBitPublisher()) {
     try {
       const DDS::DomainParticipantQos* participantQos = participant->get_qos();
 
@@ -1059,7 +1059,7 @@ void DCPS_IR_Domain::publish_topic_bit(DCPS_IR_Topic* topic)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_.value()) {
+  if (useBIT_) {
     DCPS_IR_Topic_Description* desc =
       topic->get_topic_description();
     const char* name = desc->get_name();
@@ -1120,7 +1120,7 @@ void DCPS_IR_Domain::publish_subscription_bit(DCPS_IR_Subscription* subscription
 
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_.value()) {
+  if (useBIT_) {
     DCPS_IR_Topic_Description* desc =
       subscription->get_topic_description();
     const char* name = desc->get_name();
@@ -1187,7 +1187,7 @@ void DCPS_IR_Domain::publish_publication_bit(DCPS_IR_Publication* publication)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_.value()) {
+  if (useBIT_) {
 
     DCPS_IR_Topic_Description* desc =
       publication->get_topic_description();
@@ -1267,7 +1267,7 @@ void DCPS_IR_Domain::dispose_participant_bit(DCPS_IR_Participant* participant)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_.value()) {
+  if (useBIT_) {
     if (!participant->isBitPublisher()) {
       try {
         DDS::ParticipantBuiltinTopicData key_data;
@@ -1315,7 +1315,7 @@ void DCPS_IR_Domain::dispose_topic_bit(DCPS_IR_Topic* topic)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_.value()) {
+  if (useBIT_) {
     if (!topic->is_bit()) {
       try {
         DDS::TopicBuiltinTopicData key_data;
@@ -1365,7 +1365,7 @@ void DCPS_IR_Domain::dispose_subscription_bit(DCPS_IR_Subscription* subscription
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_.value()) {
+  if (useBIT_) {
     if (!subscription->is_bit()) {
       try {
         DDS::SubscriptionBuiltinTopicData key_data;
@@ -1415,7 +1415,7 @@ void DCPS_IR_Domain::dispose_publication_bit(DCPS_IR_Publication* publication)
 {
 #if !defined (DDS_HAS_MINIMUM_BIT)
 
-  if (useBIT_.value()) {
+  if (useBIT_) {
     if (!publication->is_bit()) {
       try {
         DDS::PublicationBuiltinTopicData key_data;
@@ -1477,7 +1477,7 @@ std::string DCPS_IR_Domain::dump_to_string(const std::string& prefix, int depth)
   std::ostringstream os;
   os << "DCPS_IR_Domain[" << id_ << "]";
   str += os.str();
-  if (useBIT_.value())
+  if (useBIT_)
     str += " BITS";
   str += "\n";
 

--- a/dds/InfoRepo/DCPS_IR_Domain.h
+++ b/dds/InfoRepo/DCPS_IR_Domain.h
@@ -9,22 +9,22 @@
 #define DCPS_IR_DOMAIN_H
 
 #include  "inforepo_export.h"
-#include /**/ "dds/DdsDcpsInfrastructureC.h"
-#include /**/ "dds/DCPS/InfoRepoDiscovery/InfoS.h"
 
-#include "dds/DCPS/RepoIdGenerator.h"
-
-#include /**/ "dds/DdsDcpsDomainC.h"
-#include /**/ "dds/DdsDcpsInfoUtilsC.h"
+#include <dds/DdsDcpsInfrastructureC.h>
+#include <dds/DdsDcpsDomainC.h>
+#include <dds/DdsDcpsInfoUtilsC.h>
+#include <dds/DCPS/InfoRepoDiscovery/InfoS.h>
+#include <dds/DCPS/AtomicBool.h>
+#include <dds/DCPS/RepoIdGenerator.h>
+#include <dds/DCPS/transport/framework/TransportConfig.h>
+#include <dds/DCPS/transport/tcp/TcpTransport.h>
+#include <dds/DCPS/transport/framework/TransportConfig_rch.h>
 
 #if !defined (DDS_HAS_MINIMUM_BIT)
-#include /**/ "dds/DdsDcpsCoreTypeSupportImpl.h"
+#include <dds/DdsDcpsCoreTypeSupportImpl.h>
 #endif // !defined (DDS_HAS_MINIMUM_BIT)
 
-#include "dds/DCPS/transport/framework/TransportConfig.h"
-#include "dds/DCPS/transport/tcp/TcpTransport.h"
-#include "dds/DCPS/transport/framework/TransportConfig_rch.h"
-#include /**/ "ace/Unbounded_Set.h"
+#include <ace/Unbounded_Set.h>
 
 #include <set>
 #include <map>
@@ -175,7 +175,7 @@ public:
 
   std::string dump_to_string(const std::string& prefix, int depth) const;
 
-  bool useBIT() const { return useBIT_.value(); }
+  bool useBIT() const { return useBIT_; }
 
 private:
   OpenDDS::DCPS::TopicStatus add_topic_i(OpenDDS::DCPS::GUID_t& topicId,
@@ -239,7 +239,7 @@ private:
   IdToTopicMap idToTopicMap_;
 
   /// indicates if the BuiltIn Topics are enabled
-  ACE_Atomic_Op<ACE_Thread_Mutex, bool> useBIT_;
+  OpenDDS::DCPS::AtomicBool useBIT_;
 
   ///@{
   /// Built-in Topic variables

--- a/examples/DCPS/Messenger_IOGR_Imr/Writer.cpp
+++ b/examples/DCPS/Messenger_IOGR_Imr/Writer.cpp
@@ -119,5 +119,5 @@ Writer::is_finished () const
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }

--- a/examples/DCPS/Messenger_IOGR_Imr/Writer.h
+++ b/examples/DCPS/Messenger_IOGR_Imr/Writer.h
@@ -4,6 +4,8 @@
 #define WRITER_H
 
 #include <dds/DdsDcpsPublicationC.h>
+#include <dds/DCPS/Atomic.h>
+
 #include <ace/Task.h>
 
 class Writer : public ACE_Task_Base
@@ -24,8 +26,8 @@ public:
 
 private:
   ::DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  ::OpenDDS::DCPS::Atomic<int> finished_instances_;
+  ::OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/examples/DCPS/Messenger_Imr/Writer.cpp
+++ b/examples/DCPS/Messenger_Imr/Writer.cpp
@@ -119,5 +119,5 @@ Writer::is_finished () const
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }

--- a/examples/DCPS/Messenger_Imr/Writer.h
+++ b/examples/DCPS/Messenger_Imr/Writer.h
@@ -4,8 +4,9 @@
 #define WRITER_H
 
 #include <dds/DdsDcpsPublicationC.h>
-#include <ace/Task.h>
+#include <dds/DCPS/Atomic.h>
 
+#include <ace/Task.h>
 
 class Writer : public ACE_Task_Base
 {
@@ -27,8 +28,8 @@ public:
 private:
 
   ::DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  ::OpenDDS::DCPS::Atomic<int> finished_instances_;
+  ::OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/performance-tests/DCPS/InfoRepo_population/Writer.cpp
+++ b/performance-tests/DCPS/InfoRepo_population/Writer.cpp
@@ -117,5 +117,5 @@ Writer::is_finished () const
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }

--- a/performance-tests/DCPS/InfoRepo_population/Writer.h
+++ b/performance-tests/DCPS/InfoRepo_population/Writer.h
@@ -4,8 +4,9 @@
 #define WRITER_H
 
 #include <dds/DdsDcpsPublicationC.h>
-#include <ace/Task.h>
+#include <dds/DCPS/Atomic.h>
 
+#include <ace/Task.h>
 
 class Writer : public ACE_Task_Base
 {
@@ -28,8 +29,8 @@ public:
 private:
 
   ::DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  ::OpenDDS::DCPS::Atomic<int> finished_instances_;
+  ::OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/BuiltInTopicTest/Writer.cpp
+++ b/tests/DCPS/BuiltInTopicTest/Writer.cpp
@@ -2,7 +2,8 @@
 //
 #include "Writer.h"
 #include "MessengerTypeSupportC.h"
-#include "tests/Utils/ExceptionStreams.h"
+
+#include <tests/Utils/ExceptionStreams.h>
 
 #include <ace/OS_NS_unistd.h>
 #include <ace/streams.h>
@@ -120,5 +121,5 @@ Writer::is_finished() const
 int
 Writer::get_timeout_writes() const
 {
-  return timeout_writes_.value();
+  return timeout_writes_;
 }

--- a/tests/DCPS/BuiltInTopicTest/Writer.h
+++ b/tests/DCPS/BuiltInTopicTest/Writer.h
@@ -4,6 +4,7 @@
 #define WRITER_H
 
 #include <dds/DdsDcpsPublicationC.h>
+#include <dds/DCPS/Atomic.h>
 
 #include <ace/Task.h>
 
@@ -24,8 +25,8 @@ public:
 
 private:
   ::DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/CorbaSeq/Writer.cpp
+++ b/tests/DCPS/CorbaSeq/Writer.cpp
@@ -163,5 +163,5 @@ Writer::is_finished() const
 int
 Writer::get_timeout_writes() const
 {
-  return timeout_writes_.value();
+  return timeout_writes_;
 }

--- a/tests/DCPS/CorbaSeq/Writer.h
+++ b/tests/DCPS/CorbaSeq/Writer.h
@@ -4,8 +4,9 @@
 #define WRITER_H
 
 #include <dds/DdsDcpsPublicationC.h>
-#include <ace/Task.h>
+#include <dds/DCPS/Atomic.h>
 
+#include <ace/Task.h>
 
 class Writer : public ACE_Task_Base
 {
@@ -28,8 +29,8 @@ public:
 private:
 
   ::DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/DPFactoryQos/Writer.h
+++ b/tests/DCPS/DPFactoryQos/Writer.h
@@ -4,8 +4,9 @@
 #define WRITER_H
 
 #include <dds/DdsDcpsPublicationC.h>
-#include <ace/Task.h>
+#include <dds/DCPS/Atomic.h>
 
+#include <ace/Task.h>
 
 class Writer : public ACE_Task_Base
 {
@@ -26,7 +27,7 @@ public:
 private:
 
   ::DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/FooTest3_2/Writer.cpp
+++ b/tests/DCPS/FooTest3_2/Writer.cpp
@@ -12,7 +12,7 @@
 #include "tests/DCPS/common/TestSupport.h"
 
 const int default_key = 101010;
-ACE_Atomic_Op<ACE_SYNCH_MUTEX, CORBA::Long> key(0);
+OpenDDS::DCPS::Atomic<CORBA::Long> key(0);
 
 Writer::Writer(PubDriver* /*pubdriver*/,
                ::DDS::DataWriter_ptr writer,
@@ -149,7 +149,7 @@ Writer::svc ()
 
   if (check_data_dropped_ == 1 && writer_servant_->data_dropped_count_ > 0)
   {
-    while (writer_servant_->data_delivered_count_.value() + writer_servant_->data_dropped_count_.value()
+    while (writer_servant_->data_delivered_count_ + writer_servant_->data_dropped_count_
     < num_writes_per_thread_ * num_thread_to_write_)
     {
       ACE_OS::sleep (1);
@@ -157,7 +157,7 @@ Writer::svc ()
 
     ACE_DEBUG((LM_DEBUG,
       ACE_TEXT("(%P|%t) Writer::svc data_delivered_count=%d data_dropped_count=%d\n"),
-      writer_servant_->data_delivered_count_.value(), writer_servant_->data_dropped_count_.value()));
+      writer_servant_->data_delivered_count_.load(), writer_servant_->data_dropped_count_.load()));
   }
 
   while (true) {

--- a/tests/DCPS/FooTest5/DataReaderListener.cpp
+++ b/tests/DCPS/FooTest5/DataReaderListener.cpp
@@ -34,7 +34,7 @@ int read (::DDS::DataReader_ptr reader)
         num_reads++;
         ACE_DEBUG((LM_DEBUG,
           ACE_TEXT("(%P|%t) reader %X take foo.x = %f foo.y = %f, foo.data_source = %d, count = %d\n"),
-          reader, foo.x, foo.y, foo.data_source, num_reads.value()));
+          reader, foo.x, foo.y, foo.data_source, num_reads.load()));
         ACE_DEBUG((LM_DEBUG,
           ACE_TEXT("(%P|%t) SampleInfo.sample_rank = %d\n"), si.sample_rank));
 

--- a/tests/DCPS/FooTest5/Writer.cpp
+++ b/tests/DCPS/FooTest5/Writer.cpp
@@ -9,12 +9,12 @@
 #include "ace/Atomic_Op_T.h"
 #include "ace/OS_NS_unistd.h"
 
-ACE_Atomic_Op<ACE_SYNCH_MUTEX, CORBA::Long> key(0);
+OpenDDS::DCPS::Atomic<CORBA::Long> key(0);
 
 
 template<class DT, class DW, class DW_var>
 ::DDS::ReturnCode_t write (int writer_id,
-                           ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> & timeout_writes,
+                           OpenDDS::DCPS::Atomic<int> & timeout_writes,
                            ::DDS::DataWriter_ptr writer)
 {
 
@@ -174,5 +174,5 @@ Writer::is_finished () const
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }

--- a/tests/DCPS/FooTest5/Writer.h
+++ b/tests/DCPS/FooTest5/Writer.h
@@ -3,9 +3,10 @@
 #ifndef WRITER_H
 #define WRITER_H
 
-#include "dds/DdsDcpsPublicationC.h"
-#include "ace/Task.h"
+#include <dds/DdsDcpsPublicationC.h>
+#include <dds/DCPS/Atomic.h>
 
+#include <ace/Task.h>
 
 class Writer : public ACE_Task_Base
 {
@@ -32,8 +33,8 @@ private:
 
   ::DDS::DataWriter_var writer_;
   long writer_id_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/FooTest5/common.cpp
+++ b/tests/DCPS/FooTest5/common.cpp
@@ -33,7 +33,7 @@ int using_shmem = 0;
 int sequence_length = 10;
 int no_key = 0;
 InstanceDataMap results;
-ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> num_reads = 0;
+OpenDDS::DCPS::Atomic<int> num_reads(0);
 long op_interval_ms = 0;
 long blocking_ms = 0;
 int mixed_trans = 0;

--- a/tests/DCPS/FooTest5/common.h
+++ b/tests/DCPS/FooTest5/common.h
@@ -3,11 +3,15 @@
 #ifndef COMMON_H
 #define COMMON_H
 
-#include  "InstanceDataMap.h"
-#include  "ace/Time_Value.h"
-#include  "ace/SString.h"
-#include  "ace/Atomic_Op.h"
-#include  <string>
+#include "InstanceDataMap.h"
+
+#include <dds/DCPS/Atomic.h>
+
+#include <ace/Time_Value.h>
+#include <ace/SString.h>
+#include <ace/Atomic_Op.h>
+
+#include <string>
 
 const long  MY_DOMAIN = 111;
 extern const char* MY_TOPIC;
@@ -32,7 +36,7 @@ extern int using_shmem;
 extern int sequence_length;
 extern int no_key;
 extern InstanceDataMap results;
-extern ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> num_reads;
+extern OpenDDS::DCPS::Atomic<int> num_reads;
 extern long op_interval_ms;
 extern long blocking_ms;
 extern int mixed_trans;

--- a/tests/DCPS/FooTest5/subscriber.cpp
+++ b/tests/DCPS/FooTest5/subscriber.cpp
@@ -528,7 +528,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
                 ACE_DEBUG((LM_DEBUG,
                            ACE_TEXT ("(%P|%t) received %d of expected %d\n"),
-                           num_reads.value(), expected));
+                           num_reads.load(), expected));
 
             }
           ACE_OS::sleep (1);

--- a/tests/DCPS/GroupPresentation/Writer.cpp
+++ b/tests/DCPS/GroupPresentation/Writer.cpp
@@ -17,7 +17,7 @@
 
 const int num_instances_per_writer = 1;
 extern int num_messages;
-static ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> count;
+static OpenDDS::DCPS::Atomic<int> count;
 
 
 Writer::Writer(DDS::Publisher_ptr publisher, DDS::DataWriter_ptr writer)
@@ -155,13 +155,12 @@ Writer::is_finished() const
 int
 Writer::get_timeout_writes() const
 {
-  return timeout_writes_.value();
+  return timeout_writes_;
 }
 
 
 int
 Writer::next_count()
 {
-  ++ count;
-  return count.value();
+  return ++count;
 }

--- a/tests/DCPS/GroupPresentation/Writer.h
+++ b/tests/DCPS/GroupPresentation/Writer.h
@@ -32,8 +32,8 @@ public:
 private:
   DDS::Publisher_var publisher_;
   DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/Instances/PubDriver.h
+++ b/tests/DCPS/Instances/PubDriver.h
@@ -20,7 +20,7 @@
 #include <sstream>
 
 const int default_key = 101010;
-ACE_Atomic_Op<ACE_SYNCH_MUTEX, CORBA::Long> key(0);
+OpenDDS::DCPS::Atomic<CORBA::Long> key(0);
 
 template<typename MessageType>
 class Writer : public ACE_Task_Base
@@ -169,8 +169,8 @@ public:
     if (check_data_dropped_ == 1 && writer_servant_->data_dropped_count_ > 0)
     {
 
-      while ( writer_servant_->data_delivered_count_.value() +
-              writer_servant_->data_dropped_count_.value()  <
+      while ( writer_servant_->data_delivered_count_ +
+              writer_servant_->data_dropped_count_  <
               num_writes_per_thread_ *
               num_thread_to_write_ )
       {
@@ -180,8 +180,8 @@ public:
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Writer::svc data_delivered_count=%d ")
                  ACE_TEXT("data_dropped_count=%d\n"),
-                 writer_servant_->data_delivered_count_.value(),
-                 writer_servant_->data_dropped_count_.value()));
+                 writer_servant_->data_delivered_count_.load(),
+                 writer_servant_->data_dropped_count_.load()));
     }
 
     finished_ = true;

--- a/tests/DCPS/LargeSample/Writer.cpp
+++ b/tests/DCPS/LargeSample/Writer.cpp
@@ -122,5 +122,5 @@ void Writer::write(bool reliable, int num_messages, unsigned data_field_length_o
 int
 Writer::get_timeout_writes() const
 {
-  return timeout_writes_.value();
+  return timeout_writes_;
 }

--- a/tests/DCPS/LargeSample/Writer.h
+++ b/tests/DCPS/LargeSample/Writer.h
@@ -28,7 +28,7 @@ public:
 
 private:
   DataWriters& datawriters_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
   const int my_pid_;
 };
 

--- a/tests/DCPS/LatencyBudget/Writer.cpp
+++ b/tests/DCPS/LatencyBudget/Writer.cpp
@@ -137,7 +137,7 @@ Writer::is_finished () const
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }
 
 int

--- a/tests/DCPS/LatencyBudget/Writer.h
+++ b/tests/DCPS/LatencyBudget/Writer.h
@@ -35,8 +35,8 @@ private:
 
   ::DDS::DataWriter_var writer_;
   ACE_Time_Value offset_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 
   // The lock used to synchronize the two write threads.
   ACE_Thread_Mutex lock_;

--- a/tests/DCPS/Lifespan/Writer.cpp
+++ b/tests/DCPS/Lifespan/Writer.cpp
@@ -126,7 +126,7 @@ Writer::is_finished () const
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }
 
 int

--- a/tests/DCPS/Lifespan/Writer.h
+++ b/tests/DCPS/Lifespan/Writer.h
@@ -35,8 +35,8 @@ private:
             int num_messages);
 
   ::DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 
   // The lock used to synchronize the two write threads.
   ACE_Thread_Mutex lock_;

--- a/tests/DCPS/ManualAssertLiveliness/DataWriterListenerImpl.cpp
+++ b/tests/DCPS/ManualAssertLiveliness/DataWriterListenerImpl.cpp
@@ -16,7 +16,7 @@ void DataWriterListenerImpl::on_liveliness_lost(::DDS::DataWriter_ptr writer,
   ++num_liveliness_lost_callbacks_;
   ACE_DEBUG((LM_INFO,
               ACE_TEXT("(%P|%t) DataWriterListenerImpl::on_liveliness_lost %@ %d\n"),
-              writer, (int) num_liveliness_lost_callbacks_.value()));
+              writer, (int) num_liveliness_lost_callbacks_.load()));
   ACE_DEBUG((LM_INFO,
               ACE_TEXT("(%P|%t)    total_count=%d total_count_change=%d\n"),
               status.total_count, status.total_count_change));

--- a/tests/DCPS/ManualAssertLiveliness/DataWriterListenerImpl.h
+++ b/tests/DCPS/ManualAssertLiveliness/DataWriterListenerImpl.h
@@ -56,7 +56,7 @@ public:
 
   unsigned long num_liveliness_lost_callbacks() const
   {
-    return num_liveliness_lost_callbacks_.value();
+    return num_liveliness_lost_callbacks_;
   }
 
   void reset_liveliness_lost_callbacks()
@@ -65,7 +65,7 @@ public:
   }
 
 private:
-  ACE_Atomic_Op<ACE_Thread_Mutex, unsigned long> num_liveliness_lost_callbacks_;
+  OpenDDS::DCPS::Atomic<unsigned long> num_liveliness_lost_callbacks_;
 };
 
 #endif /* DATAWRITER_LISTENER_IMPL  */

--- a/tests/DCPS/ManyTopicMultiProcess/Writer.cpp
+++ b/tests/DCPS/ManyTopicMultiProcess/Writer.cpp
@@ -15,7 +15,7 @@
 
 #include "ace/OS_NS_unistd.h"
 
-ACE_Atomic_Op<ACE_SYNCH_MUTEX, CORBA::Long> key(0);
+OpenDDS::DCPS::Atomic<CORBA::Long> key(0);
 
 Writer::Writer(::DDS::DataWriter_ptr writer,
                int num_thread_to_write,

--- a/tests/DCPS/ManyTopicTest/publisher.cpp
+++ b/tests/DCPS/ManyTopicTest/publisher.cpp
@@ -134,7 +134,7 @@ create_writer(const DDS::Publisher_var& pub, const char* topicName,
   return OpenDDS::DCPS::DDSTraits<MessageType>::DataWriterType::_narrow(dw);
 }
 
-ACE_Atomic_Op<ACE_SYNCH_MUTEX, CORBA::Long> key(0);
+OpenDDS::DCPS::Atomic<CORBA::Long> key(0);
 
 void t1_init(T1::Foo1& foo, int)
 {

--- a/tests/DCPS/Monitor/Writer.cpp
+++ b/tests/DCPS/Monitor/Writer.cpp
@@ -146,5 +146,5 @@ Writer::is_finished() const
 int
 Writer::get_timeout_writes() const
 {
-  return timeout_writes_.value();
+  return timeout_writes_;
 }

--- a/tests/DCPS/Monitor/Writer.h
+++ b/tests/DCPS/Monitor/Writer.h
@@ -29,8 +29,8 @@ public:
 
 private:
   DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/MultiDPTest/Writer.cpp
+++ b/tests/DCPS/MultiDPTest/Writer.cpp
@@ -13,11 +13,11 @@
 #include <ace/Atomic_Op_T.h>
 #include <ace/OS_NS_unistd.h>
 
-ACE_Atomic_Op<ACE_SYNCH_MUTEX, CORBA::Long> key(0);
+OpenDDS::DCPS::Atomic<CORBA::Long> key(0);
 
 template<class DT, class DW, class DW_var>
 DDS::ReturnCode_t write(int writer_id,
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int>& timeout_writes,
+  OpenDDS::DCPS::Atomic<int>& timeout_writes,
   DDS::DataWriter_ptr writer)
 {
   try {
@@ -110,5 +110,5 @@ bool Writer::is_finished() const
 
 int Writer::get_timeout_writes() const
 {
-  return timeout_writes_.value();
+  return timeout_writes_;
 }

--- a/tests/DCPS/MultiDPTest/Writer.h
+++ b/tests/DCPS/MultiDPTest/Writer.h
@@ -4,6 +4,7 @@
 #define WRITER_H
 
 #include <dds/DdsDcpsPublicationC.h>
+#include <dds/DCPS/Atomic.h>
 
 #include <ace/Task.h>
 
@@ -27,8 +28,8 @@ public:
 private:
   ::DDS::DataWriter_var writer_;
   long writer_id_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/MultiDPTest/common.cpp
+++ b/tests/DCPS/MultiDPTest/common.cpp
@@ -10,7 +10,7 @@ int num_datawriters = 2;
 int num_instances_per_writer = 1;
 int num_samples_per_instance = 1;
 const char* topic_name[2]  = { "foo1", "foo2" };
-ACE_Atomic_Op<ACE_Thread_Mutex, int> num_reads = 0;
+OpenDDS::DCPS::Atomic<int> num_reads(0);
 
 ACE_TString synch_file_dir;
 // These files need to be unlinked in the run test script before and

--- a/tests/DCPS/MultiDPTest/common.h
+++ b/tests/DCPS/MultiDPTest/common.h
@@ -3,8 +3,9 @@
 #ifndef COMMON_H
 #define COMMON_H
 
+#include <dds/DCPS/Atomic.h>
+
 #include <ace/SString.h>
-#include <ace/Atomic_Op.h>
 
 const long domain_id = 111;
 extern const char* type_name;
@@ -12,7 +13,7 @@ extern int num_datawriters;
 extern int num_instances_per_writer;
 extern int num_samples_per_instance;
 extern const char* topic_name[2];
-extern ACE_Atomic_Op<ACE_Thread_Mutex, int> num_reads;
+extern OpenDDS::DCPS::Atomic<int> num_reads;
 
 extern ACE_TString synch_file_dir;
 // This file need to be unlinked in the run test script before and

--- a/tests/DCPS/NotifyTest/Writer.cpp
+++ b/tests/DCPS/NotifyTest/Writer.cpp
@@ -134,5 +134,5 @@ Writer::is_finished () const
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }

--- a/tests/DCPS/NotifyTest/Writer.h
+++ b/tests/DCPS/NotifyTest/Writer.h
@@ -4,8 +4,9 @@
 #define WRITER_H
 
 #include <dds/DdsDcpsPublicationC.h>
-#include <ace/Task.h>
+#include <dds/DCPS/Atomic.h>
 
+#include <ace/Task.h>
 
 class Writer : public ACE_Task_Base
 {
@@ -28,8 +29,8 @@ public:
 private:
 
   ::DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/Ownership/Writer.cpp
+++ b/tests/DCPS/Ownership/Writer.cpp
@@ -200,5 +200,5 @@ Writer::wait_for_acks()
 int
 Writer::get_timeout_writes() const
 {
-  return timeout_writes_.value();
+  return timeout_writes_;
 }

--- a/tests/DCPS/Ownership/Writer.h
+++ b/tests/DCPS/Ownership/Writer.h
@@ -32,8 +32,8 @@ public:
 private:
   DDS::DataWriter_var writer_;
   ACE_CString ownership_dw_id_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/Partition/DataReaderListener.cpp
+++ b/tests/DCPS/Partition/DataReaderListener.cpp
@@ -19,7 +19,7 @@ Test::DataReaderListener::DataReaderListener (long expected_matches)
 
 Test::DataReaderListener::~DataReaderListener ()
 {
-  long const matches = this->subscription_matches_.value ();
+  long const matches = this->subscription_matches_;
   if (matches != this->expected_matches_)
     {
       ACE_ERROR ((LM_ERROR,

--- a/tests/DCPS/Partition/DataReaderListener.h
+++ b/tests/DCPS/Partition/DataReaderListener.h
@@ -75,7 +75,7 @@ namespace Test
     long const expected_matches_;
 
     /// The actual number of subscription matches.
-    ACE_Atomic_Op<ACE_Thread_Mutex, long> subscription_matches_;
+    OpenDDS::DCPS::Atomic<long> subscription_matches_;
 
   };
 }

--- a/tests/DCPS/Partition/DataWriterListener.cpp
+++ b/tests/DCPS/Partition/DataWriterListener.cpp
@@ -10,7 +10,7 @@ Test::DataWriterListener::DataWriterListener (long expected_matches)
 
 Test::DataWriterListener::~DataWriterListener ()
 {
-  long const matches = this->publication_matches_.value ();
+  long const matches = this->publication_matches_;
   if (matches != this->expected_matches_)
     {
       ACE_ERROR ((LM_ERROR,

--- a/tests/DCPS/Partition/DataWriterListener.h
+++ b/tests/DCPS/Partition/DataWriterListener.h
@@ -64,7 +64,7 @@ namespace Test
     long const expected_matches_;
 
     /// The actual number of publication matches.
-    ACE_Atomic_Op<ACE_Thread_Mutex, long> publication_matches_;
+    OpenDDS::DCPS::Atomic<long> publication_matches_;
 
   };
 

--- a/tests/DCPS/PersistentDurability/DataWriterListenerImpl.h
+++ b/tests/DCPS/PersistentDurability/DataWriterListenerImpl.h
@@ -50,7 +50,7 @@ public:
 
   virtual ~DataWriterListenerImpl (void);
 
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, bool> publication_matched_;
+  OpenDDS::DCPS::Atomic<bool> publication_matched_;
 
 };
 

--- a/tests/DCPS/PersistentDurability/Writer.cpp
+++ b/tests/DCPS/PersistentDurability/Writer.cpp
@@ -108,7 +108,7 @@ Writer::end ()
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }
 
 int

--- a/tests/DCPS/PersistentDurability/Writer.h
+++ b/tests/DCPS/PersistentDurability/Writer.h
@@ -31,7 +31,7 @@ private:
 
   ::DDS::DataWriter_var writer_;
 
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 
   // The lock used to synchronize the two write threads.
   ACE_Thread_Mutex lock_;

--- a/tests/DCPS/PersistentDurability/publisher.cpp
+++ b/tests/DCPS/PersistentDurability/publisher.cpp
@@ -185,7 +185,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[])
           int attempts;
           for (attempts = 1;
                attempts != max_attempts
-                 && listener->publication_matched_.value () == false;
+                 && listener->publication_matched_;
                ++attempts)
           {
             ACE_OS::sleep (5);

--- a/tests/DCPS/Prst_delayed_subscriber/Writer.cpp
+++ b/tests/DCPS/Prst_delayed_subscriber/Writer.cpp
@@ -135,5 +135,5 @@ Writer::is_finished () const
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }

--- a/tests/DCPS/Prst_delayed_subscriber/Writer.h
+++ b/tests/DCPS/Prst_delayed_subscriber/Writer.h
@@ -4,8 +4,9 @@
 #define WRITER_H
 
 #include <dds/DdsDcpsPublicationC.h>
-#include <ace/Task.h>
+#include <dds/DCPS/Atomic.h>
 
+#include <ace/Task.h>
 
 class Writer : public ACE_Task_Base
 {
@@ -29,8 +30,8 @@ public:
 private:
 
   ::DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 
   size_t msg_cnt_;
   size_t sub_cnt_;

--- a/tests/DCPS/Reconnect/Writer.cpp
+++ b/tests/DCPS/Reconnect/Writer.cpp
@@ -125,5 +125,5 @@ Writer::is_finished () const
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }

--- a/tests/DCPS/Reconnect/Writer.h
+++ b/tests/DCPS/Reconnect/Writer.h
@@ -4,8 +4,9 @@
 #define WRITER_H
 
 #include <dds/DdsDcpsPublicationC.h>
-#include <ace/Task.h>
+#include <dds/DCPS/Atomic.h>
 
+#include <ace/Task.h>
 
 class Writer : public ACE_Task_Base
 {
@@ -28,8 +29,8 @@ public:
 private:
 
   ::DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/RtpsRelay/Smoke/Writer.h
+++ b/tests/DCPS/RtpsRelay/Smoke/Writer.h
@@ -27,7 +27,7 @@ public:
 
 private:
   DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
   size_t count_;
   bool delay_;
 };

--- a/tests/DCPS/SampleLost/DataWriterListenerImpl.cpp
+++ b/tests/DCPS/SampleLost/DataWriterListenerImpl.cpp
@@ -3,7 +3,7 @@
 #include "dds/DdsDcpsPublicationC.h"
 
 DataWriterListenerImpl::DataWriterListenerImpl (
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, bool> & publication_matched)
+  OpenDDS::DCPS::Atomic<bool> & publication_matched)
   : publication_matched_ (publication_matched)
 {
 }

--- a/tests/DCPS/SampleLost/DataWriterListenerImpl.h
+++ b/tests/DCPS/SampleLost/DataWriterListenerImpl.h
@@ -19,7 +19,7 @@ class DataWriterListenerImpl
 public:
 
   DataWriterListenerImpl (
-    ACE_Atomic_Op<ACE_SYNCH_MUTEX, bool> & publication_matched);
+    OpenDDS::DCPS::Atomic<bool> & publication_matched);
 
   virtual void on_offered_deadline_missed (
       ::DDS::DataWriter_ptr writer,
@@ -55,7 +55,7 @@ protected:
 
 private:
 
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, bool> & publication_matched_;
+  OpenDDS::DCPS::Atomic<bool> & publication_matched_;
 
 };
 

--- a/tests/DCPS/SampleLost/Writer.cpp
+++ b/tests/DCPS/SampleLost/Writer.cpp
@@ -100,7 +100,7 @@ Writer::end ()
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }
 
 int

--- a/tests/DCPS/SampleLost/Writer.h
+++ b/tests/DCPS/SampleLost/Writer.h
@@ -29,7 +29,7 @@ private:
 
   ::DDS::DataWriter_var writer_;
 
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 
   // The lock used to synchronize the two write threads.
   ACE_Thread_Mutex lock_;

--- a/tests/DCPS/SampleLost/publisher.cpp
+++ b/tests/DCPS/SampleLost/publisher.cpp
@@ -90,7 +90,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[]) {
       dw_qos.deadline.period = deadline_time;
 
       // Create a DataWriter.
-      ACE_Atomic_Op<ACE_SYNCH_MUTEX, bool> publication_matched;
+      OpenDDS::DCPS::Atomic<bool> publication_matched;
       ::DDS::DataWriterListener_var dwl (
           new DataWriterListenerImpl (publication_matched));
 
@@ -112,7 +112,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[]) {
       int const max_attempts = 50;
       int attempts;
       for (attempts = 1;
-           attempts != max_attempts && publication_matched.value () == false;
+           attempts != max_attempts && publication_matched == false;
            ++attempts)
       {
         ACE_OS::sleep (5);

--- a/tests/DCPS/Serializer_wstring/Writer.cpp
+++ b/tests/DCPS/Serializer_wstring/Writer.cpp
@@ -193,5 +193,5 @@ Writer::is_finished () const
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }

--- a/tests/DCPS/Serializer_wstring/Writer.h
+++ b/tests/DCPS/Serializer_wstring/Writer.h
@@ -3,10 +3,12 @@
 #ifndef WRITER_H
 #define WRITER_H
 
-#include <dds/DdsDcpsPublicationC.h>
-#include <ace/Task.h>
 #include "MessengerC.h"
 
+#include <dds/DdsDcpsPublicationC.h>
+#include <dds/DCPS/Atomic.h>
+
+#include <ace/Task.h>
 
 class Writer : public ACE_Task_Base
 {
@@ -31,8 +33,8 @@ public:
 private:
 
   ::DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/SkipSerialize/Writer.h
+++ b/tests/DCPS/SkipSerialize/Writer.h
@@ -27,7 +27,7 @@ public:
 
 private:
   DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
+++ b/tests/DCPS/StaticDiscovery/StaticDiscoveryTest.cpp
@@ -181,14 +181,14 @@ public:
 
 private:
   std::vector<std::string>& writers_;
-  static ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> thread_counter_;
+  static OpenDDS::DCPS::Atomic<int> thread_counter_;
   DDS::DomainParticipant_var participant_;
   DDS::Topic_var topic_;
   const bool& reliable_;
   int total_readers_;
 };
 
-ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> WriterTask::thread_counter_;
+OpenDDS::DCPS::Atomic<int> WriterTask::thread_counter_;
 
 ACE_Thread_Mutex readers_done_lock;
 ACE_Condition_Thread_Mutex readers_done_cond(readers_done_lock);

--- a/tests/DCPS/StringKey/Writer.cpp
+++ b/tests/DCPS/StringKey/Writer.cpp
@@ -148,5 +148,5 @@ Writer::is_finished () const
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }

--- a/tests/DCPS/StringKey/Writer.h
+++ b/tests/DCPS/StringKey/Writer.h
@@ -4,8 +4,9 @@
 #define WRITER_H
 
 #include <dds/DdsDcpsPublicationC.h>
-#include <ace/Task.h>
+#include <dds/DCPS/Atomic.h>
 
+#include <ace/Task.h>
 
 class Writer : public ACE_Task_Base
 {
@@ -28,8 +29,8 @@ public:
 private:
 
   ::DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/TcpReconnect/Writer.cpp
+++ b/tests/DCPS/TcpReconnect/Writer.cpp
@@ -88,7 +88,7 @@ Writer::svc()
     for (int i = 0; i < num_messages; i++) {
       DDS::ReturnCode_t error;
 
-      message.phase_number = writer_phase_.value();
+      message.phase_number = writer_phase_;
       do {
         error = message_dw->write(message, handle);
       } while (error == DDS::RETCODE_TIMEOUT);

--- a/tests/DCPS/TcpReconnect/Writer.h
+++ b/tests/DCPS/TcpReconnect/Writer.h
@@ -29,8 +29,8 @@ public:
 
 private:
   DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, long> writer_phase_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
+  OpenDDS::DCPS::Atomic<long> writer_phase_;
 };
 
 #endif /* WRITER_H */

--- a/tests/DCPS/TransientDurability/DataWriterListenerImpl.cpp
+++ b/tests/DCPS/TransientDurability/DataWriterListenerImpl.cpp
@@ -3,7 +3,7 @@
 #include "dds/DdsDcpsPublicationC.h"
 
 DataWriterListenerImpl::DataWriterListenerImpl (
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, bool> & publication_matched)
+  OpenDDS::DCPS::Atomic<bool> & publication_matched)
   : publication_matched_ (publication_matched)
 {
 }

--- a/tests/DCPS/TransientDurability/DataWriterListenerImpl.h
+++ b/tests/DCPS/TransientDurability/DataWriterListenerImpl.h
@@ -19,7 +19,7 @@ class DataWriterListenerImpl
 public:
 
   DataWriterListenerImpl (
-    ACE_Atomic_Op<ACE_SYNCH_MUTEX, bool> & publication_matched);
+    OpenDDS::DCPS::Atomic<bool> & publication_matched);
 
   virtual void on_offered_deadline_missed (
       ::DDS::DataWriter_ptr writer,
@@ -55,7 +55,7 @@ protected:
 
 private:
 
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, bool> & publication_matched_;
+  OpenDDS::DCPS::Atomic<bool> & publication_matched_;
 
 };
 

--- a/tests/DCPS/TransientDurability/Writer.cpp
+++ b/tests/DCPS/TransientDurability/Writer.cpp
@@ -104,7 +104,7 @@ Writer::end ()
 int
 Writer::get_timeout_writes () const
 {
-  return timeout_writes_.value ();
+  return timeout_writes_;
 }
 
 int

--- a/tests/DCPS/TransientDurability/Writer.h
+++ b/tests/DCPS/TransientDurability/Writer.h
@@ -31,7 +31,7 @@ private:
 
   ::DDS::DataWriter_var writer_;
 
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> timeout_writes_;
+  OpenDDS::DCPS::Atomic<int> timeout_writes_;
 
   // The lock used to synchronize the two write threads.
   ACE_Thread_Mutex lock_;

--- a/tests/DCPS/TransientDurability/publisher.cpp
+++ b/tests/DCPS/TransientDurability/publisher.cpp
@@ -125,7 +125,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[]) {
 
       // -------------------------------------------------------
 
-      ACE_Atomic_Op<ACE_SYNCH_MUTEX, bool> publication_matched;
+      OpenDDS::DCPS::Atomic<bool> publication_matched;
       ::DDS::DataWriterListener_var dwl (
           new DataWriterListenerImpl (publication_matched));
 
@@ -139,7 +139,7 @@ ACE_TMAIN (int argc, ACE_TCHAR *argv[]) {
       int const max_attempts = 50;
       int attempts;
       for (attempts = 1;
-           attempts != max_attempts && publication_matched.value () == false;
+           attempts != max_attempts && publication_matched == false;
            ++attempts)
       {
         ACE_OS::sleep (5);

--- a/tests/DCPS/WaitForAck/Writer.cpp
+++ b/tests/DCPS/WaitForAck/Writer.cpp
@@ -98,7 +98,7 @@ Writer::svc ()
   int count = 0;
   Test::DataDataWriter_var dataWriter
     = Test::DataDataWriter::_narrow( this->writer_.in());
-  while( this->done_.value() == false) {
+  while( this->done_ == false) {
     Test::Data sample;
     sample.pid = this->index_;
     sample.seq = ++count;

--- a/tests/DCPS/WaitForAck/Writer.h
+++ b/tests/DCPS/WaitForAck/Writer.h
@@ -4,6 +4,8 @@
 #define WRITER_H
 
 #include <dds/DdsDcpsPublicationC.h>
+#include <dds/DCPS/Atomic.h>
+
 #include <ace/Task.h>
 
 namespace Test {
@@ -51,7 +53,7 @@ class Writer : public ACE_Task_Base {
     bool verbose_;
 
     /// Completion indicator.
-    ACE_Atomic_Op<ACE_Thread_Mutex, bool> done_;
+    OpenDDS::DCPS::Atomic<bool> done_;
 
     /// Count of messages sent by this publication.
     int messages_;

--- a/tests/DCPS/ZeroCopyDataReaderListener/Writer.h
+++ b/tests/DCPS/ZeroCopyDataReaderListener/Writer.h
@@ -26,7 +26,7 @@ public:
 
 private:
   DDS::DataWriter_var writer_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
 };
 
 #endif /* WRITER_H */

--- a/tests/security/attributes/Writer.h
+++ b/tests/security/attributes/Writer.h
@@ -33,7 +33,7 @@ public:
 private:
   DDS::DataWriter_var writer_;
   const Args args_;
-  ACE_Atomic_Op<ACE_SYNCH_MUTEX, int> finished_instances_;
+  OpenDDS::DCPS::Atomic<int> finished_instances_;
   DDS::GuardCondition_var guard_condition_;
 };
 

--- a/tests/stress-tests/dds/DCPS/DispatchService.cpp
+++ b/tests/stress-tests/dds/DCPS/DispatchService.cpp
@@ -65,14 +65,14 @@ struct RecursiveTestObjTwo : public TestObjBase {
   void operator()()
   {
     increment_call_count();
-    const size_t scale = dispatch_scale_.value();
+    const size_t scale = dispatch_scale_;
     for (size_t i = 0; i < scale; ++i) {
       dispatcher_.dispatch(*this);
     }
   }
 
   OpenDDS::DCPS::DispatchService& dispatcher_;
-  ACE_Atomic_Op<ACE_Thread_Mutex, size_t> dispatch_scale_;
+  OpenDDS::DCPS::Atomic<size_t> dispatch_scale_;
 };
 
 struct InternalShutdownTestObj : public TestObjBase {

--- a/tests/stress-tests/dds/DCPS/MultiTask.cpp
+++ b/tests/stress-tests/dds/DCPS/MultiTask.cpp
@@ -7,6 +7,7 @@
 
 #include "TimingChecker.h"
 
+#include <dds/DCPS/Atomic.h>
 #include <dds/DCPS/Definitions.h>
 #include <dds/DCPS/MultiTask.h>
 #include <dds/DCPS/ReactorTask.h>
@@ -19,7 +20,7 @@ using namespace OpenDDS::DCPS;
 
 namespace {
 
-ACE_Atomic_Op<ACE_Thread_Mutex, unsigned int> total_count = 0;
+OpenDDS::DCPS::Atomic<unsigned int> total_count(0u);
 
 struct TestObj : public virtual RcObject
 {
@@ -34,7 +35,7 @@ struct TestObj : public virtual RcObject
   void execute(const MonotonicTimePoint&) {
     ACE_DEBUG((LM_DEBUG, "TestObj::execute() called at %T\n"));
     ++total_count;
-    if (do_enable_.value()) {
+    if (do_enable_) {
       multi_->enable(TimeDuration::from_msec(100)); // 0.1 seconds from now
     }
   }
@@ -42,7 +43,7 @@ struct TestObj : public virtual RcObject
   void set_do_enable(bool do_enable) { do_enable_ = do_enable; }
 
   RcHandle<Multi> multi_;
-  ACE_Atomic_Op<ACE_Thread_Mutex, bool> do_enable_;
+  OpenDDS::DCPS::Atomic<bool> do_enable_;
 };
 
 } // (anonymous) namespace
@@ -59,10 +60,10 @@ TEST(dds_DCPS_MultiTask, TimingChecker)
 
   RcHandle<TestObj> obj = make_rch<TestObj>(reactor_task.interceptor());
   obj->multi_->enable(TimeDuration::from_msec(2000)); // 2.0 seconds
-  ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
+  ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.load()));
   EXPECT_EQ(total_count, 0);
   ACE_OS::sleep(5); // 5.0 seconds
-  ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
+  ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.load()));
   EXPECT_EQ(total_count, 2); // expect 2 executions within a 5.0 second interval when period is 2.0 seconds
   obj->set_do_enable(true);
   const MonotonicTimePoint deadline = MonotonicTimePoint::now() + TimeDuration::from_msec(2000); // 2.0 seconds from now
@@ -75,7 +76,7 @@ TEST(dds_DCPS_MultiTask, TimingChecker)
   obj->set_do_enable(false);
   ACE_OS::sleep(ACE_Time_Value(0, 110000)); // sleep for 0.11 seconds to catch final "fast" executions
   ACE_DEBUG((LM_DEBUG, "enable_calls = %d\n", enable_calls));
-  ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
+  ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.load()));
   // 1 from the slow period, 20 from the fast period (2.0 / 0.1)
   if (tight_timing) {
     EXPECT_EQ(total_count, 22);
@@ -84,7 +85,7 @@ TEST(dds_DCPS_MultiTask, TimingChecker)
     EXPECT_LE(total_count, 22);
   }
   ACE_OS::sleep(5); // sleep for 5.0 more seconds, should fall back to 2.0 second default period
-  ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.value()));
+  ACE_DEBUG((LM_DEBUG, "total_count = %d\n", total_count.load()));
   // 1 from the slow period, 20 from the fast period (2.0 / 0.1), 2 more from last slow period
   if (tight_timing) {
     EXPECT_EQ(total_count, 24);

--- a/tests/stress-tests/dds/DCPS/ServiceEventDispatcher.cpp
+++ b/tests/stress-tests/dds/DCPS/ServiceEventDispatcher.cpp
@@ -74,7 +74,7 @@ struct RecursiveTestEventTwo : public TestEventBase {
   void handle_event()
   {
     increment_call_count();
-    const size_t scale = dispatch_scale_.value();
+    const size_t scale = dispatch_scale_;
     OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::EventDispatcher> dispatcher = dispatcher_.lock();
     if (dispatcher) {
       for (size_t i = 0; i < scale; ++i) {
@@ -84,7 +84,7 @@ struct RecursiveTestEventTwo : public TestEventBase {
   }
 
   OpenDDS::DCPS::WeakRcHandle<OpenDDS::DCPS::EventDispatcher> dispatcher_;
-  ACE_Atomic_Op<ACE_Thread_Mutex, size_t> dispatch_scale_;
+  OpenDDS::DCPS::Atomic<size_t> dispatch_scale_;
 };
 
 } // (anonymous) namespace

--- a/tests/unit-tests/dds/DCPS/DispatchService.cpp
+++ b/tests/unit-tests/dds/DCPS/DispatchService.cpp
@@ -65,14 +65,14 @@ struct RecursiveTestObjTwo : public TestObjBase {
   void operator()()
   {
     increment_call_count();
-    const size_t scale = dispatch_scale_.value();
+    const size_t scale = dispatch_scale_;
     for (size_t i = 0; i < scale; ++i) {
       dispatcher_.dispatch(*this);
     }
   }
 
   OpenDDS::DCPS::DispatchService& dispatcher_;
-  ACE_Atomic_Op<ACE_Thread_Mutex, size_t> dispatch_scale_;
+  OpenDDS::DCPS::Atomic<size_t> dispatch_scale_;
 };
 
 struct InternalShutdownTestObj : public TestObjBase {

--- a/tests/unit-tests/dds/DCPS/ServiceEventDispatcher.cpp
+++ b/tests/unit-tests/dds/DCPS/ServiceEventDispatcher.cpp
@@ -74,7 +74,7 @@ struct RecursiveTestEventTwo : public TestEventBase {
   void handle_event()
   {
     increment_call_count();
-    const size_t scale = dispatch_scale_.value();
+    const size_t scale = dispatch_scale_;
     OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::EventDispatcher> dispatcher = dispatcher_.lock();
     if (dispatcher) {
       for (size_t i = 0; i < scale; ++i) {
@@ -84,7 +84,7 @@ struct RecursiveTestEventTwo : public TestEventBase {
   }
 
   OpenDDS::DCPS::WeakRcHandle<OpenDDS::DCPS::EventDispatcher> dispatcher_;
-  ACE_Atomic_Op<ACE_Thread_Mutex, size_t> dispatch_scale_;
+  OpenDDS::DCPS::Atomic<size_t> dispatch_scale_;
 };
 
 } // (anonymous) namespace

--- a/tests/unit-tests/dds/DCPS/ThreadPool.cpp
+++ b/tests/unit-tests/dds/DCPS/ThreadPool.cpp
@@ -5,9 +5,9 @@
  * See: http://www.opendds.org/license.html
  */
 
+#include <dds/DCPS/Atomic.h>
 #include <dds/DCPS/ThreadPool.h>
 
-#include <ace/Atomic_Op.h>
 #include <ace/OS_NS_unistd.h>
 
 #include <gtest/gtest.h>
@@ -17,7 +17,7 @@ namespace {
 ACE_THR_FUNC_RETURN inc_count(void* arg)
 {
   if (arg) {
-    ACE_Atomic_Op<ACE_Thread_Mutex, size_t>* count = reinterpret_cast<ACE_Atomic_Op<ACE_Thread_Mutex, size_t>*>(arg);
+    OpenDDS::DCPS::Atomic<size_t>* count = reinterpret_cast<OpenDDS::DCPS::Atomic<size_t>*>(arg);
     ++(*count);
   }
   return 0;
@@ -45,7 +45,7 @@ TEST(dds_DCPS_ThreadPool, NoArgConstructor)
 
 TEST(dds_DCPS_ThreadPool, ArgConstructorZero)
 {
-  ACE_Atomic_Op<ACE_Thread_Mutex, size_t> count(0u);
+  OpenDDS::DCPS::Atomic<size_t> count(0u);
   {
     OpenDDS::DCPS::ThreadPool pool(0u, inc_count, &count);
   }
@@ -54,7 +54,7 @@ TEST(dds_DCPS_ThreadPool, ArgConstructorZero)
 
 TEST(dds_DCPS_ThreadPool, ArgConstructorOne)
 {
-  ACE_Atomic_Op<ACE_Thread_Mutex, size_t> count(0u);
+  OpenDDS::DCPS::Atomic<size_t> count(0u);
   {
     OpenDDS::DCPS::ThreadPool pool(1u, inc_count, &count);
   }
@@ -63,7 +63,7 @@ TEST(dds_DCPS_ThreadPool, ArgConstructorOne)
 
 TEST(dds_DCPS_ThreadPool, ArgConstructorFour)
 {
-  ACE_Atomic_Op<ACE_Thread_Mutex, size_t> count(0u);
+  OpenDDS::DCPS::Atomic<size_t> count(0u);
   {
     OpenDDS::DCPS::ThreadPool pool(4u, inc_count, &count);
   }
@@ -72,7 +72,7 @@ TEST(dds_DCPS_ThreadPool, ArgConstructorFour)
 
 TEST(dds_DCPS_ThreadPool, ArgConstructorSixteen)
 {
-  ACE_Atomic_Op<ACE_Thread_Mutex, size_t> count(0u);
+  OpenDDS::DCPS::Atomic<size_t> count(0u);
   {
     OpenDDS::DCPS::ThreadPool pool(16u, inc_count, &count);
   }


### PR DESCRIPTION
### Problem
The new `OpenDDS::DCPS::Atomic` type simplifies OpenDDS interactions with atomic types, both pre-and-post C++11, but it is not consistently used across the OpenDDS codebase.

### Solution
Consistently use `OpenDDS::DCPS::Atomic` rather than `ACE_Atomic_Op` (or `std::atomic`) in situations when C++11 support is not required / guaranteed in order to simplify interactions with atomic types.