### PR TITLE
Fixes for new Atomic template types for pre-C++11 Windows builds

### DIFF
--- a/dds/DCPS/TopicDescriptionImpl.h
+++ b/dds/DCPS/TopicDescriptionImpl.h
@@ -86,7 +86,7 @@ protected:
   OpenDDS::DCPS::TypeSupport_var type_support_;
 
   /// The number of entities using this topic
-  Atomic<uint32_t> entity_refs_;
+  Atomic<ACE_UINT32> entity_refs_;
 };
 
 template <typename Topic>

--- a/dds/DCPS/WriterInfo.h
+++ b/dds/DCPS/WriterInfo.h
@@ -238,7 +238,7 @@ private:
   DDS::InstanceHandle_t handle_;
 
   /// Number of received coherent changes in active change set.
-  Atomic<uint32_t> coherent_samples_;
+  Atomic<ACE_UINT32> coherent_samples_;
 
   /// Is this writer evaluated for owner ?
   typedef OPENDDS_MAP(DDS::InstanceHandle_t, bool) OwnerEvaluateFlags;


### PR DESCRIPTION
### Problem
Some of the Atomic types were inconsistent between C++11 and pre-C++11 builds, and older versions of Visual Studio are not happy with the new standard fixed size integral types.

### Solution
Use ACE's fixed size types instead.