### PR TITLE
Fix data race in replay of Sedp durable data

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -1635,6 +1635,7 @@ Sedp::replay_durable_data_for(const DCPS::GUID_t& remote_sub_id)
 {
   DCPS::GuidConverter conv(remote_sub_id);
   ACE_DEBUG((LM_DEBUG, "Sedp::replay_durable_data_for %C\n", OPENDDS_STRING(conv).c_str()));
+  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
   if (remote_sub_id.entityId == ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER) {
     write_durable_publication_data(remote_sub_id, false);
   } else if (remote_sub_id.entityId == ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER) {


### PR DESCRIPTION
### Problem
TSAN detected a [data race](https://github.com/OpenDDS/OpenDDS/actions/runs/4153628452/jobs/7186086575) (ci-disco-long) in SEDP replay of durable data. The problem appears to be that the `Sedp::replay_durable_data_for` never correctly acquires the Sedp mutex.

### Solution
Acquire the mutex.