### PR TITLE
Remove Extra Call To destinations_.erase() In TransportSendBuffer

### DIFF
--- a/dds/DCPS/transport/framework/TransportSendBuffer.cpp
+++ b/dds/DCPS/transport/framework/TransportSendBuffer.cpp
@@ -365,7 +365,6 @@ SingleSendBuffer::check_capacity_i(BufferVec& removed)
       ));
     }
 
-    destinations_.erase(it->first);
     remove_i(it, removed);
   }
 }


### PR DESCRIPTION
### Problem
The entries of the `destinations_` data structure within `TransportSendBuffer` appear to be maintained within `remove_i` and `release_i`, so the call to `erase` within `check_capacity_i` is no longer required, since it also subsequently calls `remove_i`.

### Solution
Remove the extra call.