### PR TITLE
Dynamic Data: read/write enum members as strings

### DIFF
--- a/dds/DCPS/XTypes/DynamicDataBase.cpp
+++ b/dds/DCPS/XTypes/DynamicDataBase.cpp
@@ -179,6 +179,29 @@ bool DynamicDataBase::get_index_from_id(DDS::MemberId id, ACE_CDR::ULong& index,
   return false;
 }
 
+
+bool DynamicDataBase::enum_string_helper(char*& strInOut, MemberId id)
+{
+  DDS::DynamicType_var mtype;
+  DDS::ReturnCode_t rc = get_member_type(mtype, type_, id);
+  if (rc != DDS::RETCODE_OK || mtype->get_kind() != TK_ENUM) {
+    return false;
+  }
+  DDS::Int32 valAsInt;
+  rc = get_enum_value(valAsInt, mtype, this, id);
+  if (rc != DDS::RETCODE_OK) {
+    return false;
+  }
+  DDS::String8_var valAsStr;
+  rc = get_enumerator_name(valAsStr, valAsInt, mtype);
+  if (rc != DDS::RETCODE_OK) {
+    return false;
+  }
+  CORBA::string_free(strInOut);
+  strInOut = valAsStr._retn();
+  return true;
+}
+
 bool DynamicDataBase::check_member(
   DDS::MemberDescriptor_var& md, DDS::DynamicType_var& type,
   const char* method, const char* what, DDS::MemberId id, DDS::TypeKind tk)

--- a/dds/DCPS/XTypes/DynamicDataBase.cpp
+++ b/dds/DCPS/XTypes/DynamicDataBase.cpp
@@ -20,6 +20,13 @@ DynamicDataBase::DynamicDataBase(DDS::DynamicType_ptr type)
   : type_(get_base_type(type))
 {}
 
+DDS::DynamicData* DynamicDataBase::interface_from_this() const
+{
+  // Operations defined in IDL interfaces don't use pointer-to-const
+  // parameter types.
+  return const_cast<DynamicDataBase*>(this);
+}
+
 DDS::ReturnCode_t DynamicDataBase::get_descriptor(DDS::MemberDescriptor*& value, MemberId id)
 {
   DDS::DynamicTypeMember_var dtm;

--- a/dds/DCPS/XTypes/DynamicDataBase.h
+++ b/dds/DCPS/XTypes/DynamicDataBase.h
@@ -47,6 +47,7 @@ protected:
   bool is_basic(TypeKind tk) const;
   bool is_complex(TypeKind tk) const;
   bool get_index_from_id(DDS::MemberId id, ACE_CDR::ULong& index, ACE_CDR::ULong bound) const;
+  bool enum_string_helper(char*& strInOut, MemberId id);
 
   bool check_member(DDS::MemberDescriptor_var& md, DDS::DynamicType_var& type,
     const char* method, const char* what, DDS::MemberId id, DDS::TypeKind tk = TK_NONE);

--- a/dds/DCPS/XTypes/DynamicDataBase.h
+++ b/dds/DCPS/XTypes/DynamicDataBase.h
@@ -56,6 +56,11 @@ protected:
   static DDS::MemberId get_union_default_member(DDS::DynamicType* type);
   static bool discriminator_selects_no_member(DDS::DynamicType* type, ACE_CDR::Long disc);
 
+  /// Similar idea to std::shared_from_this(), provide a type compatible with parameter
+  /// passing rules for IDL interfaces that are arguments to operations.
+  /// Doesn't change the reference count.
+  DDS::DynamicData* interface_from_this() const;
+
   /// The actual (i.e., non-alias) DynamicType of the associated type.
   DDS::DynamicType_var type_;
 };

--- a/dds/DCPS/XTypes/DynamicDataImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataImpl.cpp
@@ -1483,7 +1483,7 @@ DDS::ReturnCode_t DynamicDataImpl::set_string_value(DDS::MemberId id, const char
     if (rc != DDS::RETCODE_OK) {
       return rc;
     }
-    return set_single_value<TK_INT32>(id, intValue);
+    return set_enum_value(mtype, this, id, intValue);
   }
   return set_single_value<TK_STRING8>(id, value);
 }
@@ -1611,20 +1611,20 @@ DDS::ReturnCode_t DynamicDataImpl::get_simple_value_string(DCPS::Value& value,
 DDS::ReturnCode_t DynamicDataImpl::get_simple_value_enum(DCPS::Value& value,
                                                          DDS::MemberId id) const
 {
-  DCPS::Value enumAsInteger(0);
-  DDS::ReturnCode_t ret = get_simple_value_primitive<DDS::Int32>(enumAsInteger, id);
+  DDS::DynamicType_var mtype;
+  DDS::ReturnCode_t ret = get_member_type(mtype, type_, id);
   if (ret != DDS::RETCODE_OK) {
     return ret;
   }
 
-  DDS::DynamicType_var mtype;
-  ret = get_member_type(mtype, type_, id);
+  DDS::Int32 enumAsInteger;
+  ret = get_enum_value(enumAsInteger, mtype, interface_from_this(), id);
   if (ret != DDS::RETCODE_OK) {
     return ret;
   }
 
   DDS::String8_var str;
-  ret = get_enumerator_name(str, enumAsInteger.get<DDS::Int32>(), mtype);
+  ret = get_enumerator_name(str, enumAsInteger, mtype);
   if (ret != DDS::RETCODE_OK) {
     return ret;
   }

--- a/dds/DCPS/XTypes/DynamicDataImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataImpl.cpp
@@ -1617,20 +1617,14 @@ DDS::ReturnCode_t DynamicDataImpl::get_simple_value_enum(DCPS::Value& value,
     return ret;
   }
 
-  DDS::DynamicTypeMember_var dtm;
-  ret = type_->get_member(dtm, id);
-  if (ret != DDS::RETCODE_OK) {
-    return ret;
-  }
-
-  DDS::MemberDescriptor_var md;
-  ret = dtm->get_descriptor(md);
+  DDS::DynamicType_var mtype;
+  ret = get_member_type(mtype, type_, id);
   if (ret != DDS::RETCODE_OK) {
     return ret;
   }
 
   DDS::String8_var str;
-  ret = get_enumerator_name(str, enumAsInteger.get<DDS::Int32>(), md->type());
+  ret = get_enumerator_name(str, enumAsInteger.get<DDS::Int32>(), mtype);
   if (ret != DDS::RETCODE_OK) {
     return ret;
   }

--- a/dds/DCPS/XTypes/DynamicDataImpl.h
+++ b/dds/DCPS/XTypes/DynamicDataImpl.h
@@ -241,6 +241,7 @@ private:
   template<typename ValueType>
   DDS::ReturnCode_t get_simple_value_primitive(DCPS::Value& value, DDS::MemberId id) const;
   DDS::ReturnCode_t get_simple_value_string(DCPS::Value& value, DDS::MemberId id) const;
+  DDS::ReturnCode_t get_simple_value_enum(DCPS::Value& value, DDS::MemberId id) const;
 #endif
 
   bool is_basic_type(TypeKind tk) const;

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -1459,12 +1459,17 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_boolean_value(ACE_CDR::Boolean& v
 
 DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_string_value(ACE_CDR::Char*& value, MemberId id)
 {
+  if (enum_string_helper(value, id)) {
+    return DDS::RETCODE_OK;
+  }
+  CORBA::string_free(value);
   return get_single_value<TK_STRING8>(value, id);
 }
 
 DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_wstring_value(ACE_CDR::WChar*& value, MemberId id)
 {
 #ifdef DDS_HAS_WCHAR
+  CORBA::wstring_free(value);
   return get_single_value<TK_STRING16>(value, id);
 #else
   return DDS::RETCODE_UNSUPPORTED;

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -2914,12 +2914,11 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_simple_value(DCPS::Value& value, 
     return get_some_value(value, id, *this, &DynamicDataXcdrReadImpl::get_char8_value);
   case TK_CHAR16:
     return get_some_value(value, id, *this, &DynamicDataXcdrReadImpl::get_char16_value);
+  case TK_ENUM:
   case TK_STRING8:
     return get_some_value(value, id, *this, &DynamicDataXcdrReadImpl::get_string_value);
   case TK_STRING16:
     return get_some_value(value, id, *this, &DynamicDataXcdrReadImpl::get_wstring_value);
-  case TK_ENUM:
-    return get_some_value(value, id, *this, &DynamicDataXcdrReadImpl::get_string_value);
   default:
     return DDS::RETCODE_UNSUPPORTED;
   }

--- a/dds/DCPS/XTypes/Utils.cpp
+++ b/dds/DCPS/XTypes/Utils.cpp
@@ -1103,6 +1103,25 @@ DDS::ReturnCode_t get_enum_value(
   return rc;
 }
 
+DDS::ReturnCode_t get_enumerator_name(
+  DDS::String8_var& name, DDS::Int32 value, DDS::DynamicType_ptr type)
+{
+  DDS::DynamicTypeMember_var dtm;
+  DDS::ReturnCode_t rc = type->get_member(dtm, static_cast<DDS::MemberId>(value));
+  if (rc != DDS::RETCODE_OK) {
+    return rc;
+  }
+
+  DDS::MemberDescriptor_var md;
+  rc = dtm->get_descriptor(md);
+  if (rc != DDS::RETCODE_OK) {
+    return rc;
+  }
+
+  name = md->name();
+  return DDS::RETCODE_OK;
+}
+
 } // namespace XTypes
 } // namespace OpenDDS
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/XTypes/Utils.cpp
+++ b/dds/DCPS/XTypes/Utils.cpp
@@ -1206,7 +1206,7 @@ DDS::ReturnCode_t set_enum_value(
   if (rc != DDS::RETCODE_OK) {
     return rc;
   }
-  return set_enum_value(type, src, id, md->index());
+  return set_enum_value(type, src, id, md->id());
 }
 
 } // namespace XTypes

--- a/dds/DCPS/XTypes/Utils.h
+++ b/dds/DCPS/XTypes/Utils.h
@@ -159,6 +159,9 @@ OpenDDS_Dcps_Export DDS::ReturnCode_t enum_bound(DDS::DynamicType_ptr type, DDS:
 OpenDDS_Dcps_Export DDS::ReturnCode_t get_enum_value(
   CORBA::Int32& value, DDS::DynamicType_ptr type, DDS::DynamicData_ptr src, DDS::MemberId id);
 
+OpenDDS_Dcps_Export DDS::ReturnCode_t get_enumerator_name(
+  DDS::String8_var& name, DDS::Int32 value, DDS::DynamicType_ptr type);
+
 } // namespace XTypes
 } // namespace OpenDDS
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/XTypes/Utils.h
+++ b/dds/DCPS/XTypes/Utils.h
@@ -143,7 +143,14 @@ OpenDDS_Dcps_Export DDS::ReturnCode_t compare_members(
   int& result, DDS::DynamicData_ptr a, DDS::DynamicData_ptr b, DDS::MemberId id);
 
 OpenDDS_Dcps_Export DDS::ReturnCode_t get_member_type(
-  DDS::DynamicType_var& type, DDS::DynamicData_ptr data, DDS::MemberId id);
+  DDS::DynamicType_var& member_type, DDS::DynamicType_ptr container_type, DDS::MemberId id);
+
+inline DDS::ReturnCode_t get_member_type(
+  DDS::DynamicType_var& member_type, DDS::DynamicData_ptr container, DDS::MemberId id)
+{
+  DDS::DynamicType_var container_type = container->type();
+  return get_member_type(member_type, container_type, id);
+}
 
 OpenDDS_Dcps_Export bool is_int(DDS::TypeKind tk);
 OpenDDS_Dcps_Export bool is_uint(DDS::TypeKind tk);
@@ -205,6 +212,8 @@ inline DDS::ReturnCode_t set_enum_value(
 
 OpenDDS_Dcps_Export DDS::ReturnCode_t get_enumerator_name(
   DDS::String8_var& name, DDS::Int32 value, DDS::DynamicType_ptr type);
+OpenDDS_Dcps_Export DDS::ReturnCode_t get_enumerator_value(
+  DDS::Int32& value, const char* name, DDS::DynamicType_ptr type);
 
 } // namespace XTypes
 } // namespace OpenDDS

--- a/tests/DCPS/FilterExpression/FilterExpression.cpp
+++ b/tests/DCPS/FilterExpression/FilterExpression.cpp
@@ -64,6 +64,8 @@ template <size_t N, typename T>
 bool doEvalTest(const char* (&input)[N], bool expected, const T& sample, const DDS::StringSeq& params,
                 const TypeSupportImpl& tsStatic, const TypeSupportImpl& tsDynamic)
 {
+  ACE_UNUSED_ARG(tsStatic);
+  ACE_UNUSED_ARG(tsDynamic);
   using namespace OpenDDS::DCPS;
   static const Encoding enc_xcdr2(Encoding::KIND_XCDR2);
   bool pass = true;

--- a/tests/DCPS/FilterExpression/FilterExpression.cpp
+++ b/tests/DCPS/FilterExpression/FilterExpression.cpp
@@ -2,11 +2,15 @@
 #include "string.h" // yard references strncpy() without including this
 
 #include "FilterStructTypeSupportImpl.h"
+#include "FilterStructDynamicTypeSupport.h"
 
 #include "dds/DCPS/Definitions.h"
 #include "dds/DCPS/FilterExpressionGrammar.h"
 #include "dds/DCPS/yard/yard_parser.hpp"
 #include "dds/DCPS/FilterEvaluator.h"
+
+#include "dds/DCPS/XTypes/DynamicDataFactory.h"
+#include "dds/DCPS/XTypes/DynamicSample.h"
 
 #include "ace/OS_main.h"
 #include "ace/OS_NS_string.h"
@@ -16,13 +20,56 @@
 #include <cstdio>
 #include <iostream>
 
-template<size_t N, typename T>
-bool doEvalTest(const char* (&input)[N], bool expected, const T& sample,
-                const DDS::StringSeq& params) {
+DDS::DynamicData_var copy(const TBTD& sample, DDS::DynamicType* type)
+{
+  using namespace DDS;
+  DynamicData_var dd = DynamicDataFactory::get_instance()->create_data(type);
+  dd->set_string_value(dd->get_member_id_by_name("name"), sample.name);
+
+  DynamicData_var nested;
+  dd->get_complex_value(nested, dd->get_member_id_by_name("durability"));
+  nested->set_int32_value(nested->get_member_id_by_name("kind"), static_cast<ACE_CDR::Long>(sample.durability.kind));
+
+  dd->get_complex_value(nested, dd->get_member_id_by_name("durability_service"));
+  DynamicData_var duration;
+  nested->get_complex_value(duration, nested->get_member_id_by_name("service_cleanup_delay"));
+  duration->set_int32_value(duration->get_member_id_by_name("sec"), sample.durability_service.service_cleanup_delay.sec);
+  duration->set_uint32_value(duration->get_member_id_by_name("nanosec"), sample.durability_service.service_cleanup_delay.nanosec);
+  
+  nested->set_int32_value(nested->get_member_id_by_name("history_kind"), static_cast<ACE_CDR::Long>(sample.durability_service.history_kind));
+  nested->set_int32_value(nested->get_member_id_by_name("history_depth"), sample.durability_service.history_depth);
+  nested->set_int32_value(nested->get_member_id_by_name("max_samples"), sample.durability_service.max_samples);
+  nested->set_int32_value(nested->get_member_id_by_name("max_instances"), sample.durability_service.max_instances);
+  nested->set_int32_value(nested->get_member_id_by_name("max_samples_per_instance"), sample.durability_service.max_samples_per_instance);
+  return dd;
+}
+
+template <typename T>
+ACE_Message_Block* serialize(const OpenDDS::DCPS::Encoding& enc, const T& sample)
+{
+  using namespace OpenDDS::DCPS;
+  const EncapsulationHeader encapsulation(enc, APPENDABLE);
+  size_t sz = EncapsulationHeader::serialized_size;
+  serialized_size(enc, sz, sample);
+  Message_Block_Ptr mb(new ACE_Message_Block(sz));
+  Serializer ser(mb.get(), enc);
+  if (!(ser << encapsulation) || !(ser << sample)) {
+    return 0;
+  }
+  return mb.release();
+}
+
+using OpenDDS::DCPS::TypeSupportImpl;
+template <size_t N, typename T>
+bool doEvalTest(const char* (&input)[N], bool expected, const T& sample, const DDS::StringSeq& params,
+                const TypeSupportImpl& tsStatic, const TypeSupportImpl& tsDynamic)
+{
+  using namespace OpenDDS::DCPS;
+  static const Encoding enc_xcdr2(Encoding::KIND_XCDR2);
   bool pass = true;
   for (size_t i = 0; i < N; ++i) {
     try {
-      OpenDDS::DCPS::FilterEvaluator fe(input[i], false);
+      FilterEvaluator fe(input[i], false);
       const bool result = fe.eval(sample, params);
       if (result != expected) pass = false;
       std::cout << input[i] << " => " << result << std::endl;
@@ -30,6 +77,42 @@ bool doEvalTest(const char* (&input)[N], bool expected, const T& sample,
       if (expected) pass = false;
       std::cout << input[i] << " => exception " << e.what() << std::endl;
     }
+#ifdef TEST_CDR_STATIC_FILTER
+    try {
+      Message_Block_Ptr amb(serialize(enc_xcdr2, sample));
+      FilterEvaluator fe(input[i], false);
+      const bool result = fe.eval(amb.get(), enc_xcdr2, tsStatic, params);
+      if (result != expected) pass = false;
+      std::cout << input[i] << " =xcdr=> " << result << std::endl;
+    } catch (const std::exception& e) {
+      if (expected) pass = false;
+      std::cout << input[i] << " =xcdr=> exception " << e.what() << std::endl;
+    }
+#endif
+    try {
+      DDS::DynamicType_var dyntype = tsDynamic.get_type();
+      DDS::DynamicData_var dynamic = copy(sample, dyntype);
+      OpenDDS::XTypes::DynamicSample dsample(dynamic);
+      FilterEvaluator fe(input[i], false);
+      const bool result = fe.eval(dsample, params);
+      if (result != expected) pass = false;
+      std::cout << input[i] << " =dynamic=> " << result << std::endl;
+    } catch (const std::exception& e) {
+      if (expected) pass = false;
+      std::cout << input[i] << " =dynamic=> exception " << e.what() << std::endl;
+    }
+#ifdef TEST_CDR_DYNAMIC_FILTER
+    try {
+      Message_Block_Ptr amb(serialize(enc_xcdr2, sample));
+      FilterEvaluator fe(input[i], false);
+      const bool result = fe.eval(amb.get(), enc_xcdr2, tsDynamic, params);
+      if (result != expected) pass = false;
+      std::cout << input[i] << " =dynamic/xcdr=> " << result << std::endl;
+    } catch (const std::exception& e) {
+      if (expected) pass = false;
+      std::cout << input[i] << " =dynamic/xcdr=> exception " << e.what() << std::endl;
+    }
+#endif
   }
   return pass;
 }
@@ -41,6 +124,7 @@ bool testEval() {
     TBTD sample;
     sample.name = "Adam";
     sample.durability.kind = DDS::PERSISTENT_DURABILITY_QOS;
+    sample.durability_service.history_kind = DDS::KEEP_LAST_HISTORY_QOS;
     sample.durability_service.history_depth = 15;
     sample.durability_service.service_cleanup_delay.sec = 0;
     sample.durability_service.service_cleanup_delay.nanosec = 10;
@@ -65,8 +149,10 @@ bool testEval() {
                                          "MOD(durability_service.history_depth,4) = 0"};
 
     std::cout << std::boolalpha;
-    bool ok = doEvalTest(filters_pass, true, sample, params);
-    ok &= doEvalTest(filters_fail, false, sample, params);
+    TBTDTypeSupportImpl tsStat;
+    DummyTypeSupport tsDyn;
+    bool ok = doEvalTest(filters_pass, true, sample, params, tsStat, tsDyn);
+    ok &= doEvalTest(filters_fail, false, sample, params, tsStat, tsDyn);
     return ok;
 
   } catch (const CORBA::BAD_PARAM&) {

--- a/tests/DCPS/FilterExpression/FilterExpression.cpp
+++ b/tests/DCPS/FilterExpression/FilterExpression.cpp
@@ -35,7 +35,7 @@ DDS::DynamicData_var copy(const TBTD& sample, DDS::DynamicType* type)
   nested->get_complex_value(duration, nested->get_member_id_by_name("service_cleanup_delay"));
   duration->set_int32_value(duration->get_member_id_by_name("sec"), sample.durability_service.service_cleanup_delay.sec);
   duration->set_uint32_value(duration->get_member_id_by_name("nanosec"), sample.durability_service.service_cleanup_delay.nanosec);
-  
+
   nested->set_int32_value(nested->get_member_id_by_name("history_kind"), static_cast<ACE_CDR::Long>(sample.durability_service.history_kind));
   nested->set_int32_value(nested->get_member_id_by_name("history_depth"), sample.durability_service.history_depth);
   nested->set_int32_value(nested->get_member_id_by_name("max_samples"), sample.durability_service.max_samples);

--- a/tests/DCPS/FilterExpression/FilterStructDynamicTypeSupport.cpp
+++ b/tests/DCPS/FilterExpression/FilterStructDynamicTypeSupport.cpp
@@ -91,7 +91,7 @@ void addEnumerator(DynamicTypeImpl* dt, E kind, const char* name)
   MemberDescriptorImpl* md = new MemberDescriptorImpl;
   MemberDescriptor_var md_var = md;
   md->name(name);
-  md->id(static_cast<MemberId>(kind));
+  md->id(static_cast<DDS::MemberId>(kind));
   md->type(dt);
   md->index(static_cast<unsigned>(kind));
 
@@ -150,7 +150,7 @@ DynamicTypeMember_var memberForDurability()
   return memberDurabilityImpl;
 }
 
-DynamicTypeMember_var integerMember(TypeKind tk, const char* name, MemberId mid)
+DynamicTypeMember_var integerMember(DDS::TypeKind tk, const char* name, DDS::MemberId mid)
 {
   TypeDescriptor_var tdInt = new TypeDescriptorImpl;
   tdInt->kind(tk);

--- a/tests/DCPS/FilterExpression/FilterStructDynamicTypeSupport.cpp
+++ b/tests/DCPS/FilterExpression/FilterStructDynamicTypeSupport.cpp
@@ -1,0 +1,261 @@
+#include "FilterStructDynamicTypeSupport.h"
+
+#include <dds/DCPS/XTypes/DynamicSample.h>
+#include <dds/DCPS/XTypes/DynamicTypeImpl.h>
+#include <dds/DCPS/XTypes/DynamicTypeMemberImpl.h>
+
+using namespace DDS;
+using namespace OpenDDS::DCPS;
+using namespace OpenDDS::XTypes;
+
+// Implement required parts of TypeSupportImpl
+
+const MetaStruct& DummyTypeSupport::getMetaStructForType() const
+{
+  return getMetaStruct<DynamicSample>();
+}
+
+SerializedSizeBound DummyTypeSupport::serialized_size_bound(const Encoding&) const
+{
+  return SerializedSizeBound();
+}
+
+SerializedSizeBound DummyTypeSupport::key_only_serialized_size_bound(const Encoding&) const
+{
+  return SerializedSizeBound();
+}
+
+Extensibility DummyTypeSupport::base_extensibility() const
+{
+  return OpenDDS::DCPS::FINAL;
+}
+
+Extensibility DummyTypeSupport::max_extensibility() const
+{
+  return OpenDDS::DCPS::FINAL;
+}
+
+TypeIdentifier& DummyTypeSupport::getMinimalTypeIdentifier() const
+{
+  static TypeIdentifier ti;
+  return ti;
+}
+
+const TypeMap& DummyTypeSupport::getMinimalTypeMap() const
+{
+  static TypeMap tm;
+  return tm;
+}
+
+const TypeIdentifier& DummyTypeSupport::getCompleteTypeIdentifier() const
+{
+  static TypeIdentifier ti;
+  return ti;
+}
+
+const TypeMap& DummyTypeSupport::getCompleteTypeMap() const
+{
+  static TypeMap tm;
+  return tm;
+}
+
+
+// Construct the DynamicType for the TBTD struct in FilterStruct.idl
+// Doesn't need to be spec-compliant as long as it's enough to support
+// constructing DynamicData and using it with the FilterEvaluator
+
+DynamicTypeMember_var memberForName()
+{
+  TypeDescriptor_var tdString = new TypeDescriptorImpl;
+  tdString->kind(TK_STRING8);
+  tdString->name("String8");
+
+  DynamicTypeImpl* dtString = new DynamicTypeImpl;
+  DynamicType_var dtvar = dtString;
+  dtString->set_descriptor(tdString);
+
+  MemberDescriptor_var memberNameDesc = new MemberDescriptorImpl;
+  memberNameDesc->name("name");
+  memberNameDesc->id(0);
+  memberNameDesc->index(0);
+  memberNameDesc->type(dtString);
+
+  DynamicTypeMemberImpl* memberNameImpl = new DynamicTypeMemberImpl;
+  memberNameImpl->set_descriptor(memberNameDesc);
+  return memberNameImpl;
+}
+
+template <typename E>
+void addEnumerator(DynamicTypeImpl* dt, E kind, const char* name)
+{
+  MemberDescriptorImpl* md = new MemberDescriptorImpl;
+  MemberDescriptor_var md_var = md;
+  md->name(name);
+  md->id(static_cast<MemberId>(kind));
+  md->type(dt);
+  md->index(static_cast<unsigned>(kind));
+
+  DynamicTypeMemberImpl* dtm = new DynamicTypeMemberImpl;
+  DynamicTypeMember_var dtm_var = dtm;
+  dtm->set_descriptor(md);
+  dt->insert_dynamic_member(dtm);
+}
+
+DynamicTypeMember_var memberForKind()
+{
+  DynamicTypeImpl* dtKind = new DynamicTypeImpl;
+  DynamicType_var dtvar = dtKind;
+  addEnumerator(dtKind, VOLATILE_DURABILITY_QOS, "VOLATILE_DURABILITY_QOS");
+  addEnumerator(dtKind, TRANSIENT_LOCAL_DURABILITY_QOS, "TRANSIENT_LOCAL_DURABILITY_QOS");
+  addEnumerator(dtKind, TRANSIENT_DURABILITY_QOS, "TRANSIENT_DURABILITY_QOS");
+  addEnumerator(dtKind, PERSISTENT_DURABILITY_QOS, "PERSISTENT_DURABILITY_QOS");
+
+  TypeDescriptor_var tdKind = new TypeDescriptorImpl;
+  tdKind->kind(TK_ENUM);
+  tdKind->name("DDS::DurabilityQosPolicyKind");
+  tdKind->bound().length(1);
+  tdKind->bound()[0] = 32;
+  dtKind->set_descriptor(tdKind);
+
+  MemberDescriptor_var memberKindDesc = new MemberDescriptorImpl;
+  memberKindDesc->name("kind");
+  memberKindDesc->id(0);
+  memberKindDesc->index(0);
+  memberKindDesc->type(dtKind);
+
+  DynamicTypeMemberImpl* memberKindImpl = new DynamicTypeMemberImpl;
+  memberKindImpl->set_descriptor(memberKindDesc);
+  return memberKindImpl;
+}
+
+DynamicTypeMember_var memberForDurability()
+{
+  TypeDescriptor_var tdDurabilityQosPolicy = new TypeDescriptorImpl;
+  tdDurabilityQosPolicy->kind(TK_STRUCTURE);
+  tdDurabilityQosPolicy->name("DDS::DurabilityQosPolicy");
+
+  DynamicTypeImpl* dtDurabilityQosPolicy = new DynamicTypeImpl;
+  DynamicType_var dtvar = dtDurabilityQosPolicy;
+  dtDurabilityQosPolicy->set_descriptor(tdDurabilityQosPolicy);
+  dtDurabilityQosPolicy->insert_dynamic_member(memberForKind());
+
+  MemberDescriptor_var memberDurabilityDesc = new MemberDescriptorImpl;
+  memberDurabilityDesc->name("durability");
+  memberDurabilityDesc->id(1);
+  memberDurabilityDesc->index(1);
+  memberDurabilityDesc->type(dtDurabilityQosPolicy);
+
+  DynamicTypeMemberImpl* memberDurabilityImpl = new DynamicTypeMemberImpl;
+  memberDurabilityImpl->set_descriptor(memberDurabilityDesc);
+  return memberDurabilityImpl;
+}
+
+DynamicTypeMember_var integerMember(TypeKind tk, const char* name, MemberId mid)
+{
+  TypeDescriptor_var tdInt = new TypeDescriptorImpl;
+  tdInt->kind(tk);
+  tdInt->name(tk == TK_UINT32 ? "UInt32" : "Int32"); // update if other types are used
+
+  DynamicTypeImpl* dtInt = new DynamicTypeImpl;
+  DynamicType_var dtvar = dtInt;
+  dtInt->set_descriptor(tdInt);
+
+  MemberDescriptor_var memberDesc = new MemberDescriptorImpl;
+  memberDesc->name(name);
+  memberDesc->id(mid);
+  memberDesc->index(mid);
+  memberDesc->type(dtInt);
+
+  DynamicTypeMemberImpl* member = new DynamicTypeMemberImpl;
+  member->set_descriptor(memberDesc);
+  return member;
+}
+
+DynamicTypeMember_var memberForServiceCleanupDelay()
+{
+  TypeDescriptor_var tdDuration = new TypeDescriptorImpl;
+  tdDuration->kind(TK_STRUCTURE);
+  tdDuration->name("DDS::Duration_t");
+
+  DynamicTypeImpl* dtDuration = new DynamicTypeImpl;
+  DynamicType_var dtvar = dtDuration;
+  dtDuration->set_descriptor(tdDuration);
+  dtDuration->insert_dynamic_member(integerMember(TK_INT32, "sec", 0));
+  dtDuration->insert_dynamic_member(integerMember(TK_UINT32, "nanosec", 1));
+
+  MemberDescriptor_var memberDesc = new MemberDescriptorImpl;
+  memberDesc->name("service_cleanup_delay");
+  memberDesc->id(0);
+  memberDesc->index(0);
+  memberDesc->type(dtDuration);
+
+  DynamicTypeMemberImpl* member = new DynamicTypeMemberImpl;
+  member->set_descriptor(memberDesc);
+  return member;
+}
+
+DynamicTypeMember_var memberForHistoryKind()
+{
+  DynamicTypeImpl* dtKind = new DynamicTypeImpl;
+  DynamicType_var dtvar = dtKind;
+  addEnumerator(dtKind, KEEP_LAST_HISTORY_QOS, "KEEP_LAST_HISTORY_QOS");
+  addEnumerator(dtKind, KEEP_ALL_HISTORY_QOS, "KEEP_ALL_HISTORY_QOS");
+
+  TypeDescriptor_var tdKind = new TypeDescriptorImpl;
+  tdKind->kind(TK_ENUM);
+  tdKind->name("DDS::HistoryQosPolicyKind");
+  tdKind->bound().length(1);
+  tdKind->bound()[0] = 32;
+  dtKind->set_descriptor(tdKind);
+
+  MemberDescriptor_var memberKindDesc = new MemberDescriptorImpl;
+  memberKindDesc->name("history_kind");
+  memberKindDesc->id(1);
+  memberKindDesc->index(1);
+  memberKindDesc->type(dtKind);
+
+  DynamicTypeMemberImpl* memberKindImpl = new DynamicTypeMemberImpl;
+  memberKindImpl->set_descriptor(memberKindDesc);
+  return memberKindImpl;
+}
+
+DynamicTypeMember_var memberForDurabilityService()
+{
+  TypeDescriptor_var tdDurabilityServiceQosPolicy = new TypeDescriptorImpl;
+  tdDurabilityServiceQosPolicy->kind(TK_STRUCTURE);
+  tdDurabilityServiceQosPolicy->name("DDS::DurabilityServiceQosPolicy");
+
+  DynamicTypeImpl* dtDurabilityServiceQosPolicy = new DynamicTypeImpl;
+  DynamicType_var dtvar = dtDurabilityServiceQosPolicy;
+  dtDurabilityServiceQosPolicy->set_descriptor(tdDurabilityServiceQosPolicy);
+  dtDurabilityServiceQosPolicy->insert_dynamic_member(memberForServiceCleanupDelay());
+  dtDurabilityServiceQosPolicy->insert_dynamic_member(memberForHistoryKind());
+  dtDurabilityServiceQosPolicy->insert_dynamic_member(integerMember(TK_INT32, "history_depth", 2));
+  dtDurabilityServiceQosPolicy->insert_dynamic_member(integerMember(TK_INT32, "max_samples", 3));
+  dtDurabilityServiceQosPolicy->insert_dynamic_member(integerMember(TK_INT32, "max_instances", 4));
+  dtDurabilityServiceQosPolicy->insert_dynamic_member(integerMember(TK_INT32, "max_samples_per_instance", 5));
+
+  MemberDescriptor_var memberDurabilityServiceDesc = new MemberDescriptorImpl;
+  memberDurabilityServiceDesc->name("durability_service");
+  memberDurabilityServiceDesc->id(2);
+  memberDurabilityServiceDesc->index(2);
+  memberDurabilityServiceDesc->type(dtDurabilityServiceQosPolicy);
+
+  DynamicTypeMemberImpl* memberDurabilityServiceImpl = new DynamicTypeMemberImpl;
+  memberDurabilityServiceImpl->set_descriptor(memberDurabilityServiceDesc);
+  return memberDurabilityServiceImpl;
+}
+
+DynamicType* DummyTypeSupport::get_type() const
+{
+  TypeDescriptor_var td = new TypeDescriptorImpl;
+  td->kind(TK_STRUCTURE);
+  td->name("TBTD");
+
+  DynamicTypeImpl* dt = new DynamicTypeImpl;
+  dt->set_descriptor(td);
+  dt->insert_dynamic_member(memberForName());
+  dt->insert_dynamic_member(memberForDurability());
+  dt->insert_dynamic_member(memberForDurabilityService());
+  return dt;
+}

--- a/tests/DCPS/FilterExpression/FilterStructDynamicTypeSupport.h
+++ b/tests/DCPS/FilterExpression/FilterStructDynamicTypeSupport.h
@@ -3,6 +3,7 @@
 // FilterStruct.idl includes DdsDcpsInfrastructure.idl which doesn't have -Gxtypes-complete
 
 struct DummyTypeSupport : OpenDDS::DCPS::TypeSupportImpl {
+  ~DummyTypeSupport();
 
   // DDS::TypeSupport
   DDS::ReturnCode_t register_type(DDS::DomainParticipant*, const char*) { return DDS::RETCODE_UNSUPPORTED; }
@@ -31,5 +32,7 @@ struct DummyTypeSupport : OpenDDS::DCPS::TypeSupportImpl {
   const OpenDDS::XTypes::TypeMap& getMinimalTypeMap() const;
   const OpenDDS::XTypes::TypeIdentifier& getCompleteTypeIdentifier() const;
   const OpenDDS::XTypes::TypeMap& getCompleteTypeMap() const;
+
+  mutable DDS::DynamicType_var dt_;
 };
 

--- a/tests/DCPS/FilterExpression/FilterStructDynamicTypeSupport.h
+++ b/tests/DCPS/FilterExpression/FilterStructDynamicTypeSupport.h
@@ -1,0 +1,35 @@
+#include <dds/DCPS/TypeSupportImpl.h>
+
+// FilterStruct.idl includes DdsDcpsInfrastructure.idl which doesn't have -Gxtypes-complete
+
+struct DummyTypeSupport : OpenDDS::DCPS::TypeSupportImpl {
+
+  // DDS::TypeSupport
+  DDS::ReturnCode_t register_type(DDS::DomainParticipant*, const char*) { return DDS::RETCODE_UNSUPPORTED; }
+  char* get_type_name() { return CORBA::string_dup("TBTD"); }
+  DDS::DynamicType* get_type() { return static_cast<const DummyTypeSupport*>(this)->get_type(); }
+
+  // OpenDDS::DCPS::TypeSupport
+  DDS::DataWriter* create_datawriter() { return 0; }
+  DDS::DataReader* create_datareader() { return 0; }
+  DDS::DataReader* create_multitopic_datareader() { return 0; }
+  bool has_dcps_key() { return false; }
+  DDS::ReturnCode_t unregister_type(DDS::DomainParticipant*, const char*) { return DDS::RETCODE_UNSUPPORTED; }
+  void representations_allowed_by_type(DDS::DataRepresentationIdSeq&) {}
+
+  // TypeSupportImpl
+  const OpenDDS::DCPS::MetaStruct& getMetaStructForType() const;
+  const char* name() const { return "TBTD"; }
+  DDS::DynamicType* get_type() const;
+  size_t key_count() const { return 0; }
+  bool is_dcps_key(const char*) const { return false; }
+  OpenDDS::DCPS::SerializedSizeBound serialized_size_bound(const OpenDDS::DCPS::Encoding& encoding) const;
+  OpenDDS::DCPS::SerializedSizeBound key_only_serialized_size_bound(const OpenDDS::DCPS::Encoding& encoding) const;
+  OpenDDS::DCPS::Extensibility base_extensibility() const;
+  OpenDDS::DCPS::Extensibility max_extensibility() const;
+  OpenDDS::XTypes::TypeIdentifier& getMinimalTypeIdentifier() const;
+  const OpenDDS::XTypes::TypeMap& getMinimalTypeMap() const;
+  const OpenDDS::XTypes::TypeIdentifier& getCompleteTypeIdentifier() const;
+  const OpenDDS::XTypes::TypeMap& getCompleteTypeMap() const;
+};
+

--- a/tests/DCPS/QueryCondition/QueryConditionTest.cpp
+++ b/tests/DCPS/QueryCondition/QueryConditionTest.cpp
@@ -587,6 +587,7 @@ bool run_sorting_test(const MessageTypeSupport_var& ts, const Publisher_var& pub
   MessageDataWriter_var mdw = MessageDataWriter::_narrow(dw);
   Message sample;
   sample.key = 0;
+  sample.iteration = 0;
   sample.name = "data_X";
   sample.nest.value = B;
   for (int i(0); i < 20; ++i, ++sample.key) {

--- a/tests/unit-tests/dds/DCPS/XTypes/DynamicDataImpl.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/DynamicDataImpl.cpp
@@ -3112,4 +3112,46 @@ TEST(dds_DCPS_XTypes_DynamicDataImpl, Union_Setter)
   EXPECT_EQ(DDS::RETCODE_OK, data.get_int32_value(disc, XTypes::DISCRIMINATOR_ID));
   EXPECT_EQ(static_cast<int>(DynamicDataImpl::E_INT16), disc);
 }
+
+TEST(dds_DCPS_XTypes_DynamicDataImpl, Enum_As_String)
+{
+  const XTypes::TypeIdentifier& ti = DCPS::getCompleteTypeIdentifier<DCPS::DynamicDataImpl_FinalSingleValueStruct_xtag>();
+  const XTypes::TypeMap& type_map = DCPS::getCompleteTypeMap<DCPS::DynamicDataImpl_FinalSingleValueStruct_xtag>();
+  const XTypes::TypeMap::const_iterator it = type_map.find(ti);
+  EXPECT_NE(it, type_map.end());
+
+  XTypes::TypeLookupService tls;
+  tls.add(type_map.begin(), type_map.end());
+  DDS::DynamicType_var dt = tls.complete_to_dynamic(it->second.complete, DCPS::GUID_t());
+  EXPECT_TRUE(dt);
+
+  XTypes::DynamicDataImpl data(dt);
+  static const DDS::MemberId MID_my_enum = 0u;
+  EXPECT_EQ(DDS::RETCODE_OK, data.set_int32_value(MID_my_enum, static_cast<int>(E_UINT64)));
+
+  DDS::String8_var str;
+  EXPECT_EQ(DDS::RETCODE_OK, data.get_string_value(str, MID_my_enum));
+  EXPECT_STREQ("E_UINT64", str.in());
+}
+
+TEST(dds_DCPS_XTypes_DynamicDataImpl, String_As_Enum)
+{
+  const XTypes::TypeIdentifier& ti = DCPS::getCompleteTypeIdentifier<DCPS::DynamicDataImpl_FinalSingleValueStruct_xtag>();
+  const XTypes::TypeMap& type_map = DCPS::getCompleteTypeMap<DCPS::DynamicDataImpl_FinalSingleValueStruct_xtag>();
+  const XTypes::TypeMap::const_iterator it = type_map.find(ti);
+  EXPECT_NE(it, type_map.end());
+
+  XTypes::TypeLookupService tls;
+  tls.add(type_map.begin(), type_map.end());
+  DDS::DynamicType_var dt = tls.complete_to_dynamic(it->second.complete, DCPS::GUID_t());
+  EXPECT_TRUE(dt);
+
+  XTypes::DynamicDataImpl data(dt);
+  static const DDS::MemberId MID_my_enum = 0u;
+  EXPECT_EQ(DDS::RETCODE_OK, data.set_string_value(MID_my_enum, "E_UINT64"));
+
+  DDS::Int32 eval;
+  EXPECT_EQ(DDS::RETCODE_OK, data.get_int32_value(eval, MID_my_enum));
+  EXPECT_EQ(static_cast<int>(E_UINT64), eval);
+}
 #endif // OPENDDS_SAFETY_PROFILE


### PR DESCRIPTION
Also used by content filtering to compare enum members to query string literals/parameters.