### PR TITLE
Add Hardening Features To RtpsRelay

### DIFF
--- a/tools/dds/rtpsrelaylib/Relay.idl
+++ b/tools/dds/rtpsrelaylib/Relay.idl
@@ -173,6 +173,9 @@ module RtpsRelay {
     unsigned long relay_address_pub_count;
     unsigned long spdp_replay_pub_count;
     unsigned long admission_deferral_count;
+    unsigned long remote_map_size;
+    unsigned long max_addr_set_size;
+    unsigned long rejected_address_map_size;
   };
 };
 

--- a/tools/rtpsrelay/Config.h
+++ b/tools/rtpsrelay/Config.h
@@ -33,6 +33,7 @@ public:
     , publish_participant_statistics_(false)
     , restart_detection_(false)
     , admission_control_queue_size_(0)
+    , max_addr_set_size_(0)
   {}
 
   void relay_id(const std::string& value)
@@ -295,6 +296,26 @@ public:
     return run_time_;
   }
 
+  void max_addr_set_size(size_t value)
+  {
+    max_addr_set_size_ = value;
+  }
+
+  size_t max_addr_set_size() const
+  {
+    return max_addr_set_size_;
+  }
+
+  OpenDDS::DCPS::TimeDuration rejected_address_duration() const
+  {
+    return rejected_address_duration_;
+  }
+
+  void rejected_address_duration(OpenDDS::DCPS::TimeDuration value)
+  {
+    rejected_address_duration_ = value;
+  }
+
 private:
   std::string relay_id_;
   OpenDDS::DCPS::GUID_t application_participant_guid_;
@@ -322,6 +343,8 @@ private:
   size_t admission_control_queue_size_;
   OpenDDS::DCPS::TimeDuration admission_control_queue_duration_;
   OpenDDS::DCPS::TimeDuration run_time_;
+  size_t max_addr_set_size_;
+  OpenDDS::DCPS::TimeDuration rejected_address_duration_;
 };
 
 }

--- a/tools/rtpsrelay/GuidAddrSet.cpp
+++ b/tools/rtpsrelay/GuidAddrSet.cpp
@@ -25,6 +25,9 @@ GuidAddrSet::record_activity(const Proxy& proxy,
   if (config_.restart_detection()) {
     Remote remote(remote_address.addr, src_guid);
     const auto result = remote_map_.insert(std::make_pair(remote, src_guid));
+    if (result.second) {
+      relay_stats_reporter_.remote_map_size(remote_map_.size(), now);
+    }
     if (!result.second && result.first->second != src_guid) {
       if (config_.log_activity()) {
         ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: GuidAddrSet::record_activity change detected %C -> %C\n"),
@@ -64,29 +67,32 @@ GuidAddrSet::record_activity(const Proxy& proxy,
   relay_participant_status_reporter_.set_alive_active(proxy, src_guid, true, true);
 
   {
-    AddrSet& addr_set = *addr_set_stats.select_addr_set(remote_address.port);
-    const auto res = addr_set.insert(std::make_pair(remote_address, expiration));
-    if (res.second) {
-      if (config_.log_activity()) {
-        ACE_DEBUG((LM_INFO, "(%P|%t) INFO: GuidAddrSet::record_activity "
-                   "%C %C is at %C %C into session addrs=%B total=%B remote=%B deactivation=%B expire=%B admit=%B\n",
-                   handler.name().c_str(),
-                   guid_to_string(src_guid).c_str(),
-                   OpenDDS::DCPS::LogAddr(remote_address.addr).c_str(),
-                   addr_set_stats.get_session_time(now).sec_str().c_str(),
-                   addr_set.size(),
-                   guid_addr_set_map_.size(),
-                   remote_map_.size(),
-                   deactivation_guid_queue_.size(),
-                   expiration_guid_addr_queue_.size(),
-                   admission_control_queue_.size()));
+    AddrSet& addr_set = *addr_set_stats.select_addr_set(remote_address.port, now);
+    if (config_.max_addr_set_size() == 0 || addr_set.size() <= config_.max_addr_set_size()) {
+      const auto pos = addr_set.find(remote_address);
+      if (pos != addr_set.end()) {
+        pos->second = expiration;
+      } else if (config_.max_addr_set_size() == 0 || addr_set.size() < config_.max_addr_set_size()) {
+        addr_set[remote_address] = expiration;
+        if (config_.log_activity()) {
+          ACE_DEBUG((LM_INFO, "(%P|%t) INFO: GuidAddrSet::record_activity "
+                     "%C %C is at %C %C into session addrs=%B total=%B remote=%B deactivation=%B expire=%B admit=%B\n",
+                     handler.name().c_str(),
+                     guid_to_string(src_guid).c_str(),
+                     OpenDDS::DCPS::LogAddr(remote_address.addr).c_str(),
+                     addr_set_stats.get_session_time(now).sec_str().c_str(),
+                     addr_set.size(),
+                     guid_addr_set_map_.size(),
+                     remote_map_.size(),
+                     deactivation_guid_queue_.size(),
+                     expiration_guid_addr_queue_.size(),
+                     admission_control_queue_.size()));
+        }
+        relay_stats_reporter_.new_address(now);
+        const GuidAddr ga(src_guid, remote_address);
+        expiration_guid_addr_queue_.push_back(std::make_pair(expiration, ga));
       }
-      relay_stats_reporter_.new_address(now);
-
-      const GuidAddr ga(src_guid, remote_address);
-      expiration_guid_addr_queue_.push_back(std::make_pair(expiration, ga));
     }
-    res.first->second = expiration;
   }
 
   ParticipantStatisticsReporter& stats_reporter =
@@ -99,6 +105,24 @@ GuidAddrSet::record_activity(const Proxy& proxy,
 void GuidAddrSet::process_expirations(const Proxy& proxy,
                                       const OpenDDS::DCPS::MonotonicTimePoint& now)
 {
+  bool update_reject_stat = false;
+  auto it = rejected_address_expiration_queue_.begin();
+  while (it != rejected_address_expiration_queue_.end() && (*it)->second < now) {
+    if (config_.log_activity()) {
+      const auto ago = now - (*it)->second;
+      ACE_DEBUG((LM_INFO, "(%P|%t) INFO: GuidAddrSet::process_expirations "
+                 "Rejected address %C expired %C ago, removing from rejeced address map.\n",
+                 OpenDDS::DCPS::LogAddr((*it)->first).c_str(),
+                 ago.str().c_str()));
+    }
+    rejected_address_map_.erase(*it);
+    rejected_address_expiration_queue_.erase(it++);
+    update_reject_stat = true;
+  }
+  if (update_reject_stat) {
+    relay_stats_reporter_.rejected_address_map_size(rejected_address_map_.size(), now);
+  }
+
   while (!deactivation_guid_queue_.empty() && deactivation_guid_queue_.front().first <= now) {
     const OpenDDS::DCPS::MonotonicTimePoint deactivation = deactivation_guid_queue_.front().first;
     const OpenDDS::DCPS::GUID_t guid = deactivation_guid_queue_.front().second;
@@ -133,7 +157,7 @@ void GuidAddrSet::process_expirations(const Proxy& proxy,
     }
 
     AddrSetStats& addr_stats = pos->second;
-    AddrSet& addr_set = *addr_stats.select_addr_set(ga.address.port);
+    AddrSet& addr_set = *addr_stats.select_addr_set(ga.address.port, now);
     const auto p = addr_set.find(ga.address);
     if (p == addr_set.end()) {
       continue;
@@ -141,7 +165,9 @@ void GuidAddrSet::process_expirations(const Proxy& proxy,
 
     if (p->second <= now) {
       addr_set.erase(p);
-      remote_map_.erase(Remote(ga.address.addr, ga.guid));
+      if (remote_map_.erase(Remote(ga.address.addr, ga.guid)) != 0) {
+        relay_stats_reporter_.remote_map_size(remote_map_.size(), now);
+      }
     } else {
       expiration_guid_addr_queue_.push_back(std::make_pair(p->second, ga));
       continue;
@@ -270,6 +296,27 @@ void GuidAddrSet::remove(const Proxy& proxy,
   if (reporter) {
     reporter->set_alive(proxy, guid, false);
   }
+}
+
+void GuidAddrSet::reject_address(const ACE_INET_Addr& addr,
+                                 const OpenDDS::DCPS::MonotonicTimePoint& now)
+{
+  OpenDDS::DCPS::MonotonicTimePoint expiration = now + config_.rejected_address_duration();
+  auto result = rejected_address_map_.insert(std::make_pair(OpenDDS::DCPS::NetworkAddress(addr), expiration));
+  if (result.second) {
+    if (config_.log_activity()) {
+      ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: GuidAddrSet::reject_address ")
+                 "Adding %C to list of rejected addresses.\n",
+                 OpenDDS::DCPS::LogAddr(addr).c_str()));
+    }
+    rejected_address_expiration_queue_.push_back(result.first);
+    relay_stats_reporter_.rejected_address_map_size(rejected_address_map_.size(), now);
+  }
+}
+
+bool GuidAddrSet::check_address(const ACE_INET_Addr& addr)
+{
+  return rejected_address_map_.find(OpenDDS::DCPS::NetworkAddress(addr)) == rejected_address_map_.end();
 }
 
 }

--- a/tools/rtpsrelay/GuidAddrSet.h
+++ b/tools/rtpsrelay/GuidAddrSet.h
@@ -61,7 +61,7 @@ struct AddrSetStats {
       break;
     }
 
-    relay_stats_reporter_.max_addr_set_size(result->size(), now);
+    relay_stats_reporter_.max_addr_set_size(static_cast<uint32_t>(result->size()), now);
 
     return result;
   }

--- a/tools/rtpsrelay/GuidAddrSet.h
+++ b/tools/rtpsrelay/GuidAddrSet.h
@@ -25,17 +25,20 @@ struct AddrSetStats {
   OpenDDS::DCPS::Message_Block_Shared_Ptr spdp_message;
   OpenDDS::DCPS::MonotonicTimePoint session_start;
   OpenDDS::DCPS::MonotonicTimePoint deactivation;
+  RelayStatisticsReporter& relay_stats_reporter_;
 #ifdef OPENDDS_SECURITY
   std::string common_name;
 #endif
 
   AddrSetStats(const OpenDDS::DCPS::GUID_t& guid,
-               const OpenDDS::DCPS::MonotonicTimePoint& a_session_start)
+               const OpenDDS::DCPS::MonotonicTimePoint& a_session_start,
+               RelayStatisticsReporter& relay_stats_reporter)
     : allow_rtps(false)
     , spdp_stats_reporter(rtps_guid_to_relay_guid(guid), "SPDP")
     , sedp_stats_reporter(rtps_guid_to_relay_guid(guid), "SEDP")
     , data_stats_reporter(rtps_guid_to_relay_guid(guid), "DATA")
     , session_start(a_session_start)
+    , relay_stats_reporter_(relay_stats_reporter)
   {}
 
   bool empty() const
@@ -43,18 +46,24 @@ struct AddrSetStats {
     return spdp_addr_set.empty() && sedp_addr_set.empty() && data_addr_set.empty();
   }
 
-  AddrSet* select_addr_set(Port port)
+  AddrSet* select_addr_set(Port port, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
+    AddrSet* result = 0;
     switch (port) {
     case SPDP:
-      return &spdp_addr_set;
+      result = &spdp_addr_set;
+      break;
     case SEDP:
-      return &sedp_addr_set;
+      result = &sedp_addr_set;
+      break;
     case DATA:
-      return &data_addr_set;
+      result = &data_addr_set;
+      break;
     }
 
-    return 0;
+    relay_stats_reporter_.max_addr_set_size(result->size(), now);
+
+    return result;
   }
 
   ParticipantStatisticsReporter* select_stats_reporter(Port port)
@@ -227,6 +236,17 @@ public:
       gas_.remove(*this, guid, it, now, reporter);
     }
 
+    void reject_address(const ACE_INET_Addr& addr,
+                        const OpenDDS::DCPS::MonotonicTimePoint& now)
+    {
+      gas_.reject_address(addr, now);
+    }
+
+    bool check_address(const ACE_INET_Addr& addr)
+    {
+      return gas_.check_address(addr);
+    }
+
     void process_expirations(const OpenDDS::DCPS::MonotonicTimePoint& now)
     {
       gas_.process_expirations(*this, now);
@@ -250,7 +270,7 @@ private:
     const bool create = it == guid_addr_set_map_.end();
     if (create) {
       const auto it_bool_pair =
-        guid_addr_set_map_.insert(std::make_pair(guid, AddrSetStats(guid, now)));
+        guid_addr_set_map_.insert(std::make_pair(guid, AddrSetStats(guid, now, relay_stats_reporter_)));
       it = it_bool_pair.first;
     }
     return CreatedAddrSetStats(create, it->second);
@@ -285,6 +305,11 @@ private:
               GuidAddrSetMap::iterator it,
               const OpenDDS::DCPS::MonotonicTimePoint& now,
               RelayParticipantStatusReporter* reporter);
+
+  void reject_address(const ACE_INET_Addr& addr,
+                      const OpenDDS::DCPS::MonotonicTimePoint& now);
+
+  bool check_address(const ACE_INET_Addr& addr);
 
   OpenDDS::DCPS::TimeDuration get_session_time(const OpenDDS::DCPS::GUID_t& guid,
                                                const OpenDDS::DCPS::MonotonicTimePoint& now)
@@ -322,6 +347,10 @@ private:
   typedef std::list<std::pair<OpenDDS::DCPS::MonotonicTimePoint, GuidAddr> > ExpirationGuidAddrQueue;
   ExpirationGuidAddrQueue expiration_guid_addr_queue_;
   AdmissionControlQueue admission_control_queue_;
+  typedef OPENDDS_UNORDERED_MAP_T(OpenDDS::DCPS::NetworkAddress, OpenDDS::DCPS::MonotonicTimePoint) RejectedAddressMapType;
+  RejectedAddressMapType rejected_address_map_;
+  typedef std::list<RejectedAddressMapType::iterator> RejectedAddressExpirationQueue;
+  RejectedAddressExpirationQueue rejected_address_expiration_queue_;
   mutable ACE_Thread_Mutex mutex_;
 };
 

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -143,7 +143,6 @@ public:
     report(guard, now);
   }
 
-  //handler_statistics_sub_count
   void handler_statistics_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -152,7 +151,6 @@ public:
     report(guard, now);
   }
 
-  //relay_statistics_sub_count
   void relay_statistics_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -161,7 +159,6 @@ public:
     report(guard, now);
   }
 
-  //participant_statistics_sub_count
   void participant_statistics_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -170,7 +167,6 @@ public:
     report(guard, now);
   }
 
-  //relay_partitions_sub_count
   void relay_partitions_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -179,7 +175,6 @@ public:
     report(guard, now);
   }
 
-  //relay_participant_status_sub_count
   void relay_participant_status_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -188,7 +183,6 @@ public:
     report(guard, now);
   }
 
-  //spdp_replay_sub_count
   void spdp_replay_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -197,7 +191,6 @@ public:
     report(guard, now);
   }
 
-  //relay_address_sub_count
   void relay_address_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -206,7 +199,6 @@ public:
     report(guard, now);
   }
 
-  //relay_status_sub_count
   void relay_status_sub_count(uint32_t count, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -247,6 +239,30 @@ public:
     report(guard, now);
   }
 
+  void remote_map_size(uint32_t size, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    log_relay_statistics_.remote_map_size(size);
+    publish_relay_statistics_.remote_map_size(size);
+    report(guard, now);
+  }
+
+  void max_addr_set_size(uint32_t size, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    log_relay_statistics_.max_addr_set_size(std::max(log_relay_statistics_.max_addr_set_size(), size));
+    publish_relay_statistics_.max_addr_set_size(std::max(publish_relay_statistics_.max_addr_set_size(), size));
+    report(guard, now);
+  }
+
+  void rejected_address_map_size(uint32_t size, const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    log_relay_statistics_.rejected_address_map_size(std::max(log_relay_statistics_.rejected_address_map_size(), size));
+    publish_relay_statistics_.rejected_address_map_size(std::max(publish_relay_statistics_.rejected_address_map_size(), size));
+    report(guard, now);
+  }
+
   void report()
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -276,6 +292,7 @@ private:
     log_relay_statistics_.new_address_count(0);
     log_relay_statistics_.expired_address_count(0);
     log_relay_statistics_.admission_deferral_count(0);
+    log_relay_statistics_.max_addr_set_size(0);
   }
 
   void publish_report(ACE_Guard<ACE_Thread_Mutex>& guard,
@@ -293,6 +310,7 @@ private:
     publish_relay_statistics_.new_address_count(0);
     publish_relay_statistics_.expired_address_count(0);
     publish_relay_statistics_.admission_deferral_count(0);
+    publish_relay_statistics_.max_addr_set_size(0);
 
     guard.release();
 

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -211,6 +211,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     } else if ((arg = args.get_the_parameter("-RunTime"))) {
       config.run_time(OpenDDS::DCPS::TimeDuration(ACE_OS::atoi(arg)));
       args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-MaxAddrSetSize"))) {
+      config.max_addr_set_size(ACE_OS::atoi(arg));
+      args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-RejectedAddressDuration"))) {
+      config.rejected_address_duration(OpenDDS::DCPS::TimeDuration(ACE_OS::atoi(arg)));
+      args.consume_arg();
 #ifdef OPENDDS_SECURITY
     } else if ((arg = args.get_the_parameter("-IdentityCA"))) {
       identity_ca_file = file + arg;


### PR DESCRIPTION
### Problem
RtpsRelay lacks certain features for gauging interaction with poorly behaving (either intentionally or unintentionally) participants, such as a limit for the maximum size of address sets associated with a participant and the ability to ignore/reject certain addresses which behave poorly (such as echoing back traffic) for a period of time.

### Solution
Implement these features, as well as some logging surrounding the data structure sizes.