### PR TITLE
[Bench] Improve Worker ForwardAction Queue Locking Performance

### DIFF
--- a/performance-tests/bench/node_controller/main.cpp
+++ b/performance-tests/bench/node_controller/main.cpp
@@ -362,7 +362,7 @@ public:
       int index = 0;
       for (auto spawned_process_i : all_spawned_processes_) {
         auto& spawned_process = spawned_process_i.second;
-        pid_t pid = process_manager_->spawn(*spawned_proc_opts[index]);
+        const pid_t pid = process_manager_->spawn(*spawned_proc_opts[index]);
         if (log_handles[index] != ACE_INVALID_HANDLE) {
           ACE_OS::close(log_handles[index]);
         }

--- a/performance-tests/bench/worker/ForwardAction.h
+++ b/performance-tests/bench/worker/ForwardAction.h
@@ -40,6 +40,7 @@ protected:
   std::mutex mutex_;
   ACE_Proactor& proactor_;
   bool started_, stopped_;
+  bool write_task_active_;
   std::vector<std::shared_ptr<Registration> > registrations_;
   std::vector<DataDataWriter_var> data_dws_;
   std::mt19937_64 mt_;


### PR DESCRIPTION
### Problem
ForwardAction writes currently taking place under lock, preventing reads from updating queue and returning (potentially blocking transport reactor threads).

### Solution
Copy and/or swap data out of the queue before writing in order to be able to release action's lock.