### PR TITLE
Secure writer and reader in same participant do not associate

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -7568,7 +7568,7 @@ void Sedp::match_continue_security_enabled(
   const GUID_t& writer, const GUID_t& reader, bool call_writer, bool call_reader)
 {
   DDS::Security::CryptoKeyExchange_var keyexg = get_crypto_key_exchange();
-  if (call_reader) {
+  if (call_reader && !call_writer) {
     const DDS::Security::DatareaderCryptoHandle drch =
       get_handle_registry()->get_local_datareader_crypto_handle(reader);
     const DDS::Security::EndpointSecurityAttributes attribs =
@@ -7598,7 +7598,7 @@ void Sedp::match_continue_security_enabled(
     }
   }
 
-  if (call_writer) {
+  if (call_writer && !call_reader) {
     const DDS::Security::DatawriterCryptoHandle dwch =
       get_handle_registry()->get_local_datawriter_crypto_handle(writer);
     const DDS::Security::EndpointSecurityAttributes attribs =

--- a/tests/security/SingleParticipantWithSecurity/governance.xml
+++ b/tests/security/SingleParticipantWithSecurity/governance.xml
@@ -5,25 +5,33 @@
 -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-SECURITY/20170901/omg_shared_ca_permissions.xsd">
   <domain_access_rules>
-    <!-- Domain 4 is an "open domain" -->
     <domain_rule>
       <domains>
         <id>4</id>
       </domains>
-      <allow_unauthenticated_participants>true</allow_unauthenticated_participants>
-      <enable_join_access_control>false</enable_join_access_control>
-      <discovery_protection_kind>NONE</discovery_protection_kind>
-      <liveliness_protection_kind>NONE</liveliness_protection_kind>
-      <rtps_protection_kind>NONE</rtps_protection_kind>
+      <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+      <enable_join_access_control>true</enable_join_access_control>
+      <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
+      <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+      <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
       <topic_access_rules>
         <topic_rule>
           <topic_expression>*</topic_expression>
-          <enable_discovery_protection>false</enable_discovery_protection>
-          <enable_liveliness_protection>false</enable_liveliness_protection>
+          <enable_discovery_protection>true</enable_discovery_protection>
+          <enable_liveliness_protection>true</enable_liveliness_protection>
+          <enable_read_access_control>true</enable_read_access_control>
+          <enable_write_access_control>true</enable_write_access_control>
+          <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+          <data_protection_kind>ENCRYPT</data_protection_kind>
+        </topic_rule>
+        <topic_rule>
+          <topic_expression>Work Around for check_create_participant_bug</topic_expression>
+          <enable_discovery_protection>true</enable_discovery_protection>
+          <enable_liveliness_protection>true</enable_liveliness_protection>
           <enable_read_access_control>false</enable_read_access_control>
           <enable_write_access_control>false</enable_write_access_control>
-          <metadata_protection_kind>NONE</metadata_protection_kind>
-          <data_protection_kind>NONE</data_protection_kind>
+          <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+          <data_protection_kind>ENCRYPT</data_protection_kind>
         </topic_rule>
       </topic_access_rules>
     </domain_rule>

--- a/tests/security/SingleParticipantWithSecurity/governance_signed.p7s
+++ b/tests/security/SingleParticipantWithSecurity/governance_signed.p7s
@@ -1,9 +1,9 @@
 MIME-Version: 1.0
-Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha1"; boundary="----B00CC7D2DB0442C38E8880D89D30B6E4"
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----3004E4678350193BE6C073BBC4925DCB"
 
 This is an S/MIME signed message
 
-------B00CC7D2DB0442C38E8880D89D30B6E4
+------3004E4678350193BE6C073BBC4925DCB
 Content-Type: text/plain
 
 <?xml version="1.0" encoding="UTF-8"?>
@@ -13,75 +13,83 @@ Content-Type: text/plain
 -->
 <dds xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.omg.org/spec/DDS-SECURITY/20170901/omg_shared_ca_permissions.xsd">
   <domain_access_rules>
-    <!-- Domain 4 is an "open domain" -->
     <domain_rule>
       <domains>
         <id>4</id>
       </domains>
-      <allow_unauthenticated_participants>true</allow_unauthenticated_participants>
-      <enable_join_access_control>false</enable_join_access_control>
-      <discovery_protection_kind>NONE</discovery_protection_kind>
-      <liveliness_protection_kind>NONE</liveliness_protection_kind>
-      <rtps_protection_kind>NONE</rtps_protection_kind>
+      <allow_unauthenticated_participants>false</allow_unauthenticated_participants>
+      <enable_join_access_control>true</enable_join_access_control>
+      <discovery_protection_kind>ENCRYPT</discovery_protection_kind>
+      <liveliness_protection_kind>ENCRYPT</liveliness_protection_kind>
+      <rtps_protection_kind>ENCRYPT</rtps_protection_kind>
       <topic_access_rules>
         <topic_rule>
           <topic_expression>*</topic_expression>
-          <enable_discovery_protection>false</enable_discovery_protection>
-          <enable_liveliness_protection>false</enable_liveliness_protection>
+          <enable_discovery_protection>true</enable_discovery_protection>
+          <enable_liveliness_protection>true</enable_liveliness_protection>
+          <enable_read_access_control>true</enable_read_access_control>
+          <enable_write_access_control>true</enable_write_access_control>
+          <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+          <data_protection_kind>ENCRYPT</data_protection_kind>
+        </topic_rule>
+        <topic_rule>
+          <topic_expression>Work Around for check_create_participant_bug</topic_expression>
+          <enable_discovery_protection>true</enable_discovery_protection>
+          <enable_liveliness_protection>true</enable_liveliness_protection>
           <enable_read_access_control>false</enable_read_access_control>
           <enable_write_access_control>false</enable_write_access_control>
-          <metadata_protection_kind>NONE</metadata_protection_kind>
-          <data_protection_kind>NONE</data_protection_kind>
+          <metadata_protection_kind>ENCRYPT</metadata_protection_kind>
+          <data_protection_kind>ENCRYPT</data_protection_kind>
         </topic_rule>
       </topic_access_rules>
     </domain_rule>
   </domain_access_rules>
 </dds>
 
-------B00CC7D2DB0442C38E8880D89D30B6E4
+------3004E4678350193BE6C073BBC4925DCB
 Content-Type: application/x-pkcs7-signature; name="smime.p7s"
 Content-Transfer-Encoding: base64
 Content-Disposition: attachment; filename="smime.p7s"
 
-MIIHLAYJKoZIhvcNAQcCoIIHHTCCBxkCAQExCzAJBgUrDgMCGgUAMAsGCSqGSIb3
-DQEHAaCCA/gwggP0MIIC3AIJAKSOim/ArjfyMA0GCSqGSIb3DQEBCwUAMIG7MQsw
-CQYDVQQGEwJVUzELMAkGA1UECAwCTU8xFDASBgNVBAcMC1NhaW50IExvdWlzMS8w
-LQYDVQQKDCZPYmplY3QgQ29tcHV0aW5nIChUZXN0IFBlcm1pc3Npb25zIENBKTEv
-MC0GA1UEAwwmT2JqZWN0IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkx
-JzAlBgkqhkiG9w0BCQEWGGluZm9Ab2JqZWN0Y29tcHV0aW5nLmNvbTAeFw0xODA2
-MTMwNDIwMTNaFw0yODA2MTAwNDIwMTNaMIG7MQswCQYDVQQGEwJVUzELMAkGA1UE
-CAwCTU8xFDASBgNVBAcMC1NhaW50IExvdWlzMS8wLQYDVQQKDCZPYmplY3QgQ29t
-cHV0aW5nIChUZXN0IFBlcm1pc3Npb25zIENBKTEvMC0GA1UEAwwmT2JqZWN0IENv
-bXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkxJzAlBgkqhkiG9w0BCQEWGGlu
-Zm9Ab2JqZWN0Y29tcHV0aW5nLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCC
-AQoCggEBAJ3eiwIeyTCJY+SBD4WJQkQ+P2UYBXqCqcb1dxMc/M6y/6GtZySWrhZx
-Ny7kRHGO/DOt8H0xXYmPWaGcBB+nSwi5Ml7hCheKDJ/QjJ7OxIDWh6h+Qm4GUDpx
-H7kBPN80RwkkbexVoRprQv3YJdvXjstzMwxj7oj+MP0f8pqaimHWEKB2HaUadg33
-sRMzFfmog22E7Xv+pnnlH4fmcTY6nV/hjQuGMq7dbO0SMhl4AkOACSyhhHKdWF8O
-yyF1lZQxI7SMckY/AS/HCFOwCSdZ22G4T/GBlCoM/dpePcwUlxmTJ1L7zG+dfRy4
-eyv/sypUrSg6aNZLumLtwwFj0O0HcpUCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEA
-T1BZrXE2PEtYjDzx5WtDE4EIiWoKQCJPHakC6sR2IO3PxlB0MxBCagC6mlPotZVW
-05ZzVs/dr4gcGiU0CKZc6b4H18xK9CepFuuIlnwdzn5jlNeUneLKokMTI+JaFQUt
-9B+eMTyFEvmgo+SGTaBELornH7XRxkxyWASZk40A20C5Im6syHCCovHCAbDnVoik
-votPG11nfcsg8zwA3nVOCPm3ZUz/j2I2r0d2oCXtVC7IcRz94IAinunr2epylL1U
-EkAmgc3yWYMMdjEz6li1ACCYEosHFPIOuAln7ePcVU6nSitHFqsTdeMn7RshWc7r
-KGO6c86mCzIRzEf3/sSebzGCAvwwggL4AgEBMIHJMIG7MQswCQYDVQQGEwJVUzEL
-MAkGA1UECAwCTU8xFDASBgNVBAcMC1NhaW50IExvdWlzMS8wLQYDVQQKDCZPYmpl
-Y3QgQ29tcHV0aW5nIChUZXN0IFBlcm1pc3Npb25zIENBKTEvMC0GA1UEAwwmT2Jq
-ZWN0IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkxJzAlBgkqhkiG9w0B
-CQEWGGluZm9Ab2JqZWN0Y29tcHV0aW5nLmNvbQIJAKSOim/ArjfyMAkGBSsOAwIa
-BQCgggEHMBgGCSqGSIb3DQEJAzELBgkqhkiG9w0BBwEwHAYJKoZIhvcNAQkFMQ8X
-DTIyMDIwNDIwMDE0MVowIwYJKoZIhvcNAQkEMRYEFCJLXtsE/odaiFqPSyo1/6cQ
-3uIwMIGnBgkqhkiG9w0BCQ8xgZkwgZYwCwYJYIZIAWUDBAEqMAgGBiqFAwICCTAK
-BggqhQMHAQECAjAKBggqhQMHAQECAzAIBgYqhQMCAhUwCwYJYIZIAWUDBAEWMAsG
-CWCGSAFlAwQBAjAKBggqhkiG9w0DBzAOBggqhkiG9w0DAgICAIAwDQYIKoZIhvcN
-AwICAUAwBwYFKw4DAgcwDQYIKoZIhvcNAwICASgwDQYJKoZIhvcNAQEBBQAEggEA
-f0dWcMZtCEE+7yyJ1NcudQDchEq3c1U/Z3UmMDIFQY9ynlue7a/iMkI+QpQ9PIp2
-Kx6oKM5cpnutjmdMbP5kyZoEBbHp/Y93XL1xHieRidJ7McWiPTSgu99dvG3Pxh1p
-FGt/p0tLBuF2zAYNjD6HXqgweWeUPihjTzkmq1CoCv8CaoYCCpiMoppzCl2u1sxG
-9qORIobHRbp8MNx8G8WDhEseA6jAlccJq5Of1f/DPLz08Sf7ICTPtOJZeB1bP6Sq
-H44RF/Gm68HzAYuvBDrhDKOjo1AFSooF7sLUcSCa6FPje//Azmv0q70xUufOdPKK
-J29Vr6AkkWFrr6O/ORRlgQ==
+MIIHQAYJKoZIhvcNAQcCoIIHMTCCBy0CAQExDzANBglghkgBZQMEAgEFADALBgkq
+hkiG9w0BBwGgggP4MIID9DCCAtwCCQCkjopvwK438jANBgkqhkiG9w0BAQsFADCB
+uzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAk1PMRQwEgYDVQQHDAtTYWludCBMb3Vp
+czEvMC0GA1UECgwmT2JqZWN0IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBD
+QSkxLzAtBgNVBAMMJk9iamVjdCBDb21wdXRpbmcgKFRlc3QgUGVybWlzc2lvbnMg
+Q0EpMScwJQYJKoZIhvcNAQkBFhhpbmZvQG9iamVjdGNvbXB1dGluZy5jb20wHhcN
+MTgwNjEzMDQyMDEzWhcNMjgwNjEwMDQyMDEzWjCBuzELMAkGA1UEBhMCVVMxCzAJ
+BgNVBAgMAk1PMRQwEgYDVQQHDAtTYWludCBMb3VpczEvMC0GA1UECgwmT2JqZWN0
+IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkxLzAtBgNVBAMMJk9iamVj
+dCBDb21wdXRpbmcgKFRlc3QgUGVybWlzc2lvbnMgQ0EpMScwJQYJKoZIhvcNAQkB
+FhhpbmZvQG9iamVjdGNvbXB1dGluZy5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQCd3osCHskwiWPkgQ+FiUJEPj9lGAV6gqnG9XcTHPzOsv+hrWck
+lq4WcTcu5ERxjvwzrfB9MV2Jj1mhnAQfp0sIuTJe4QoXigyf0IyezsSA1oeofkJu
+BlA6cR+5ATzfNEcJJG3sVaEaa0L92CXb147LczMMY+6I/jD9H/Kamoph1hCgdh2l
+GnYN97ETMxX5qINthO17/qZ55R+H5nE2Op1f4Y0LhjKu3WztEjIZeAJDgAksoYRy
+nVhfDsshdZWUMSO0jHJGPwEvxwhTsAknWdthuE/xgZQqDP3aXj3MFJcZkydS+8xv
+nX0cuHsr/7MqVK0oOmjWS7pi7cMBY9DtB3KVAgMBAAEwDQYJKoZIhvcNAQELBQAD
+ggEBAE9QWa1xNjxLWIw88eVrQxOBCIlqCkAiTx2pAurEdiDtz8ZQdDMQQmoAuppT
+6LWVVtOWc1bP3a+IHBolNAimXOm+B9fMSvQnqRbriJZ8Hc5+Y5TXlJ3iyqJDEyPi
+WhUFLfQfnjE8hRL5oKPkhk2gRC6K5x+10cZMclgEmZONANtAuSJurMhwgqLxwgGw
+51aIpL6LTxtdZ33LIPM8AN51Tgj5t2VM/49iNq9HdqAl7VQuyHEc/eCAIp7p69nq
+cpS9VBJAJoHN8lmDDHYxM+pYtQAgmBKLBxTyDrgJZ+3j3FVOp0orRxarE3XjJ+0b
+IVnO6yhjunPOpgsyEcxH9/7Enm8xggMMMIIDCAIBATCByTCBuzELMAkGA1UEBhMC
+VVMxCzAJBgNVBAgMAk1PMRQwEgYDVQQHDAtTYWludCBMb3VpczEvMC0GA1UECgwm
+T2JqZWN0IENvbXB1dGluZyAoVGVzdCBQZXJtaXNzaW9ucyBDQSkxLzAtBgNVBAMM
+Jk9iamVjdCBDb21wdXRpbmcgKFRlc3QgUGVybWlzc2lvbnMgQ0EpMScwJQYJKoZI
+hvcNAQkBFhhpbmZvQG9iamVjdGNvbXB1dGluZy5jb20CCQCkjopvwK438jANBglg
+hkgBZQMEAgEFAKCCARMwGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAcBgkqhkiG
+9w0BCQUxDxcNMjMwMjE0MDQwMzUzWjAvBgkqhkiG9w0BCQQxIgQgbHXL4/ElrR4g
+jhAxdVc8j17Q7z1ZNjXgtrtTevXIfKAwgacGCSqGSIb3DQEJDzGBmTCBljALBglg
+hkgBZQMEASowCAYGKoUDAgIJMAoGCCqFAwcBAQICMAoGCCqFAwcBAQIDMAgGBiqF
+AwICFTALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMHMA4GCCqG
+SIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggqhkiG9w0DAgIB
+KDANBgkqhkiG9w0BAQEFAASCAQAMBUKLd5hNp/lf4ZrXCP6ScqLudCgem+/Z2rH+
+XVK7PdphBl8BYv+n2eQOezPXSLjkI0bE3edu0uueFZdpD9RfK1BDYIpelNtjSHgS
+YZ0Qlekp156EZRSMwqjudYB22pA4ld5wPo0gh5s6HBi4B5qzYGTKqE7mjrBtitVD
+JR6NenHqSs31IkTEHSPRO2IvBDSqNR/j78/2cKVkVtdeKnNTjmurg4Oyl2JSRNlC
+cJU4EaVMQVGsqsLNwRperudkR/htR9yt33RIEuAuoufbxbR26Wf3yW6P6Zhb+e86
+oR9/b7MrgiPrVdi2pf0rFszGYNL6jioGq1llqFSTR1UfYNCX
 
-------B00CC7D2DB0442C38E8880D89D30B6E4--
+------3004E4678350193BE6C073BBC4925DCB--
 


### PR DESCRIPTION
Problem
-------

A writer and reader in the same participant that uses non-trivial security fail to associate and exchange data.  The SingleParticipantWithSecurity tests this scenario but uses an "open" domain so all of the encryption and decryption logic was skipped.

Solution
--------

* Turn on encryption so that those code paths are exercised in the test.
* Fix code paths that cannot handle a remote writer being local.