### PR TITLE
Fix Random LargeSample Shmem Failures

### DIFF
--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -1005,7 +1005,7 @@ TransportClient::send_i(SendStateDataSampleList send_list, ACE_UINT64 transactio
         VDBG_LVL((LM_DEBUG,"(%P|%t) DBG: Found DataLinkSet. Sending element %@.\n"
                   , cur), 5);
 
-  #ifndef OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE
+#ifndef OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE
 
         // Content-Filtering adjustment to the pub_links:
         // - If the sample should be filtered out of all subscriptions on a given
@@ -1057,7 +1057,7 @@ TransportClient::send_i(SendStateDataSampleList send_list, ACE_UINT64 transactio
           pub_links = subset;
         }
 
-  #endif /* OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE */
+#endif
 
         // This will do several things, including adding to the membership
         // of the send_links set.  Any DataLinks added to the send_links

--- a/dds/DCPS/transport/shmem/ShmemInst.cpp
+++ b/dds/DCPS/transport/shmem/ShmemInst.cpp
@@ -19,13 +19,15 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
+const TimeDuration ShmemInst::default_association_resend_period(0, 250000);
+
 ShmemInst::ShmemInst(const std::string& name)
   : TransportInst("shmem", name)
   , pool_size_(16 * 1024 * 1024)
   , datalink_control_size_(4 * 1024)
   , hostname_(get_fully_qualified_hostname())
-  , association_resend_period_(0, DEFAULT_ASSOCIATION_RESEND_PERIOD_USEC)
-  , association_resend_max_count_(DEFAULT_ASSOCIATION_RESEND_MAX_COUNT)
+  , association_resend_period_(default_association_resend_period)
+  , association_resend_max_count_(default_association_resend_max_count)
 {
   std::ostringstream pool;
   pool << "OpenDDS-" << ACE_OS::getpid() << '-' << this->name();

--- a/dds/DCPS/transport/shmem/ShmemInst.h
+++ b/dds/DCPS/transport/shmem/ShmemInst.h
@@ -19,9 +19,8 @@ namespace DCPS {
 
 class OpenDDS_Shmem_Export ShmemInst : public TransportInst {
 public:
-
-  static const suseconds_t DEFAULT_ASSOCIATION_RESEND_PERIOD_USEC = 250000;
-  static const long DEFAULT_ASSOCIATION_RESEND_MAX_COUNT = 10;
+  static const TimeDuration default_association_resend_period;
+  static const size_t default_association_resend_max_count = 10;
 
   virtual int load(ACE_Configuration_Heap& cf,
                    ACE_Configuration_Section_Key& sect);

--- a/dds/DCPS/transport/shmem/ShmemSendStrategy.cpp
+++ b/dds/DCPS/transport/shmem/ShmemSendStrategy.cpp
@@ -50,7 +50,7 @@ ShmemSendStrategy::start_i()
 
   ShmemData* data = reinterpret_cast<ShmemData*>(mem);
   const size_t limit = (extra >= sizeof(int)) ? n_elems : (n_elems - 1);
-  data[limit].status_ = SHMEM_DATA_END_OF_ALLOC;
+  data[limit].status_ = ShmemData::EndOfAlloc;
   alloc->bind(bound_name_.c_str(), mem);
 
   ShmemAllocator* peer = link_->peer_allocator();
@@ -125,13 +125,13 @@ ShmemSendStrategy::send_bytes_i(const iovec iov[], int n)
   }
 
   for (ShmemData* iter = reinterpret_cast<ShmemData*>(mem);
-       iter->status_ != SHMEM_DATA_END_OF_ALLOC; ++iter) {
-    if (iter->status_ == SHMEM_DATA_RECV_DONE) {
+       iter->status_ != ShmemData::EndOfAlloc; ++iter) {
+    if (iter->status_ == ShmemData::RecvDone) {
       alloc->free(iter->payload_);
       // This will eventually be refcounted so instead of a free(), the previous
       // statement would decrement the refcount and check for 0 before free().
       // See the 'FUTURE' comment above.
-      iter->status_ = SHMEM_DATA_FREE;
+      iter->status_ = ShmemData::Free;
       VDBG_LVL((LM_DEBUG, "(%P|%t) ShmemSendStrategy for link %@ "
                 "releasing control block #%d\n", link_,
                 iter - reinterpret_cast<ShmemData*>(mem)), 5);
@@ -142,8 +142,8 @@ ShmemSendStrategy::send_bytes_i(const iovec iov[], int n)
     current_data_ = reinterpret_cast<ShmemData*>(mem);
   }
 
-  for (ShmemData* start = 0; current_data_->status_ == SHMEM_DATA_IN_USE ||
-         current_data_->status_ == SHMEM_DATA_RECV_DONE; ++current_data_) {
+  for (ShmemData* start = 0; current_data_->status_ == ShmemData::InUse ||
+         current_data_->status_ == ShmemData::RecvDone; ++current_data_) {
     if (!start) {
       start = current_data_;
     } else if (start == current_data_) {
@@ -151,12 +151,12 @@ ShmemSendStrategy::send_bytes_i(const iovec iov[], int n)
                 "space for control\n", link_), 0);
       return -1;
     }
-    if (current_data_[1].status_ == SHMEM_DATA_END_OF_ALLOC) {
+    if (current_data_[1].status_ == ShmemData::EndOfAlloc) {
       current_data_ = reinterpret_cast<ShmemData*>(mem) - 1; // incremented by the for loop
     }
   }
 
-  if (current_data_->status_ == SHMEM_DATA_FREE) {
+  if (current_data_->status_ == ShmemData::Free) {
     VDBG((LM_DEBUG, "(%P|%t) ShmemSendStrategy for link %@ "
           "writing at control block #%d header %@ payload %@ len %B\n",
           link_, current_data_ - reinterpret_cast<ShmemData*>(mem),
@@ -164,7 +164,7 @@ ShmemSendStrategy::send_bytes_i(const iovec iov[], int n)
     std::memcpy(current_data_->transport_header_, iov[0].iov_base,
                 sizeof(current_data_->transport_header_));
     current_data_->payload_ = payload;
-    current_data_->status_ = SHMEM_DATA_IN_USE;
+    current_data_->status_ = ShmemData::InUse;
   } else {
     VDBG_LVL((LM_ERROR, "(%P|%t) ERROR: ShmemSendStrategy for link %@ "
               "failed to find space for control\n", link_), 0);

--- a/dds/DCPS/transport/shmem/ShmemTransport.cpp
+++ b/dds/DCPS/transport/shmem/ShmemTransport.cpp
@@ -44,14 +44,40 @@ ShmemTransport::make_datalink(const std::string& remote_address)
 {
   ShmemDataLink_rch link = make_rch<ShmemDataLink>(rchandle_from(this));
 
-  // Open logical connection:
-  if (link->open(remote_address))
-    return link;
+  if (!link->open(remote_address)) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: ShmemTransport::make_datalink: "
+      "failed to open DataLink!\n"));
+    return ShmemDataLink_rch();
+  }
 
-  ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: ")
-             ACE_TEXT("ShmemTransport::make_datalink: ")
-             ACE_TEXT("failed to open DataLink!\n")));
-  return ShmemDataLink_rch();
+  if (!links_.insert(ShmemDataLinkMap::value_type(remote_address, link)).second) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: ShmemTransport::make_datalink: "
+      "there is an existing link for %C!\n", remote_address.c_str()));
+    return ShmemDataLink_rch();
+  }
+
+  return link;
+}
+
+ShmemDataLink_rch ShmemTransport::get_or_make_datalink(
+  const char* caller, const RemoteTransport& remote)
+{
+  const std::pair<std::string, std::string> key = blob_to_key(remote.blob_);
+  ShmemInst_rch cfg = config();
+  if (!cfg || key.first != cfg->hostname()) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: ShmemTransport::get_or_make_datalink: "
+               "%C link %C:%C not found, hostname %C.\n",
+               caller, key.first.c_str(), key.second.c_str(),
+               cfg ? cfg->hostname().c_str() : "(no config)"));
+    return ShmemDataLink_rch();
+  }
+
+  GuardType guard(links_lock_);
+  ShmemDataLinkMap::iterator iter = links_.find(key.second);
+  const bool make = iter == links_.end();
+  VDBG_LVL((LM_DEBUG, "(%P|%t) ShmemTransport::get_or_make_datalink: %C using %C link %C:%C\n",
+            caller, make ? "new" : "existing", key.first.c_str(), key.second.c_str()), 2);
+  return make ? make_datalink(key.second) : iter->second;
 }
 
 TransportImpl::AcceptConnectResult
@@ -59,36 +85,16 @@ ShmemTransport::connect_datalink(const RemoteTransport& remote,
                                  const ConnectionAttribs&,
                                  const TransportClient_rch& client)
 {
-  const std::pair<std::string, std::string> key = blob_to_key(remote.blob_);
-  ShmemInst_rch cfg = config();
-  if (!cfg || key.first != cfg->hostname()) {
-    VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::connect_datalink ")
-              ACE_TEXT("link %C:%C not found, hostname %C.\n"),
-              key.first.c_str(), key.second.c_str(), cfg->hostname().c_str()), 2);
+  ShmemDataLink_rch link = get_or_make_datalink("connect_datalink", remote);
+  if (!link) {
     return AcceptConnectResult();
   }
-  GuardType guard(links_lock_);
-  ShmemDataLinkMap::iterator iter = links_.find(key.second);
-  if (iter != links_.end()) {
-    ShmemDataLink_rch link = iter->second;
-    VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::connect_datalink ")
-              ACE_TEXT("link %C:%C found.\n"), key.first.c_str(), key.second.c_str()), 2);
-    return AcceptConnectResult(link);
-  }
-  VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::connect_datalink ")
-            ACE_TEXT("new link %C:%C.\n"), key.first.c_str(), key.second.c_str()), 2);
-  ShmemDataLink_rch link = add_datalink(key.second);
+  // Wait for invoke_on_start_callbacks to actually start a writer. This is done
+  // when the writer gets an association message from the reader in the writer
+  // case of ShmemDataLink::request_ack_received.
   link->add_on_start_callback(client, remote.repo_id_);
   add_pending_connection(client, link);
   return AcceptConnectResult(AcceptConnectResult::ACR_SUCCESS);
-}
-
-ShmemDataLink_rch
-ShmemTransport::add_datalink(const std::string& remote_address)
-{
-  ShmemDataLink_rch link = make_datalink(remote_address);
-  links_.insert(ShmemDataLinkMap::value_type(remote_address, link));
-  return link;
 }
 
 TransportImpl::AcceptConnectResult
@@ -96,31 +102,14 @@ ShmemTransport::accept_datalink(const RemoteTransport& remote,
                                 const ConnectionAttribs& /*attribs*/,
                                 const TransportClient_rch& /*client*/)
 {
-  const std::pair<std::string, std::string> key = blob_to_key(remote.blob_);
-  ShmemInst_rch cfg = config();
-  if (!cfg || key.first != cfg->hostname()) {
-    VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::accept_datalink ")
-              ACE_TEXT("link %C:%C not found, hostname %C.\n"),
-              key.first.c_str(), key.second.c_str(), cfg->hostname().c_str()), 2);
-    return AcceptConnectResult();
-  }
-  GuardType guard(links_lock_);
-  ShmemDataLinkMap::iterator iter = links_.find(key.second);
-  if (iter != links_.end()) {
-    ShmemDataLink_rch link = iter->second;
-    VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::accept_datalink ")
-              ACE_TEXT("link %C:%C found.\n"), key.first.c_str(), key.second.c_str()), 2);
-    return AcceptConnectResult(link);
-  }
-  VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) ShmemTransport::accept_datalink ")
-            ACE_TEXT("new link %C:%C.\n"), key.first.c_str(), key.second.c_str()), 2);
-  return AcceptConnectResult(add_datalink(key.second));
+  return AcceptConnectResult(get_or_make_datalink("accept_datalink", remote));
 }
 
-void
-ShmemTransport::stop_accepting_or_connecting(const TransportClient_wrch&, const GUID_t&, bool, bool)
+void ShmemTransport::stop_accepting_or_connecting(
+  const TransportClient_wrch& /*client*/, const GUID_t& /*remote_id*/,
+  bool /*disassociate*/, bool /*association_failed*/)
 {
-  // no-op: accept and connect either complete or fail immediately
+  // TODO: Remove any pending association message resends
 }
 
 bool

--- a/dds/DCPS/transport/shmem/ShmemTransport.h
+++ b/dds/DCPS/transport/shmem/ShmemTransport.h
@@ -60,12 +60,10 @@ protected:
   virtual std::string transport_type() const { return "shmem"; }
 
 private:
-
-  /// Create a new link (using make_datalink) and add it to the map
-  ShmemDataLink_rch add_datalink(const std::string& remote_address);
-
   /// Create the DataLink object and start it
   ShmemDataLink_rch make_datalink(const std::string& remote_address);
+
+  ShmemDataLink_rch get_or_make_datalink(const char* caller, const RemoteTransport& remote);
 
   std::pair<std::string, std::string> blob_to_key(const TransportBLOB& blob);
 

--- a/tests/DCPS/LargeSample/DataReaderListener.cpp
+++ b/tests/DCPS/LargeSample/DataReaderListener.cpp
@@ -59,6 +59,7 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
                                                DDS::ANY_INSTANCE_STATE);
 
     if (error == DDS::RETCODE_OK) {
+      ACE_GUARD(ACE_Thread_Mutex, guard, lock_);
 
       for (unsigned int i = 0; i < messages.length(); ++i) {
         const DDS::SampleInfo& si = info[i];
@@ -187,6 +188,8 @@ void DataReaderListenerImpl::on_sample_lost(
 
 bool DataReaderListenerImpl::data_consistent() const
 {
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, lock_, false);
+
   bool valid_and_done = valid_;
   if (process_writers_.size() != writer_process_count_) {
     std::cout << "ERROR: expect to receive data from " << writer_process_count_

--- a/tests/DCPS/LargeSample/DataReaderListener.h
+++ b/tests/DCPS/LargeSample/DataReaderListener.h
@@ -56,13 +56,15 @@ public:
 
   size_t num_samples() const
   {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, lock_, SIZE_MAX);
     return num_samples_;
   }
 
   bool data_consistent() const;
 
 private:
-  DDS::DataReader_var  reader_;
+  mutable ACE_Thread_Mutex lock_;
+  DDS::DataReader_var reader_;
   size_t num_samples_;
   typedef CORBA::Long ProcessId, WriterId, SampleId;
   typedef std::set<SampleId> Counts;


### PR DESCRIPTION
An initial message exchange [was previously added](https://github.com/OpenDDS/OpenDDS/pull/3549) to shared memory association that went from the reader to the writer and back to indicate to the writer that it could start. After this was added occasionally the LargeSample shared memory test would fail.

The main cause of this was a broken less than operator for a map tracking writers that readers should resend association messages to. Another cause that probably occurred a smaller part of the time was an unanticipated call path on the writer side that sent an acknowledgement message to the reader that messed up the exchange. The fix for this was to adjust how the writer association messages were sent and how data links were created.

Also:
- Some refactoring in Shmem, especially in `ShmemTransport` to cleanup shared code between `accept_datalink` and `connect_datalink`.
- Fix a data race TSAN identified in the LargeSample test