### PR TITLE
GitHub Actions: Moved the part of build_w22_x86_i0_j_FM-1f that builds CMake tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10214,15 +10214,6 @@ jobs:
         cd OpenDDS
         call setenv.cmd
         msbuild -p:Configuration=Debug,Platform=Win32 -m DDS.sln
-    - name: Build CMake Tests
-      shell: cmd
-      run: |
-        cd OpenDDS
-        call setenv.cmd
-        mkdir C:\tests\cmake\build
-        cd /d C:\tests\cmake\build
-        cmake -A Win32 %DDS_ROOT%\tests\cmake
-        cmake --build .
     - name: create OpenDDS tar.xz artifact
       shell: bash
       run: |
@@ -10236,17 +10227,6 @@ jobs:
       with:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
-    - name: create tests tar.xz artifact
-      shell: bash
-      run: |
-        find /c/tests -iname "*\.obj" -o -iname "*\.pdb" -o -iname "*\.idb" -o -type f -iname "*\.tlog" | xargs rm
-        tar cvPf tests_${{ github.job }}.tar /c/tests
-        xz -3 tests_${{ github.job }}.tar
-    - name: upload tests artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: tests_${{ github.job }}_artifact
-        path: tests_${{ github.job }}.tar.xz
 
   cmake_w22_x86_i0_j_FM-1f:
 
@@ -10313,25 +10293,24 @@ jobs:
         cd OpenDDS
         tar xvfJ build_w22_x86_i0_j_FM-1f.tar.xz
         rm -f build_w22_x86_i0_j_FM-1f.tar.xz
-    - name: download tests artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: tests_build_w22_x86_i0_j_FM-1f_artifact
-        path: OpenDDS
-    - name: extract tests artifact
-      shell: bash
-      run: |
-        cd OpenDDS
-        tar xvPfJ tests_build_w22_x86_i0_j_FM-1f.tar.xz
-        rm -f tests_build_w22_x86_i0_j_FM-1f.tar.xz
     - name: set up msvc env
       uses: ilammy/msvc-dev-cmd@v1
+    - uses: ammaraskar/msvc-problem-matcher@0.2.0
     - name: check build configuration
       shell: cmd
       run: |
         cd OpenDDS
         call setenv.cmd
         perl tools\scripts\show_build_config.pl
+    - name: Build CMake Tests
+      shell: cmd
+      run: |
+        cd OpenDDS
+        call setenv.cmd
+        mkdir C:\tests\cmake\build
+        cd /d C:\tests\cmake\build
+        cmake -A Win32 %DDS_ROOT%\tests\cmake
+        cmake --build .
     - name: create autobuild config
       shell: bash
       run: |


### PR DESCRIPTION
This may avoid running of space during the build