### PR TITLE
Initializing DDS::DataWriterQos for constructors is difficult

### DIFF
--- a/dds/DCPS/Qos_Helper.cpp
+++ b/dds/DCPS/Qos_Helper.cpp
@@ -13,7 +13,7 @@
 #endif /* __ACE_INLINE__ */
 
 #include "debug.h"
-#include "Service_Participant.h"
+#include "DCPS_Utils.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -484,6 +484,44 @@ bool Qos_Helper::valid(const DDS::DomainParticipantFactoryQos& qos)
   }
 
   return true;
+}
+
+DataWriterQosBuilder::DataWriterQosBuilder(DDS::Publisher_var publisher)
+{
+  const DDS::ReturnCode_t ret = publisher->get_default_datawriter_qos(qos_);
+  if (ret != DDS::RETCODE_OK && log_level >= LogLevel::Warning) {
+    ACE_ERROR((LM_WARNING,
+               ACE_TEXT("(%P|%t) WARNING: DataWriterQosBuilder: ")
+               ACE_TEXT("could not get_default_datawriter_qos: %C\n"),
+               retcode_to_string(ret)));
+  }
+}
+
+DataWriterQosBuilder::DataWriterQosBuilder(DDS::Topic_var topic,
+                                           DDS::Publisher_var publisher)
+{
+  DDS::TopicQos tqos;
+  DDS::ReturnCode_t ret = topic->get_qos(tqos);
+  if (ret != DDS::RETCODE_OK && log_level >= LogLevel::Warning) {
+    ACE_ERROR((LM_WARNING,
+               ACE_TEXT("(%P|%t) WARNING: DataWriterQosBuilder: ")
+               ACE_TEXT("could not get_qos on topic: %C\n"),
+               retcode_to_string(ret)));
+  }
+  ret = publisher->get_default_datawriter_qos(qos_);
+  if (ret != DDS::RETCODE_OK && log_level >= LogLevel::Warning) {
+    ACE_ERROR((LM_WARNING,
+               ACE_TEXT("(%P|%t) WARNING: DataWriterQosBuilder: ")
+               ACE_TEXT("could not get_default_datawriter_qos: %C\n"),
+               retcode_to_string(ret)));
+  }
+  ret = publisher->copy_from_topic_qos(qos_, tqos);
+  if (ret != DDS::RETCODE_OK && log_level >= LogLevel::Warning) {
+    ACE_ERROR((LM_WARNING,
+               ACE_TEXT("(%P|%t) WARNING: DataWriterQosBuilder: ")
+               ACE_TEXT("could not copy_from_topic: %C\n"),
+               retcode_to_string(ret)));
+  }
 }
 
 } // namespace DCPS

--- a/dds/DCPS/Qos_Helper.h
+++ b/dds/DCPS/Qos_Helper.h
@@ -9,6 +9,8 @@
 #define OPENDDS_DCPS_QOS_HELPER_H
 
 #include "dds/DdsDcpsInfrastructureC.h"
+#include "dds/DdsDcpsPublicationC.h"
+#include "dds/DdsDcpsTopicC.h"
 #include "Time_Helper.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
@@ -19,8 +21,6 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
 namespace DCPS {
-
-class Service_Participant;
 
 /**
  * @class Qos_Helper
@@ -504,6 +504,1133 @@ ACE_INLINE OpenDDS_Dcps_Export
 bool operator!=(const DDS::TypeConsistencyEnforcementQosPolicy& qos1,
                 const DDS::TypeConsistencyEnforcementQosPolicy& qos2);
 #endif
+
+class TransportPriorityQosPolicyBuilder {
+public:
+  TransportPriorityQosPolicyBuilder()
+  {
+    qos_.value = 0;
+  }
+
+  explicit TransportPriorityQosPolicyBuilder(const DDS::TransportPriorityQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::TransportPriorityQosPolicy& qos() const { return qos_; }
+  DDS::TransportPriorityQosPolicy& qos() { return qos_; }
+  operator const DDS::TransportPriorityQosPolicy&() const { return qos_; }
+  operator DDS::TransportPriorityQosPolicy&() { return qos_; }
+
+  TransportPriorityQosPolicyBuilder& value(int value)
+  {
+    qos_.value = value;
+    return *this;
+  }
+
+private:
+  DDS::TransportPriorityQosPolicy qos_;
+};
+
+class LifespanQosPolicyBuilder {
+public:
+  LifespanQosPolicyBuilder()
+  {
+    qos_.duration.sec = DDS::DURATION_INFINITE_SEC;
+    qos_.duration.nanosec = DDS::DURATION_INFINITE_NSEC;
+  }
+
+  explicit LifespanQosPolicyBuilder(const DDS::LifespanQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::LifespanQosPolicy& qos() const { return qos_; }
+  DDS::LifespanQosPolicy& qos() { return qos_; }
+  operator const DDS::LifespanQosPolicy&() const { return qos_; }
+  operator DDS::LifespanQosPolicy&() { return qos_; }
+
+  LifespanQosPolicyBuilder& duration(const DDS::Duration_t& duration)
+  {
+    qos_.duration = duration;
+    return *this;
+  }
+
+private:
+  DDS::LifespanQosPolicy qos_;
+};
+
+class DurabilityQosPolicyBuilder {
+public:
+  DurabilityQosPolicyBuilder()
+  {
+    qos_.kind = DDS::VOLATILE_DURABILITY_QOS;
+  }
+
+  explicit DurabilityQosPolicyBuilder(const DDS::DurabilityQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::DurabilityQosPolicy& qos() const { return qos_; }
+  DDS::DurabilityQosPolicy& qos() { return qos_; }
+  operator const DDS::DurabilityQosPolicy&() const { return qos_; }
+  operator DDS::DurabilityQosPolicy&() { return qos_; }
+
+  DurabilityQosPolicyBuilder& kind(DDS::DurabilityQosPolicyKind kind)
+  {
+    qos_.kind = kind;
+    return *this;
+  }
+
+  DurabilityQosPolicyBuilder& _volatile()
+  {
+    qos_.kind = DDS::VOLATILE_DURABILITY_QOS;
+    return *this;
+  }
+
+  DurabilityQosPolicyBuilder& transient_local()
+  {
+    qos_.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+    return *this;
+  }
+
+  DurabilityQosPolicyBuilder& transient()
+  {
+    qos_.kind = DDS::TRANSIENT_DURABILITY_QOS;
+    return *this;
+  }
+
+  DurabilityQosPolicyBuilder& persistent()
+  {
+    qos_.kind = DDS::PERSISTENT_DURABILITY_QOS;
+    return *this;
+  }
+
+private:
+  DDS::DurabilityQosPolicy qos_;
+};
+
+class DurabilityServiceQosPolicyBuilder {
+public:
+  DurabilityServiceQosPolicyBuilder()
+  {
+    qos_.service_cleanup_delay.sec = DDS::DURATION_ZERO_SEC;
+    qos_.service_cleanup_delay.nanosec = DDS::DURATION_ZERO_NSEC;
+    qos_.history_kind = DDS::KEEP_LAST_HISTORY_QOS;
+    qos_.history_depth = 1;
+    qos_.max_samples = DDS::LENGTH_UNLIMITED;
+    qos_.max_instances = DDS::LENGTH_UNLIMITED;
+    qos_.max_samples_per_instance = DDS::LENGTH_UNLIMITED;
+  }
+
+  explicit DurabilityServiceQosPolicyBuilder(const DDS::DurabilityServiceQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::DurabilityServiceQosPolicy& qos() const { return qos_; }
+  DDS::DurabilityServiceQosPolicy& qos() { return qos_; }
+  operator const DDS::DurabilityServiceQosPolicy&() const { return qos_; }
+  operator DDS::DurabilityServiceQosPolicy&() { return qos_; }
+
+  DurabilityServiceQosPolicyBuilder& service_cleanup_delay(const DDS::Duration_t& delay)
+  {
+    qos_.service_cleanup_delay = delay;
+    return *this;
+  }
+
+  DurabilityServiceQosPolicyBuilder& history_kind(DDS::HistoryQosPolicyKind kind)
+  {
+    qos_.history_kind = kind;
+    return *this;
+  }
+
+  DurabilityServiceQosPolicyBuilder& keep_last(int depth)
+  {
+    qos_.history_kind = DDS::KEEP_LAST_HISTORY_QOS;
+    qos_.history_depth = depth;
+    return *this;
+  }
+
+  DurabilityServiceQosPolicyBuilder& keep_all()
+  {
+    qos_.history_kind = DDS::KEEP_ALL_HISTORY_QOS;
+    return *this;
+  }
+
+  DurabilityServiceQosPolicyBuilder& history_depth(int depth)
+  {
+    qos_.history_depth = depth;
+    return *this;
+  }
+
+  DurabilityServiceQosPolicyBuilder& max_samples(int value)
+  {
+    qos_.max_samples = value;
+    return *this;
+  }
+
+  DurabilityServiceQosPolicyBuilder& max_instances(int value)
+  {
+    qos_.max_instances = value;
+    return *this;
+  }
+
+  DurabilityServiceQosPolicyBuilder& max_samples_per_instance(int value)
+  {
+    qos_.max_samples_per_instance = value;
+    return *this;
+  }
+
+private:
+  DDS::DurabilityServiceQosPolicy qos_;
+};
+
+class DeadlineQosPolicyBuilder {
+public:
+  DeadlineQosPolicyBuilder()
+  {
+    qos_.period.sec = DDS::DURATION_INFINITE_SEC;
+    qos_.period.nanosec = DDS::DURATION_INFINITE_NSEC;
+  }
+
+  explicit DeadlineQosPolicyBuilder(const DDS::DeadlineQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::DeadlineQosPolicy& qos() const { return qos_; }
+  DDS::DeadlineQosPolicy& qos() { return qos_; }
+  operator const DDS::DeadlineQosPolicy&() const { return qos_; }
+  operator DDS::DeadlineQosPolicy&() { return qos_; }
+
+  DeadlineQosPolicyBuilder& period(const DDS::Duration_t& period)
+  {
+    qos_.period = period;
+    return *this;
+  }
+
+private:
+  DDS::DeadlineQosPolicy qos_;
+};
+
+class LatencyBudgetQosPolicyBuilder {
+public:
+  LatencyBudgetQosPolicyBuilder()
+  {
+    qos_.duration.sec = DDS::DURATION_ZERO_SEC;
+    qos_.duration.nanosec = DDS::DURATION_ZERO_NSEC;
+  }
+
+  explicit LatencyBudgetQosPolicyBuilder(const DDS::LatencyBudgetQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::LatencyBudgetQosPolicy& qos() const { return qos_; }
+  DDS::LatencyBudgetQosPolicy& qos() { return qos_; }
+  operator const DDS::LatencyBudgetQosPolicy&() const { return qos_; }
+  operator DDS::LatencyBudgetQosPolicy&() { return qos_; }
+
+  LatencyBudgetQosPolicyBuilder& duration(const DDS::Duration_t& duration)
+  {
+    qos_.duration = duration;
+    return *this;
+  }
+
+private:
+  DDS::LatencyBudgetQosPolicy qos_;
+};
+
+class OwnershipQosPolicyBuilder {
+public:
+  OwnershipQosPolicyBuilder()
+  {
+    qos_.kind = DDS::SHARED_OWNERSHIP_QOS;
+  }
+
+  explicit OwnershipQosPolicyBuilder(const DDS::OwnershipQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::OwnershipQosPolicy& qos() const { return qos_; }
+  DDS::OwnershipQosPolicy& qos() { return qos_; }
+  operator const DDS::OwnershipQosPolicy&() const { return qos_; }
+  operator DDS::OwnershipQosPolicy&() { return qos_; }
+
+  OwnershipQosPolicyBuilder& kind(DDS::OwnershipQosPolicyKind kind)
+  {
+    qos_.kind = kind;
+    return *this;
+  }
+
+  OwnershipQosPolicyBuilder& shared()
+  {
+    qos_.kind = DDS::SHARED_OWNERSHIP_QOS;
+    return *this;
+  }
+
+  OwnershipQosPolicyBuilder& exclusive()
+  {
+    qos_.kind = DDS::EXCLUSIVE_OWNERSHIP_QOS;
+    return *this;
+  }
+
+private:
+  DDS::OwnershipQosPolicy qos_;
+};
+
+class OwnershipStrengthQosPolicyBuilder {
+public:
+  OwnershipStrengthQosPolicyBuilder()
+  {
+    qos_.value = 0;
+  }
+
+  explicit OwnershipStrengthQosPolicyBuilder(const DDS::OwnershipStrengthQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::OwnershipStrengthQosPolicy& qos() const { return qos_; }
+  DDS::OwnershipStrengthQosPolicy& qos() { return qos_; }
+  operator const DDS::OwnershipStrengthQosPolicy&() const { return qos_; }
+  operator DDS::OwnershipStrengthQosPolicy&() { return qos_; }
+
+  OwnershipStrengthQosPolicyBuilder& value(int value)
+  {
+    qos_.value = value;
+    return *this;
+  }
+
+private:
+  DDS::OwnershipStrengthQosPolicy qos_;
+};
+
+class LivelinessQosPolicyBuilder {
+public:
+  LivelinessQosPolicyBuilder()
+  {
+    qos_.kind = DDS::AUTOMATIC_LIVELINESS_QOS;
+    qos_.lease_duration.sec = DDS::DURATION_INFINITE_SEC;
+    qos_.lease_duration.nanosec = DDS::DURATION_INFINITE_NSEC;
+  }
+
+  explicit LivelinessQosPolicyBuilder(const DDS::LivelinessQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::LivelinessQosPolicy& qos() const { return qos_; }
+  DDS::LivelinessQosPolicy& qos() { return qos_; }
+  operator const DDS::LivelinessQosPolicy&() const { return qos_; }
+  operator DDS::LivelinessQosPolicy&() { return qos_; }
+
+  LivelinessQosPolicyBuilder& kind(DDS::LivelinessQosPolicyKind kind)
+  {
+    qos_.kind = kind;
+    return *this;
+  }
+
+  LivelinessQosPolicyBuilder& automatic()
+  {
+    qos_.kind = DDS::AUTOMATIC_LIVELINESS_QOS;
+    return *this;
+  }
+
+  LivelinessQosPolicyBuilder& manual_by_participant()
+  {
+    qos_.kind = DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+    return *this;
+  }
+
+  LivelinessQosPolicyBuilder& manual_by_topic()
+  {
+    qos_.kind = DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS;
+    return *this;
+  }
+
+  LivelinessQosPolicyBuilder& lease_duration(const DDS::Duration_t& duration)
+  {
+    qos_.lease_duration = duration;
+    return *this;
+  }
+
+private:
+  DDS::LivelinessQosPolicy qos_;
+};
+
+class ReliabilityQosPolicyBuilder {
+public:
+  ReliabilityQosPolicyBuilder()
+  {
+    qos_.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
+    // TODO: According to the spec, this should be:
+    // qos_.max_blocking_time.sec = 0;
+    // qos_.max_blocking_time.nanosec = 100000000;
+    // Change this at the next major release.
+    qos_.max_blocking_time.sec = DDS::DURATION_INFINITE_SEC;
+    qos_.max_blocking_time.nanosec = DDS::DURATION_INFINITE_NSEC;
+  }
+
+  explicit ReliabilityQosPolicyBuilder(const DDS::ReliabilityQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::ReliabilityQosPolicy& qos() const { return qos_; }
+  DDS::ReliabilityQosPolicy& qos() { return qos_; }
+  operator const DDS::ReliabilityQosPolicy&() const { return qos_; }
+  operator DDS::ReliabilityQosPolicy&() { return qos_; }
+
+  ReliabilityQosPolicyBuilder& kind(DDS::ReliabilityQosPolicyKind kind)
+  {
+    qos_.kind = kind;
+    return *this;
+  }
+
+  ReliabilityQosPolicyBuilder& best_effort()
+  {
+    qos_.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
+    return *this;
+  }
+
+  ReliabilityQosPolicyBuilder& reliable()
+  {
+    qos_.kind = DDS::RELIABLE_RELIABILITY_QOS;
+    return *this;
+  }
+
+  ReliabilityQosPolicyBuilder& max_blocking_time(const DDS::Duration_t& duration)
+  {
+    qos_.max_blocking_time = duration;
+    return *this;
+  }
+
+private:
+  DDS::ReliabilityQosPolicy qos_;
+};
+
+class DestinationOrderQosPolicyBuilder {
+public:
+  DestinationOrderQosPolicyBuilder()
+  {
+    qos_.kind = DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS;
+  }
+
+  explicit DestinationOrderQosPolicyBuilder(const DDS::DestinationOrderQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::DestinationOrderQosPolicy& qos() const { return qos_; }
+  DDS::DestinationOrderQosPolicy& qos() { return qos_; }
+  operator const DDS::DestinationOrderQosPolicy&() const { return qos_; }
+  operator DDS::DestinationOrderQosPolicy&() { return qos_; }
+
+  DestinationOrderQosPolicyBuilder& kind(DDS::DestinationOrderQosPolicyKind kind)
+  {
+    qos_.kind = kind;
+    return *this;
+  }
+
+  DestinationOrderQosPolicyBuilder& by_reception_timestamp()
+  {
+    qos_.kind = DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS;
+    return *this;
+  }
+
+  DestinationOrderQosPolicyBuilder& by_source_timestamp()
+  {
+    qos_.kind = DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;
+    return *this;
+  }
+
+private:
+  DDS::DestinationOrderQosPolicy qos_;
+};
+
+class HistoryQosPolicyBuilder {
+public:
+  HistoryQosPolicyBuilder()
+  {
+    qos_.kind = DDS::KEEP_LAST_HISTORY_QOS;
+    qos_.depth = 1;
+  }
+
+  explicit HistoryQosPolicyBuilder(const DDS::HistoryQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::HistoryQosPolicy& qos() const { return qos_; }
+  DDS::HistoryQosPolicy& qos() { return qos_; }
+  operator const DDS::HistoryQosPolicy&() const { return qos_; }
+  operator DDS::HistoryQosPolicy&() { return qos_; }
+
+  HistoryQosPolicyBuilder& kind(DDS::HistoryQosPolicyKind kind)
+  {
+    qos_.kind = kind;
+    return *this;
+  }
+
+  HistoryQosPolicyBuilder& keep_last(int depth)
+  {
+    qos_.kind = DDS::KEEP_LAST_HISTORY_QOS;
+    qos_.depth = depth;
+    return *this;
+  }
+
+  HistoryQosPolicyBuilder& keep_all()
+  {
+    qos_.kind = DDS::KEEP_ALL_HISTORY_QOS;
+    return *this;
+  }
+
+  HistoryQosPolicyBuilder& depth(int depth)
+  {
+    qos_.depth = depth;
+    return *this;
+  }
+
+private:
+  DDS::HistoryQosPolicy qos_;
+};
+
+class ResourceLimitsQosPolicyBuilder {
+public:
+  ResourceLimitsQosPolicyBuilder()
+  {
+    qos_.max_samples = DDS::LENGTH_UNLIMITED;
+    qos_.max_instances = DDS::LENGTH_UNLIMITED;
+    qos_.max_samples_per_instance = DDS::LENGTH_UNLIMITED;
+  }
+
+  explicit ResourceLimitsQosPolicyBuilder(const DDS::ResourceLimitsQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::ResourceLimitsQosPolicy& qos() const { return qos_; }
+  DDS::ResourceLimitsQosPolicy& qos() { return qos_; }
+  operator const DDS::ResourceLimitsQosPolicy&() const { return qos_; }
+  operator DDS::ResourceLimitsQosPolicy&() { return qos_; }
+
+  ResourceLimitsQosPolicyBuilder& max_samples(int value)
+  {
+    qos_.max_samples = value;
+    return *this;
+  }
+
+  ResourceLimitsQosPolicyBuilder& max_instances(int value)
+  {
+    qos_.max_instances = value;
+    return *this;
+  }
+
+  ResourceLimitsQosPolicyBuilder& max_samples_per_instance(int value)
+  {
+    qos_.max_samples_per_instance = value;
+    return *this;
+  }
+
+private:
+  DDS::ResourceLimitsQosPolicy qos_;
+};
+
+class WriterDataLifecycleQosPolicyBuilder {
+public:
+  WriterDataLifecycleQosPolicyBuilder()
+  {
+    qos_.autodispose_unregistered_instances = true;
+  }
+
+  explicit WriterDataLifecycleQosPolicyBuilder(const DDS::WriterDataLifecycleQosPolicy& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::WriterDataLifecycleQosPolicy& qos() const { return qos_; }
+  DDS::WriterDataLifecycleQosPolicy& qos() { return qos_; }
+  operator const DDS::WriterDataLifecycleQosPolicy&() const { return qos_; }
+  operator DDS::WriterDataLifecycleQosPolicy&() { return qos_; }
+
+  WriterDataLifecycleQosPolicyBuilder& autodispose_unregistered_instances(bool value)
+  {
+    qos_.autodispose_unregistered_instances = value;
+    return *this;
+  }
+
+private:
+  DDS::WriterDataLifecycleQosPolicy qos_;
+};
+
+class TopicQosBuilder {
+public:
+  TopicQosBuilder()
+  {
+    // topic_data
+    qos_.durability = DurabilityQosPolicyBuilder();
+    qos_.durability_service = DurabilityServiceQosPolicyBuilder();
+    qos_.deadline = DeadlineQosPolicyBuilder();
+    qos_.latency_budget = LatencyBudgetQosPolicyBuilder();
+    qos_.liveliness = LivelinessQosPolicyBuilder();
+    qos_.reliability = ReliabilityQosPolicyBuilder();
+    qos_.destination_order = DestinationOrderQosPolicyBuilder();
+    qos_.history = HistoryQosPolicyBuilder();
+    qos_.resource_limits = ResourceLimitsQosPolicyBuilder();
+    qos_.transport_priority = TransportPriorityQosPolicyBuilder();
+    qos_.lifespan = LifespanQosPolicyBuilder();
+    qos_.ownership = OwnershipQosPolicyBuilder();
+    // representation
+  }
+
+  explicit TopicQosBuilder(const DDS::TopicQos& qos)
+    : qos_(qos)
+  {}
+
+  const DDS::TopicQos& qos() const { return qos_; }
+  DDS::TopicQos& qos() { return qos_; }
+  operator const DDS::TopicQos&() const { return qos_; }
+  operator DDS::TopicQos&() { return qos_; }
+
+  TopicQosBuilder& topic_data_value(const DDS::OctetSeq& value)
+  {
+    qos_.topic_data.value = value;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_kind(DDS::DurabilityQosPolicyKind kind)
+  {
+    qos_.durability.kind = kind;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_volatile()
+  {
+    qos_.durability.kind = DDS::VOLATILE_DURABILITY_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_transient_local()
+  {
+    qos_.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_transient()
+  {
+    qos_.durability.kind = DDS::TRANSIENT_DURABILITY_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_persistent()
+  {
+    qos_.durability.kind = DDS::PERSISTENT_DURABILITY_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_service_service_cleanup_delay(const DDS::Duration_t& delay)
+  {
+    qos_.durability_service.service_cleanup_delay = delay;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_service_history_kind(DDS::HistoryQosPolicyKind kind)
+  {
+    qos_.durability_service.history_kind = kind;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_service_keep_last(int depth)
+  {
+    qos_.durability_service.history_kind = DDS::KEEP_LAST_HISTORY_QOS;
+    qos_.durability_service.history_depth = depth;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_service_keep_all()
+  {
+    qos_.durability_service.history_kind = DDS::KEEP_ALL_HISTORY_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_service_history_depth(int depth)
+  {
+    qos_.durability_service.history_depth = depth;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_service_max_samples(int value)
+  {
+    qos_.durability_service.max_samples = value;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_service_max_instances(int value)
+  {
+    qos_.durability_service.max_instances = value;
+    return *this;
+  }
+
+  TopicQosBuilder& durability_service_max_samples_per_instance(int value)
+  {
+    qos_.durability_service.max_samples_per_instance = value;
+    return *this;
+  }
+
+  TopicQosBuilder& deadline_period(const DDS::Duration_t& duration)
+  {
+    qos_.deadline.period = duration;
+    return *this;
+  }
+
+  TopicQosBuilder& latency_budget_duration(const DDS::Duration_t& duration)
+  {
+    qos_.latency_budget.duration = duration;
+    return *this;
+  }
+
+  TopicQosBuilder& liveliness_kind(DDS::LivelinessQosPolicyKind kind)
+  {
+    qos_.liveliness.kind = kind;
+    return *this;
+  }
+
+  TopicQosBuilder& liveliness_automatic()
+  {
+    qos_.liveliness.kind = DDS::AUTOMATIC_LIVELINESS_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& liveliness_manual_by_participant()
+  {
+    qos_.liveliness.kind = DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& liveliness_manual_by_topic()
+  {
+    qos_.liveliness.kind = DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& liveliness_lease_duration(const DDS::Duration_t& duration)
+  {
+    qos_.liveliness.lease_duration = duration;
+    return *this;
+  }
+
+  TopicQosBuilder& reliability_kind(DDS::ReliabilityQosPolicyKind kind)
+  {
+    qos_.reliability.kind = kind;
+    return *this;
+  }
+
+  TopicQosBuilder& reliability_best_effort()
+  {
+    qos_.reliability.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& reliability_reliable()
+  {
+    qos_.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& reliability_max_blocking_time(const DDS::Duration_t& duration)
+  {
+    qos_.reliability.max_blocking_time = duration;
+    return *this;
+  }
+
+  TopicQosBuilder& destination_order_kind(DDS::DestinationOrderQosPolicyKind kind)
+  {
+    qos_.destination_order.kind = kind;
+    return *this;
+  }
+
+  TopicQosBuilder& destination_order_by_reception_timestamp()
+  {
+    qos_.destination_order.kind = DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& destination_order_by_source_timestamp()
+  {
+    qos_.destination_order.kind = DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& history_kind(DDS::HistoryQosPolicyKind kind)
+  {
+    qos_.history.kind = kind;
+    return *this;
+  }
+
+  TopicQosBuilder& history_keep_last(int depth)
+  {
+    qos_.history.kind = DDS::KEEP_LAST_HISTORY_QOS;
+    qos_.history.depth = depth;
+    return *this;
+  }
+
+  TopicQosBuilder& history_keep_all()
+  {
+    qos_.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& history_depth(int depth)
+  {
+    qos_.history.depth = depth;
+    return *this;
+  }
+
+  TopicQosBuilder& resource_limits_max_samples(int value)
+  {
+    qos_.resource_limits.max_samples = value;
+    return *this;
+  }
+
+  TopicQosBuilder& resource_limits_max_instances(int value)
+  {
+    qos_.resource_limits.max_instances = value;
+    return *this;
+  }
+
+  TopicQosBuilder& resource_limits_max_samples_per_instance(int value)
+  {
+    qos_.resource_limits.max_samples_per_instance = value;
+    return *this;
+  }
+
+  TopicQosBuilder& transport_priority_value(int value)
+  {
+    qos_.transport_priority.value = value;
+    return *this;
+  }
+
+  TopicQosBuilder& lifespan_duration(const DDS::Duration_t& duration)
+  {
+    qos_.lifespan.duration = duration;
+    return *this;
+  }
+
+  TopicQosBuilder& ownership_kind(DDS::OwnershipQosPolicyKind kind)
+  {
+    qos_.ownership.kind = kind;
+    return *this;
+  }
+
+  TopicQosBuilder& ownership_shared()
+  {
+    qos_.ownership.kind = DDS::SHARED_OWNERSHIP_QOS;
+    return *this;
+  }
+
+  TopicQosBuilder& ownership_exclusive()
+  {
+    qos_.ownership.kind = DDS::EXCLUSIVE_OWNERSHIP_QOS;
+    return *this;
+  }
+
+private:
+  DDS::TopicQos qos_;
+};
+
+class OpenDDS_Dcps_Export DataWriterQosBuilder {
+public:
+  DataWriterQosBuilder()
+  {
+    qos_.durability = DurabilityQosPolicyBuilder();
+    qos_.durability_service = DurabilityServiceQosPolicyBuilder();
+    qos_.deadline = DeadlineQosPolicyBuilder();
+    qos_.latency_budget = LatencyBudgetQosPolicyBuilder();
+    qos_.liveliness = LivelinessQosPolicyBuilder();
+    qos_.reliability = ReliabilityQosPolicyBuilder().reliable().max_blocking_time(make_duration(0, 100000000));
+    qos_.destination_order = DestinationOrderQosPolicyBuilder();
+    qos_.history = HistoryQosPolicyBuilder();
+    qos_.resource_limits = ResourceLimitsQosPolicyBuilder();
+    qos_.transport_priority = TransportPriorityQosPolicyBuilder();
+    qos_.lifespan = LifespanQosPolicyBuilder();
+    // userdata
+    qos_.ownership = OwnershipQosPolicyBuilder();
+    qos_.ownership_strength = OwnershipStrengthQosPolicyBuilder();
+    qos_.writer_data_lifecycle = WriterDataLifecycleQosPolicyBuilder();
+    // representation
+  }
+
+  explicit DataWriterQosBuilder(const DDS::DataWriterQos& qos)
+    : qos_(qos)
+  {}
+
+  explicit DataWriterQosBuilder(DDS::Publisher_var publisher);
+
+  DataWriterQosBuilder(DDS::Topic_var topic,
+                       DDS::Publisher_var publisher);
+
+  const DDS::DataWriterQos& qos() const { return qos_; }
+  DDS::DataWriterQos& qos() { return qos_; }
+  operator const DDS::DataWriterQos&() const { return qos_; }
+  operator DDS::DataWriterQos&() { return qos_; }
+
+  bool operator==(const DataWriterQosBuilder& other) const
+  {
+    return qos_ == other.qos_;
+  }
+
+  bool operator!=(const DataWriterQosBuilder& other) const
+  {
+    return !(*this == other);
+  }
+
+  DataWriterQosBuilder& durability_kind(DDS::DurabilityQosPolicyKind kind)
+  {
+    qos_.durability.kind = kind;
+    return *this;
+  }
+
+  DataWriterQosBuilder& durability_volatile()
+  {
+    qos_.durability.kind = DDS::VOLATILE_DURABILITY_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& durability_transient_local()
+  {
+    qos_.durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& durability_transient()
+  {
+    qos_.durability.kind = DDS::TRANSIENT_DURABILITY_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& durability_persistent()
+  {
+    qos_.durability.kind = DDS::PERSISTENT_DURABILITY_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& durability_service_service_cleanup_delay(const DDS::Duration_t& delay)
+  {
+    qos_.durability_service.service_cleanup_delay = delay;
+    return *this;
+  }
+
+  DataWriterQosBuilder& durability_service_history_kind(DDS::HistoryQosPolicyKind kind)
+  {
+    qos_.durability_service.history_kind = kind;
+    return *this;
+  }
+
+  DataWriterQosBuilder& durability_service_keep_last(int depth)
+  {
+    qos_.durability_service.history_kind = DDS::KEEP_LAST_HISTORY_QOS;
+    qos_.durability_service.history_depth = depth;
+    return *this;
+  }
+
+  DataWriterQosBuilder& durability_service_keep_all()
+  {
+    qos_.durability_service.history_kind = DDS::KEEP_ALL_HISTORY_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& durability_service_history_depth(int depth)
+  {
+    qos_.durability_service.history_depth = depth;
+    return *this;
+  }
+
+  DataWriterQosBuilder& durability_service_max_samples(int value)
+  {
+    qos_.durability_service.max_samples = value;
+    return *this;
+  }
+
+  DataWriterQosBuilder& durability_service_max_instances(int value)
+  {
+    qos_.durability_service.max_instances = value;
+    return *this;
+  }
+
+  DataWriterQosBuilder& durability_service_max_samples_per_instance(int value)
+  {
+    qos_.durability_service.max_samples_per_instance = value;
+    return *this;
+  }
+
+  DataWriterQosBuilder& deadline_period(const DDS::Duration_t& duration)
+  {
+    qos_.deadline.period = duration;
+    return *this;
+  }
+
+  DataWriterQosBuilder& latency_budget_duration(const DDS::Duration_t& duration)
+  {
+    qos_.latency_budget.duration = duration;
+    return *this;
+  }
+
+  DataWriterQosBuilder& liveliness_kind(DDS::LivelinessQosPolicyKind kind)
+  {
+    qos_.liveliness.kind = kind;
+    return *this;
+  }
+
+  DataWriterQosBuilder& liveliness_automatic()
+  {
+    qos_.liveliness.kind = DDS::AUTOMATIC_LIVELINESS_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& liveliness_manual_by_participant()
+  {
+    qos_.liveliness.kind = DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& liveliness_manual_by_topic()
+  {
+    qos_.liveliness.kind = DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& liveliness_lease_duration(const DDS::Duration_t& duration)
+  {
+    qos_.liveliness.lease_duration = duration;
+    return *this;
+  }
+
+  DataWriterQosBuilder& reliability_kind(DDS::ReliabilityQosPolicyKind kind)
+  {
+    qos_.reliability.kind = kind;
+    return *this;
+  }
+
+  DataWriterQosBuilder& reliability_best_effort()
+  {
+    qos_.reliability.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& reliability_reliable()
+  {
+    qos_.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& reliability_max_blocking_time(const DDS::Duration_t& duration)
+  {
+    qos_.reliability.max_blocking_time = duration;
+    return *this;
+  }
+
+  DataWriterQosBuilder& destination_order_kind(DDS::DestinationOrderQosPolicyKind kind)
+  {
+    qos_.destination_order.kind = kind;
+    return *this;
+  }
+
+  DataWriterQosBuilder& destination_order_by_reception_timestamp()
+  {
+    qos_.destination_order.kind = DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& destination_order_by_source_timestamp()
+  {
+    qos_.destination_order.kind = DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& history_kind(DDS::HistoryQosPolicyKind kind)
+  {
+    qos_.history.kind = kind;
+    return *this;
+  }
+
+  DataWriterQosBuilder& history_keep_last(int depth)
+  {
+    qos_.history.kind = DDS::KEEP_LAST_HISTORY_QOS;
+    qos_.history.depth = depth;
+    return *this;
+  }
+
+  DataWriterQosBuilder& history_keep_all()
+  {
+    qos_.history.kind = DDS::KEEP_ALL_HISTORY_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& history_depth(int depth)
+  {
+    qos_.history.depth = depth;
+    return *this;
+  }
+
+  DataWriterQosBuilder& resource_limits_max_samples(int value)
+  {
+    qos_.resource_limits.max_samples = value;
+    return *this;
+  }
+
+  DataWriterQosBuilder& resource_limits_max_instances(int value)
+  {
+    qos_.resource_limits.max_instances = value;
+    return *this;
+  }
+
+  DataWriterQosBuilder& resource_limits_max_samples_per_instance(int value)
+  {
+    qos_.resource_limits.max_samples_per_instance = value;
+    return *this;
+  }
+
+  DataWriterQosBuilder& transport_priority_value(int value)
+  {
+    qos_.transport_priority.value = value;
+    return *this;
+  }
+
+  DataWriterQosBuilder& lifespan_duration(const DDS::Duration_t& duration)
+  {
+    qos_.lifespan.duration = duration;
+    return *this;
+  }
+
+  DataWriterQosBuilder& user_data_value(const DDS::OctetSeq& value)
+  {
+    qos_.user_data.value = value;
+    return *this;
+  }
+
+  DataWriterQosBuilder& ownership_kind(DDS::OwnershipQosPolicyKind kind)
+  {
+    qos_.ownership.kind = kind;
+    return *this;
+  }
+
+  DataWriterQosBuilder& ownership_shared()
+  {
+    qos_.ownership.kind = DDS::SHARED_OWNERSHIP_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& ownership_exclusive()
+  {
+    qos_.ownership.kind = DDS::EXCLUSIVE_OWNERSHIP_QOS;
+    return *this;
+  }
+
+  DataWriterQosBuilder& ownership_strength_value(int value)
+  {
+    qos_.ownership_strength.value = value;
+    return *this;
+  }
+
+  DataWriterQosBuilder& writer_data_lifecycle_autodispose_unregistered_instances(bool value)
+  {
+    qos_.writer_data_lifecycle.autodispose_unregistered_instances = value;
+    return *this;
+  }
+
+private:
+  DDS::DataWriterQos qos_;
+};
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -21,6 +21,7 @@
 #include "DefaultNetworkConfigMonitor.h"
 #include "StaticDiscovery.h"
 #include "ThreadStatusManager.h"
+#include "Qos_Helper.h"
 #include "../Version.h"
 #ifdef OPENDDS_SECURITY
 #  include "security/framework/SecurityRegistry.h"
@@ -831,60 +832,34 @@ int Service_Participant::parse_args(int& argc, ACE_TCHAR* argv[])
 void
 Service_Participant::initialize()
 {
-  //NOTE: in the future these initial values may be configurable
-  //      (to override the Specification's default values
-  //       hmm - I guess that would be OK since the user
-  //       is overriding them.)
-  initial_TransportPriorityQosPolicy_.value = 0;
-  initial_LifespanQosPolicy_.duration.sec = DDS::DURATION_INFINITE_SEC;
-  initial_LifespanQosPolicy_.duration.nanosec = DDS::DURATION_INFINITE_NSEC;
+  initial_TransportPriorityQosPolicy_ = TransportPriorityQosPolicyBuilder();
+  initial_LifespanQosPolicy_ = LifespanQosPolicyBuilder();
 
-  initial_DurabilityQosPolicy_.kind = DDS::VOLATILE_DURABILITY_QOS;
+  initial_DurabilityQosPolicy_ = DurabilityQosPolicyBuilder();
 
-  initial_DurabilityServiceQosPolicy_.service_cleanup_delay.sec =
-    DDS::DURATION_ZERO_SEC;
-  initial_DurabilityServiceQosPolicy_.service_cleanup_delay.nanosec =
-    DDS::DURATION_ZERO_NSEC;
-  initial_DurabilityServiceQosPolicy_.history_kind =
-    DDS::KEEP_LAST_HISTORY_QOS;
-  initial_DurabilityServiceQosPolicy_.history_depth = 1;
-  initial_DurabilityServiceQosPolicy_.max_samples =
-    DDS::LENGTH_UNLIMITED;
-  initial_DurabilityServiceQosPolicy_.max_instances =
-    DDS::LENGTH_UNLIMITED;
-  initial_DurabilityServiceQosPolicy_.max_samples_per_instance =
-    DDS::LENGTH_UNLIMITED;
+  initial_DurabilityServiceQosPolicy_ = DurabilityServiceQosPolicyBuilder();
 
   initial_PresentationQosPolicy_.access_scope = DDS::INSTANCE_PRESENTATION_QOS;
   initial_PresentationQosPolicy_.coherent_access = false;
   initial_PresentationQosPolicy_.ordered_access = false;
 
-  initial_DeadlineQosPolicy_.period.sec = DDS::DURATION_INFINITE_SEC;
-  initial_DeadlineQosPolicy_.period.nanosec = DDS::DURATION_INFINITE_NSEC;
+  initial_DeadlineQosPolicy_ = DeadlineQosPolicyBuilder();
 
-  initial_LatencyBudgetQosPolicy_.duration.sec = DDS::DURATION_ZERO_SEC;
-  initial_LatencyBudgetQosPolicy_.duration.nanosec = DDS::DURATION_ZERO_NSEC;
+  initial_LatencyBudgetQosPolicy_ = LatencyBudgetQosPolicyBuilder();
 
-  initial_OwnershipQosPolicy_.kind = DDS::SHARED_OWNERSHIP_QOS;
-#ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
-  initial_OwnershipStrengthQosPolicy_.value = 0;
-#endif
+  initial_OwnershipQosPolicy_ = OwnershipQosPolicyBuilder();
+  initial_OwnershipStrengthQosPolicy_ = OwnershipStrengthQosPolicyBuilder();
 
-  initial_LivelinessQosPolicy_.kind = DDS::AUTOMATIC_LIVELINESS_QOS;
-  initial_LivelinessQosPolicy_.lease_duration.sec = DDS::DURATION_INFINITE_SEC;
-  initial_LivelinessQosPolicy_.lease_duration.nanosec = DDS::DURATION_INFINITE_NSEC;
+  initial_LivelinessQosPolicy_ = LivelinessQosPolicyBuilder();
 
   initial_TimeBasedFilterQosPolicy_.minimum_separation.sec = DDS::DURATION_ZERO_SEC;
   initial_TimeBasedFilterQosPolicy_.minimum_separation.nanosec = DDS::DURATION_ZERO_NSEC;
 
-  initial_ReliabilityQosPolicy_.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
-  initial_ReliabilityQosPolicy_.max_blocking_time.sec = DDS::DURATION_INFINITE_SEC;
-  initial_ReliabilityQosPolicy_.max_blocking_time.nanosec = DDS::DURATION_INFINITE_NSEC;
+  initial_ReliabilityQosPolicy_ = ReliabilityQosPolicyBuilder();
 
-  initial_DestinationOrderQosPolicy_.kind = DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS;
+  initial_DestinationOrderQosPolicy_ = DestinationOrderQosPolicyBuilder();
 
-  initial_HistoryQosPolicy_.kind = DDS::KEEP_LAST_HISTORY_QOS;
-  initial_HistoryQosPolicy_.depth = 1;
+  initial_HistoryQosPolicy_ = HistoryQosPolicyBuilder();
 
   initial_ResourceLimitsQosPolicy_.max_samples = DDS::LENGTH_UNLIMITED;
   initial_ResourceLimitsQosPolicy_.max_instances = DDS::LENGTH_UNLIMITED;
@@ -892,7 +867,7 @@ Service_Participant::initialize()
 
   initial_EntityFactoryQosPolicy_.autoenable_created_entities = true;
 
-  initial_WriterDataLifecycleQosPolicy_.autodispose_unregistered_instances = true;
+  initial_WriterDataLifecycleQosPolicy_ = WriterDataLifecycleQosPolicyBuilder();
 
   // Will get interpreted based on how the type was annotated.
   initial_DataRepresentationQosPolicy_.value.length(0);
@@ -913,44 +888,9 @@ Service_Participant::initialize()
   initial_DomainParticipantQos_.entity_factory = initial_EntityFactoryQosPolicy_;
   initial_DomainParticipantFactoryQos_.entity_factory = initial_EntityFactoryQosPolicy_;
 
-  initial_TopicQos_.topic_data = initial_TopicDataQosPolicy_;
-  initial_TopicQos_.durability = initial_DurabilityQosPolicy_;
-  initial_TopicQos_.durability_service = initial_DurabilityServiceQosPolicy_;
-  initial_TopicQos_.deadline = initial_DeadlineQosPolicy_;
-  initial_TopicQos_.latency_budget = initial_LatencyBudgetQosPolicy_;
-  initial_TopicQos_.liveliness = initial_LivelinessQosPolicy_;
-  initial_TopicQos_.reliability = initial_ReliabilityQosPolicy_;
-  initial_TopicQos_.destination_order = initial_DestinationOrderQosPolicy_;
-  initial_TopicQos_.history = initial_HistoryQosPolicy_;
-  initial_TopicQos_.resource_limits = initial_ResourceLimitsQosPolicy_;
-  initial_TopicQos_.transport_priority = initial_TransportPriorityQosPolicy_;
-  initial_TopicQos_.lifespan = initial_LifespanQosPolicy_;
-  initial_TopicQos_.ownership = initial_OwnershipQosPolicy_;
-  initial_TopicQos_.representation = initial_DataRepresentationQosPolicy_;
+  initial_TopicQos_ = TopicQosBuilder();
 
-  initial_DataWriterQos_.durability = initial_DurabilityQosPolicy_;
-  initial_DataWriterQos_.durability_service = initial_DurabilityServiceQosPolicy_;
-  initial_DataWriterQos_.deadline = initial_DeadlineQosPolicy_;
-  initial_DataWriterQos_.latency_budget = initial_LatencyBudgetQosPolicy_;
-  initial_DataWriterQos_.liveliness = initial_LivelinessQosPolicy_;
-  initial_DataWriterQos_.reliability = initial_ReliabilityQosPolicy_;
-  initial_DataWriterQos_.reliability.kind = DDS::RELIABLE_RELIABILITY_QOS;
-  initial_DataWriterQos_.reliability.max_blocking_time.sec = 0;
-  initial_DataWriterQos_.reliability.max_blocking_time.nanosec = 100000000;
-  initial_DataWriterQos_.destination_order = initial_DestinationOrderQosPolicy_;
-  initial_DataWriterQos_.history = initial_HistoryQosPolicy_;
-  initial_DataWriterQos_.resource_limits = initial_ResourceLimitsQosPolicy_;
-  initial_DataWriterQos_.transport_priority = initial_TransportPriorityQosPolicy_;
-  initial_DataWriterQos_.lifespan = initial_LifespanQosPolicy_;
-  initial_DataWriterQos_.user_data = initial_UserDataQosPolicy_;
-  initial_DataWriterQos_.ownership = initial_OwnershipQosPolicy_;
-#ifdef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
-  initial_DataWriterQos_.ownership_strength.value = 0;
-#else
-  initial_DataWriterQos_.ownership_strength = initial_OwnershipStrengthQosPolicy_;
-#endif
-  initial_DataWriterQos_.writer_data_lifecycle = initial_WriterDataLifecycleQosPolicy_;
-  initial_DataWriterQos_.representation = initial_DataRepresentationQosPolicy_;
+  initial_DataWriterQos_ = DataWriterQosBuilder();
 
   initial_PublisherQos_.presentation = initial_PresentationQosPolicy_;
   initial_PublisherQos_.partition = initial_PartitionQosPolicy_;

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -140,9 +140,7 @@ public:
   const DDS::DeadlineQosPolicy& initial_DeadlineQosPolicy() const;
   const DDS::LatencyBudgetQosPolicy& initial_LatencyBudgetQosPolicy() const;
   const DDS::OwnershipQosPolicy& initial_OwnershipQosPolicy() const;
-#ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   const DDS::OwnershipStrengthQosPolicy& initial_OwnershipStrengthQosPolicy() const;
-#endif
   const DDS::LivelinessQosPolicy& initial_LivelinessQosPolicy() const;
   const DDS::TimeBasedFilterQosPolicy& initial_TimeBasedFilterQosPolicy() const;
   const DDS::PartitionQosPolicy& initial_PartitionQosPolicy() const;
@@ -585,9 +583,7 @@ private:
   DDS::DeadlineQosPolicy              initial_DeadlineQosPolicy_;
   DDS::LatencyBudgetQosPolicy         initial_LatencyBudgetQosPolicy_;
   DDS::OwnershipQosPolicy             initial_OwnershipQosPolicy_;
-#ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   DDS::OwnershipStrengthQosPolicy     initial_OwnershipStrengthQosPolicy_;
-#endif
   DDS::LivelinessQosPolicy            initial_LivelinessQosPolicy_;
   DDS::TimeBasedFilterQosPolicy       initial_TimeBasedFilterQosPolicy_;
   DDS::PartitionQosPolicy             initial_PartitionQosPolicy_;

--- a/dds/DCPS/Time_Helper.h
+++ b/dds/DCPS/Time_Helper.h
@@ -132,6 +132,9 @@ bool is_infinite(const DDS::Duration_t& value);
 ACE_INLINE OpenDDS_Dcps_Export
 const MonotonicTime_t& monotonic_time_zero();
 
+ACE_INLINE OpenDDS_Dcps_Export
+DDS::Duration_t make_duration(int sec, unsigned long nanosec);
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/Time_Helper.inl
+++ b/dds/DCPS/Time_Helper.inl
@@ -307,6 +307,15 @@ const MonotonicTime_t& monotonic_time_zero()
   return zero;
 }
 
+ACE_INLINE OpenDDS_Dcps_Export
+DDS::Duration_t make_duration(int sec, unsigned long nanosec)
+{
+  DDS::Duration_t x;
+  x.sec = sec;
+  x.nanosec = nanosec;
+  return x;
+}
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DdsDcpsCore.idl
+++ b/dds/DdsDcpsCore.idl
@@ -217,8 +217,8 @@ module DDS {
   // This is for when we support XCDR1.
   // @appendable
   struct TransportPriorityQosPolicy {
-  long value;
-    };
+    long value;
+  };
 
   // This is for when we support XCDR1.
   // @appendable

--- a/tests/unit-tests/dds/DCPS/MockLogger.h
+++ b/tests/unit-tests/dds/DCPS/MockLogger.h
@@ -1,0 +1,47 @@
+#ifndef TEST_DDS_DCPS_MOCK_LOGGER_H
+#define TEST_DDS_DCPS_MOCK_LOGGER_H
+
+#include <gmock/gmock.h>
+
+#include <ace/Log_Msg_Backend.h>
+#include <ace/Log_Record.h>
+
+#include "dds/Versioned_Namespace.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace Test {
+
+class MockLogger : public ACE_Log_Msg_Backend {
+public:
+  MockLogger()
+  {
+    // Install as backend.
+    previous_ = ACE_Log_Msg::msg_backend(this);
+    ACE_Log_Msg::instance()->set_flags(ACE_Log_Msg::CUSTOM);
+    ACE_Log_Msg::instance()->clr_flags(ACE_Log_Msg::STDERR);
+  }
+
+  ~MockLogger()
+  {
+    ACE_Log_Msg::instance()->clr_flags(ACE_Log_Msg::CUSTOM);
+    ACE_Log_Msg::instance()->set_flags(ACE_Log_Msg::STDERR);
+    ACE_Log_Msg::msg_backend(previous_);
+  }
+
+  MOCK_METHOD1(open, int(const ACE_TCHAR*));
+  MOCK_METHOD0(reset, int());
+  MOCK_METHOD0(close, int());
+  MOCK_METHOD1(log, ssize_t(ACE_Log_Record&));
+
+private:
+  ACE_Log_Msg_Backend* previous_;
+};
+
+}
+}
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif // TEST_DDS_DCPS_MOCK_LOGGER_H

--- a/tests/unit-tests/dds/DCPS/MockPublisher.h
+++ b/tests/unit-tests/dds/DCPS/MockPublisher.h
@@ -1,0 +1,52 @@
+#ifndef TEST_DDS_DCPS_MOCK_PUBLISHER_H
+#define TEST_DDS_DCPS_MOCK_PUBLISHER_H
+
+#include <gmock/gmock.h>
+
+#include "dds/DCPS/LocalObject.h"
+#include "dds/DCPS/EntityImpl.h"
+#include "dds/DCPS/Qos_Helper.h"
+
+#include "dds/Versioned_Namespace.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace Test {
+
+class MockPublisher
+  : public virtual OpenDDS::DCPS::LocalObject<DDS::Publisher>
+  , public virtual OpenDDS::DCPS::EntityImpl {
+public:
+  MOCK_METHOD0(enable, DDS::ReturnCode_t(void));
+  MOCK_METHOD0(get_instance_handle, DDS::InstanceHandle_t(void));
+  MOCK_METHOD4(create_datawriter, DDS::DataWriter_ptr(DDS::Topic_ptr a_topic,
+                                                      const DDS::DataWriterQos & qos,
+                                                      DDS::DataWriterListener_ptr a_listener,
+                                                      DDS::StatusMask mask));
+  MOCK_METHOD1(delete_datawriter, DDS::ReturnCode_t(DDS::DataWriter_ptr a_datawriter));
+  MOCK_METHOD1(lookup_datawriter, DDS::DataWriter_ptr(const char * topic_name));
+  MOCK_METHOD0(delete_contained_entities, DDS::ReturnCode_t(void));
+  MOCK_METHOD1(set_qos, DDS::ReturnCode_t(const DDS::PublisherQos & qos));
+  MOCK_METHOD1(get_qos, DDS::ReturnCode_t(DDS::PublisherQos & qos));
+  MOCK_METHOD2(set_listener, DDS::ReturnCode_t(DDS::PublisherListener_ptr a_listener,
+                                               DDS::StatusMask mask));
+  MOCK_METHOD0(get_listener, DDS::PublisherListener_ptr(void));
+  MOCK_METHOD0(suspend_publications, DDS::ReturnCode_t(void));
+  MOCK_METHOD0(resume_publications, DDS::ReturnCode_t(void));
+  MOCK_METHOD0(begin_coherent_changes, DDS::ReturnCode_t(void));
+  MOCK_METHOD0(end_coherent_changes, DDS::ReturnCode_t(void));
+  MOCK_METHOD1(wait_for_acknowledgments, DDS::ReturnCode_t(const DDS::Duration_t & max_wait));
+  MOCK_METHOD0(get_participant, DDS::DomainParticipant_ptr(void));
+  MOCK_METHOD1(set_default_datawriter_qos, DDS::ReturnCode_t(const DDS::DataWriterQos & qos));
+  MOCK_METHOD1(get_default_datawriter_qos, DDS::ReturnCode_t(DDS::DataWriterQos & qos));
+  MOCK_METHOD2(copy_from_topic_qos, DDS::ReturnCode_t(DDS::DataWriterQos & a_datawriter_qos,
+                                                      const DDS::TopicQos & a_topic_qos));
+};
+
+}
+}
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif // TEST_DDS_DCPS_MOCK_PUBLISHER_H

--- a/tests/unit-tests/dds/DCPS/MockTopic.h
+++ b/tests/unit-tests/dds/DCPS/MockTopic.h
@@ -1,0 +1,39 @@
+#ifndef TEST_DDS_DCPS_MOCK_TOPIC_H
+#define TEST_DDS_DCPS_MOCK_TOPIC_H
+
+#include <gmock/gmock.h>
+
+#include "dds/DCPS/LocalObject.h"
+#include "dds/DCPS/EntityImpl.h"
+#include "dds/DCPS/Qos_Helper.h"
+
+#include "dds/Versioned_Namespace.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace Test {
+
+class MockTopic
+  : public virtual OpenDDS::DCPS::LocalObject<DDS::Topic>
+  , public virtual OpenDDS::DCPS::EntityImpl {
+public:
+  MOCK_METHOD0(enable, DDS::ReturnCode_t(void));
+  MOCK_METHOD0(get_instance_handle, DDS::InstanceHandle_t(void));
+  MOCK_METHOD0(get_type_name, char*(void));
+  MOCK_METHOD0(get_name, char*(void));
+  MOCK_METHOD0(get_participant, DDS::DomainParticipant_ptr(void));
+  MOCK_METHOD1(set_qos, DDS::ReturnCode_t(const DDS::TopicQos & qos));
+  MOCK_METHOD1(get_qos, DDS::ReturnCode_t(DDS::TopicQos & qos));
+  MOCK_METHOD2(set_listener, DDS::ReturnCode_t(DDS::TopicListener_ptr a_listener,
+                                               DDS::StatusMask mask));
+  MOCK_METHOD0(get_listener, DDS::TopicListener_ptr(void));
+  MOCK_METHOD1(get_inconsistent_topic_status, DDS::ReturnCode_t(DDS::InconsistentTopicStatus & a_status));
+};
+
+}
+}
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif // TEST_DDS_DCPS_MOCK_PUBLISHER_H

--- a/tests/unit-tests/dds/DCPS/Qos_Helper.cpp
+++ b/tests/unit-tests/dds/DCPS/Qos_Helper.cpp
@@ -1,18 +1,21 @@
 // -*- C++ -*-
-// ============================================================================
-/**
- *  @file   LivelinessCompatibility.cpp
- *
- *
- *
- */
-// ============================================================================
 
 #include <gtest/gtest.h>
 
-#include "dds/DdsDcpsInfrastructureC.h"
 #include "dds/DCPS/Qos_Helper.h"
+
+#include "MockTopic.h"
+#include "MockPublisher.h"
+#include "MockLogger.h"
+
+#include "dds/DdsDcpsInfrastructureC.h"
+#include "dds/DCPS/Time_Helper.h"
 #include "dds/DCPS/Definitions.h"
+
+
+const DDS::Duration_t zero = { DDS::DURATION_ZERO_SEC, DDS::DURATION_ZERO_NSEC };
+const DDS::Duration_t infinite = { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+const DDS::Duration_t ms100 = { 0, 100000000 };
 
 bool
 lease_greater_than (::DDS::LivelinessQosPolicy const & qos1,
@@ -132,4 +135,1283 @@ TEST(dds_DCPS_Qos_Helper, maintest)
     EXPECT_TRUE(!lease_greater_than(dw_liveliness, dr_liveliness));
     EXPECT_TRUE(lease_greater_than(dr_liveliness, dw_liveliness));
   }
+}
+
+TEST(dds_DCPS_Qos_Helper, TransportPriorityQosPolicyBuilder_default_ctor)
+{
+  const OpenDDS::DCPS::TransportPriorityQosPolicyBuilder uut;
+  const DDS::TransportPriorityQosPolicy& qos = uut;
+  EXPECT_EQ(qos.value, 0);
+}
+
+TEST(dds_DCPS_Qos_Helper, TransportPriorityQosPolicyBuilder_ctor)
+{
+  OpenDDS::DCPS::TransportPriorityQosPolicyBuilder uut;
+  uut.qos().value = 5;
+  DDS::TransportPriorityQosPolicy& qos = uut;
+  qos.value = 3;
+
+  EXPECT_EQ(uut.qos().value, 3);
+}
+
+TEST(dds_DCPS_Qos_Helper, TransportPriorityQosPolicyBuilder_value)
+{
+  OpenDDS::DCPS::TransportPriorityQosPolicyBuilder uut;
+  uut.value(3);
+  EXPECT_EQ(uut.qos().value, 3);
+}
+
+TEST(dds_DCPS_Qos_Helper, LifespanQosPolicyBuilder_default_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  const OpenDDS::DCPS::LifespanQosPolicyBuilder uut;
+  const DDS::LifespanQosPolicy& qos = uut;
+  EXPECT_TRUE(qos.duration == infinite);
+}
+
+TEST(dds_DCPS_Qos_Helper, LifespanQosPolicyBuilder_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  OpenDDS::DCPS::LifespanQosPolicyBuilder uut;
+  uut.qos().duration = zero;
+  DDS::LifespanQosPolicy& qos = uut;
+  qos.duration = ms100;
+
+  EXPECT_TRUE(uut.qos().duration == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, LifespanQosPolicyBuilder_duration)
+{
+  using OpenDDS::DCPS::operator==;
+
+  OpenDDS::DCPS::LifespanQosPolicyBuilder uut;
+  uut.duration(zero);
+  EXPECT_TRUE(uut.qos().duration == zero);
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityQosPolicyBuilder_default_ctor)
+{
+  const OpenDDS::DCPS::DurabilityQosPolicyBuilder uut;
+  const DDS::DurabilityQosPolicy& qos = uut;
+  EXPECT_EQ(qos.kind, DDS::VOLATILE_DURABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityQosPolicyBuilder_ctor)
+{
+  OpenDDS::DCPS::DurabilityQosPolicyBuilder uut;
+  uut.qos().kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+  DDS::DurabilityQosPolicy& qos = uut;
+  qos.kind = DDS::TRANSIENT_DURABILITY_QOS;
+
+  EXPECT_EQ(uut.qos().kind, DDS::TRANSIENT_DURABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityQosPolicyBuilder_kind)
+{
+  OpenDDS::DCPS::DurabilityQosPolicyBuilder uut;
+  uut.kind(DDS::TRANSIENT_DURABILITY_QOS);
+  EXPECT_EQ(uut.qos().kind, DDS::TRANSIENT_DURABILITY_QOS);;
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityQosPolicyBuilder_volatile)
+{
+  OpenDDS::DCPS::DurabilityQosPolicyBuilder uut;
+  uut._volatile();
+  EXPECT_EQ(uut.qos().kind, DDS::VOLATILE_DURABILITY_QOS);;
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityQosPolicyBuilder_transient_local)
+{
+  OpenDDS::DCPS::DurabilityQosPolicyBuilder uut;
+  uut.transient_local();
+  EXPECT_EQ(uut.qos().kind, DDS::TRANSIENT_LOCAL_DURABILITY_QOS);;
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityQosPolicyBuilder_transient)
+{
+  OpenDDS::DCPS::DurabilityQosPolicyBuilder uut;
+  uut.transient();
+  EXPECT_EQ(uut.qos().kind, DDS::TRANSIENT_DURABILITY_QOS);;
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityQosPolicyBuilder_persistent)
+{
+  OpenDDS::DCPS::DurabilityQosPolicyBuilder uut;
+  uut.persistent();
+  EXPECT_EQ(uut.qos().kind, DDS::PERSISTENT_DURABILITY_QOS);;
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityServiceQosPolicyBuilder_default_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  const OpenDDS::DCPS::DurabilityServiceQosPolicyBuilder uut;
+  const DDS::DurabilityServiceQosPolicy& qos = uut;
+  EXPECT_TRUE(qos.service_cleanup_delay == zero);
+  EXPECT_EQ(qos.history_kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(qos.history_depth, 1);
+  EXPECT_EQ(qos.max_samples, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.max_instances, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.max_samples_per_instance, DDS::LENGTH_UNLIMITED);
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityServiceQosPolicyBuilder_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  OpenDDS::DCPS::DurabilityServiceQosPolicyBuilder uut;
+  uut.qos().history_kind = DDS::KEEP_ALL_HISTORY_QOS;
+  DDS::DurabilityServiceQosPolicy& qos = uut;
+  qos.history_depth = 3;
+
+  EXPECT_TRUE(uut.qos().service_cleanup_delay == zero);
+  EXPECT_EQ(uut.qos().history_kind, DDS::KEEP_ALL_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().history_depth, 3);
+  EXPECT_EQ(uut.qos().max_samples, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(uut.qos().max_instances, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(uut.qos().max_samples_per_instance, DDS::LENGTH_UNLIMITED);
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityServiceQosPolicyBuilder_service_cleanup_delay)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::DurabilityServiceQosPolicyBuilder uut;
+  uut.service_cleanup_delay(ms100);
+  EXPECT_TRUE(uut.qos().service_cleanup_delay == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityServiceQosPolicyBuilder_history_kind)
+{
+  OpenDDS::DCPS::DurabilityServiceQosPolicyBuilder uut;
+  uut.history_kind(DDS::KEEP_ALL_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().history_kind, DDS::KEEP_ALL_HISTORY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityServiceQosPolicyBuilder_keep_last)
+{
+  OpenDDS::DCPS::DurabilityServiceQosPolicyBuilder uut;
+  uut.keep_last(5);
+  EXPECT_EQ(uut.qos().history_kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().history_depth, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityServiceQosPolicyBuilder_keep_all)
+{
+  OpenDDS::DCPS::DurabilityServiceQosPolicyBuilder uut;
+  uut.keep_all();
+  EXPECT_EQ(uut.qos().history_kind, DDS::KEEP_ALL_HISTORY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityServiceQosPolicyBuilder_history_depth)
+{
+  OpenDDS::DCPS::DurabilityServiceQosPolicyBuilder uut;
+  uut.history_depth(5);
+  EXPECT_EQ(uut.qos().history_depth, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityServiceQosPolicyBuilder_max_samples)
+{
+  OpenDDS::DCPS::DurabilityServiceQosPolicyBuilder uut;
+  uut.max_samples(5);
+  EXPECT_EQ(uut.qos().max_samples, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityServiceQosPolicyBuilder_max_instances)
+{
+  OpenDDS::DCPS::DurabilityServiceQosPolicyBuilder uut;
+  uut.max_instances(5);
+  EXPECT_EQ(uut.qos().max_instances, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DurabilityServiceQosPolicyBuilder_max_samples_per_instance)
+{
+  OpenDDS::DCPS::DurabilityServiceQosPolicyBuilder uut;
+  uut.max_samples_per_instance(5);
+  EXPECT_EQ(uut.qos().max_samples_per_instance, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DeadlineQosPolicyBuilder_default_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  const OpenDDS::DCPS::DeadlineQosPolicyBuilder uut;
+  const DDS::DeadlineQosPolicy& qos = uut;
+  EXPECT_TRUE(qos.period == infinite);
+}
+
+TEST(dds_DCPS_Qos_Helper, DeadlineQosPolicyBuilder_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  OpenDDS::DCPS::DeadlineQosPolicyBuilder uut;
+  uut.qos().period = zero;
+  DDS::DeadlineQosPolicy& qos = uut;
+  qos.period = ms100;
+
+  EXPECT_TRUE(uut.qos().period == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, DeadlineQosPolicyBuilder_period)
+{
+  using OpenDDS::DCPS::operator==;
+
+  OpenDDS::DCPS::DeadlineQosPolicyBuilder uut;
+  uut.period(zero);
+  EXPECT_TRUE(uut.qos().period == zero);
+}
+
+TEST(dds_DCPS_Qos_Helper, LatencyBudgetQosPolicyBuilder_default_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  const OpenDDS::DCPS::LatencyBudgetQosPolicyBuilder uut;
+  const DDS::LatencyBudgetQosPolicy& qos = uut;
+  EXPECT_TRUE(qos.duration == zero);
+}
+
+TEST(dds_DCPS_Qos_Helper, LatencyBudgetQosPolicyBuilder_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  OpenDDS::DCPS::LatencyBudgetQosPolicyBuilder uut;
+  uut.qos().duration = infinite;
+  DDS::LatencyBudgetQosPolicy& qos = uut;
+  qos.duration = ms100;
+
+  EXPECT_TRUE(uut.qos().duration == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, LatencyBudgetQosPolicyBuilder_duration)
+{
+  using OpenDDS::DCPS::operator==;
+
+  OpenDDS::DCPS::LatencyBudgetQosPolicyBuilder uut;
+  uut.duration(zero);
+  EXPECT_TRUE(uut.qos().duration == zero);
+}
+
+TEST(dds_DCPS_Qos_Helper, OwnershipQosPolicyBuilder_default_ctor)
+{
+  const OpenDDS::DCPS::OwnershipQosPolicyBuilder uut;
+  const DDS::OwnershipQosPolicy& qos = uut;
+  EXPECT_EQ(qos.kind, DDS::SHARED_OWNERSHIP_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, OwnershipQosPolicyBuilder_ctor)
+{
+  OpenDDS::DCPS::OwnershipQosPolicyBuilder uut;
+  uut.qos().kind = DDS::SHARED_OWNERSHIP_QOS;
+  DDS::OwnershipQosPolicy& qos = uut;
+  qos.kind = DDS::EXCLUSIVE_OWNERSHIP_QOS;
+
+  EXPECT_EQ(uut.qos().kind, DDS::EXCLUSIVE_OWNERSHIP_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, OwnershipQosPolicyBuilder_kind)
+{
+  OpenDDS::DCPS::OwnershipQosPolicyBuilder uut;
+  uut.kind(DDS::EXCLUSIVE_OWNERSHIP_QOS);
+  EXPECT_EQ(uut.qos().kind, DDS::EXCLUSIVE_OWNERSHIP_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, OwnershipQosPolicyBuilder_shared)
+{
+  OpenDDS::DCPS::OwnershipQosPolicyBuilder uut;
+  uut.shared();
+  EXPECT_EQ(uut.qos().kind, DDS::SHARED_OWNERSHIP_QOS);;
+}
+
+TEST(dds_DCPS_Qos_Helper, OwnershipQosPolicyBuilder_exclusive)
+{
+  OpenDDS::DCPS::OwnershipQosPolicyBuilder uut;
+  uut.exclusive();
+  EXPECT_EQ(uut.qos().kind, DDS::EXCLUSIVE_OWNERSHIP_QOS);;
+}
+
+TEST(dds_DCPS_Qos_Helper, OwnershipStrengthQosPolicyBuilder_default_ctor)
+{
+  const OpenDDS::DCPS::OwnershipStrengthQosPolicyBuilder uut;
+  const DDS::OwnershipStrengthQosPolicy& qos = uut;
+  EXPECT_EQ(qos.value, 0);
+}
+
+TEST(dds_DCPS_Qos_Helper, OwnershipStrengthQosPolicyBuilder_ctor)
+{
+  OpenDDS::DCPS::OwnershipStrengthQosPolicyBuilder uut;
+  uut.qos().value = 5;
+  DDS::OwnershipStrengthQosPolicy& qos = uut;
+  qos.value = 3;
+
+  EXPECT_EQ(uut.qos().value, 3);
+}
+
+TEST(dds_DCPS_Qos_Helper, OwnershipStrengthQosPolicyBuilder_value)
+{
+  OpenDDS::DCPS::OwnershipStrengthQosPolicyBuilder uut;
+  uut.value(3);
+  EXPECT_EQ(uut.qos().value, 3);
+}
+
+TEST(dds_DCPS_Qos_Helper, LivelinessQosPolicyBuilder_default_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+  const OpenDDS::DCPS::LivelinessQosPolicyBuilder uut;
+  const DDS::LivelinessQosPolicy& qos = uut;
+  EXPECT_EQ(qos.kind, DDS::AUTOMATIC_LIVELINESS_QOS);
+  EXPECT_TRUE(qos.lease_duration == infinite);
+}
+
+TEST(dds_DCPS_Qos_Helper, LivelinessQosPolicyBuilder_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::LivelinessQosPolicyBuilder uut;
+  uut.qos().kind = DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+  DDS::LivelinessQosPolicy& qos = uut;
+  qos.lease_duration = ms100;
+
+  EXPECT_EQ(uut.qos().kind, DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
+  EXPECT_TRUE(qos.lease_duration == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, LivelinessQosPolicyBuilder_kind)
+{
+  OpenDDS::DCPS::LivelinessQosPolicyBuilder uut;
+  uut.kind(DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
+  EXPECT_EQ(uut.qos().kind, DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, LivelinessQosPolicyBuilder_automatic)
+{
+  OpenDDS::DCPS::LivelinessQosPolicyBuilder uut;
+  uut.automatic();
+  EXPECT_EQ(uut.qos().kind, DDS::AUTOMATIC_LIVELINESS_QOS);;
+}
+
+TEST(dds_DCPS_Qos_Helper, LivelinessQosPolicyBuilder_manual_by_participant)
+{
+  OpenDDS::DCPS::LivelinessQosPolicyBuilder uut;
+  uut.manual_by_participant();
+  EXPECT_EQ(uut.qos().kind, DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);;
+}
+
+TEST(dds_DCPS_Qos_Helper, LivelinessQosPolicyBuilder_manual_by_topic)
+{
+  OpenDDS::DCPS::LivelinessQosPolicyBuilder uut;
+  uut.manual_by_topic();
+  EXPECT_EQ(uut.qos().kind, DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS);;
+}
+
+TEST(dds_DCPS_Qos_Helper, LivelinessQosPolicyBuilder_lease_duration)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::LivelinessQosPolicyBuilder uut;
+  uut.lease_duration(ms100);
+  EXPECT_TRUE(uut.qos().lease_duration == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, ResourceLimitsQosPolicyBuilder_default_ctor)
+{
+  const OpenDDS::DCPS::ResourceLimitsQosPolicyBuilder uut;
+  const DDS::ResourceLimitsQosPolicy& qos = uut;
+  EXPECT_EQ(qos.max_samples, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.max_instances, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.max_samples_per_instance, DDS::LENGTH_UNLIMITED);
+}
+
+TEST(dds_DCPS_Qos_Helper, ResourceLimitsQosPolicyBuilder_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  OpenDDS::DCPS::ResourceLimitsQosPolicyBuilder uut;
+  uut.qos().max_samples = 1;
+  DDS::ResourceLimitsQosPolicy& qos = uut;
+  qos.max_instances = 2;
+
+  EXPECT_EQ(uut.qos().max_samples, 1);
+  EXPECT_EQ(uut.qos().max_instances, 2);
+  EXPECT_EQ(uut.qos().max_samples_per_instance, DDS::LENGTH_UNLIMITED);
+}
+
+TEST(dds_DCPS_Qos_Helper, ResourceLimitsQosPolicyBuilder_max_samples)
+{
+  OpenDDS::DCPS::ResourceLimitsQosPolicyBuilder uut;
+  uut.max_samples(5);
+  EXPECT_EQ(uut.qos().max_samples, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, ResourceLimitsQosPolicyBuilder_max_instances)
+{
+  OpenDDS::DCPS::ResourceLimitsQosPolicyBuilder uut;
+  uut.max_instances(5);
+  EXPECT_EQ(uut.qos().max_instances, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, ResourceLimitsQosPolicyBuilder_max_samples_per_instance)
+{
+  OpenDDS::DCPS::ResourceLimitsQosPolicyBuilder uut;
+  uut.max_samples_per_instance(5);
+  EXPECT_EQ(uut.qos().max_samples_per_instance, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, WriterDataLifecycleQosPolicyBuilder_default_ctor)
+{
+  const OpenDDS::DCPS::WriterDataLifecycleQosPolicyBuilder uut;
+  const DDS::WriterDataLifecycleQosPolicy& qos = uut;
+  EXPECT_EQ(qos.autodispose_unregistered_instances, true);
+}
+
+TEST(dds_DCPS_Qos_Helper, WriterDataLifecycleQosPolicyBuilder_ctor)
+{
+  OpenDDS::DCPS::WriterDataLifecycleQosPolicyBuilder uut;
+  uut.qos().autodispose_unregistered_instances = false;
+  DDS::WriterDataLifecycleQosPolicy& qos = uut;
+  qos.autodispose_unregistered_instances = true;
+
+  EXPECT_EQ(uut.qos().autodispose_unregistered_instances, true);
+}
+
+TEST(dds_DCPS_Qos_Helper, WriterDataLifecycleQosPolicyBuilder_autodispose_unregistered_instances)
+{
+  OpenDDS::DCPS::WriterDataLifecycleQosPolicyBuilder uut;
+  uut.autodispose_unregistered_instances(false);
+  EXPECT_EQ(uut.qos().autodispose_unregistered_instances, false);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_default_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  const OpenDDS::DCPS::TopicQosBuilder uut;
+  const DDS::TopicQos& qos = uut;
+  EXPECT_EQ(qos.topic_data.value.length(), 0u);
+  EXPECT_EQ(qos.durability.kind, DDS::VOLATILE_DURABILITY_QOS);
+  EXPECT_TRUE(qos.durability_service.service_cleanup_delay == zero);
+  EXPECT_EQ(qos.durability_service.history_kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(qos.durability_service.history_depth, 1);
+  EXPECT_EQ(qos.durability_service.max_samples, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.durability_service.max_instances, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.durability_service.max_samples_per_instance, DDS::LENGTH_UNLIMITED);
+  EXPECT_TRUE(qos.deadline.period == infinite);
+  EXPECT_TRUE(qos.latency_budget.duration == zero);
+  EXPECT_EQ(qos.liveliness.kind, DDS::AUTOMATIC_LIVELINESS_QOS);
+  EXPECT_TRUE(qos.liveliness.lease_duration == infinite);
+  EXPECT_EQ(qos.reliability.kind, DDS::BEST_EFFORT_RELIABILITY_QOS);
+  EXPECT_TRUE(qos.reliability.max_blocking_time == infinite);
+  EXPECT_EQ(qos.destination_order.kind, DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS);
+  EXPECT_EQ(qos.history.kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(qos.history.depth, 1);
+  EXPECT_EQ(qos.resource_limits.max_samples, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.resource_limits.max_instances, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.resource_limits.max_samples_per_instance, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.transport_priority.value, 0);
+  EXPECT_TRUE(qos.lifespan.duration == infinite);
+  EXPECT_EQ(qos.ownership.kind, DDS::SHARED_OWNERSHIP_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.qos().durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+  DDS::TopicQos& qos = uut;
+  qos.history.depth = 3;
+
+  EXPECT_EQ(uut.qos().topic_data.value.length(), 0u);
+  EXPECT_EQ(uut.qos().durability.kind, DDS::TRANSIENT_LOCAL_DURABILITY_QOS);
+  EXPECT_TRUE(uut.qos().durability_service.service_cleanup_delay == zero);
+  EXPECT_EQ(uut.qos().durability_service.history_kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().durability_service.history_depth, 1);
+  EXPECT_EQ(uut.qos().durability_service.max_samples, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(uut.qos().durability_service.max_instances, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(uut.qos().durability_service.max_samples_per_instance, DDS::LENGTH_UNLIMITED);
+  EXPECT_TRUE(uut.qos().deadline.period == infinite);
+  EXPECT_TRUE(uut.qos().latency_budget.duration == zero);
+  EXPECT_EQ(uut.qos().liveliness.kind, DDS::AUTOMATIC_LIVELINESS_QOS);
+  EXPECT_TRUE(uut.qos().liveliness.lease_duration == infinite);
+  EXPECT_EQ(uut.qos().reliability.kind, DDS::BEST_EFFORT_RELIABILITY_QOS);
+  EXPECT_TRUE(uut.qos().reliability.max_blocking_time == infinite);
+  EXPECT_EQ(uut.qos().destination_order.kind, DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS);
+  EXPECT_EQ(uut.qos().history.kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().history.depth, 3);
+  EXPECT_EQ(uut.qos().resource_limits.max_samples, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(uut.qos().resource_limits.max_instances, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(uut.qos().resource_limits.max_samples_per_instance, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(uut.qos().transport_priority.value, 0);
+  EXPECT_TRUE(uut.qos().lifespan.duration == infinite);
+  EXPECT_EQ(uut.qos().ownership.kind, DDS::SHARED_OWNERSHIP_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_topic_data_value)
+{
+  using OpenDDS::DCPS::operator==;
+  DDS::OctetSeq topic_data;
+  topic_data.length(1);
+  topic_data[0] = 'A';
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.topic_data_value(topic_data);
+  EXPECT_TRUE(uut.qos().topic_data.value == topic_data);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_kind)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_kind(DDS::TRANSIENT_LOCAL_DURABILITY_QOS);
+  EXPECT_EQ(uut.qos().durability.kind, DDS::TRANSIENT_LOCAL_DURABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_volatile)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_transient_local().durability_volatile();
+  EXPECT_EQ(uut.qos().durability.kind, DDS::VOLATILE_DURABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_transient_local)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_transient_local();
+  EXPECT_EQ(uut.qos().durability.kind, DDS::TRANSIENT_LOCAL_DURABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_transient)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_transient();
+  EXPECT_EQ(uut.qos().durability.kind, DDS::TRANSIENT_DURABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_persistent)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_persistent();
+  EXPECT_EQ(uut.qos().durability.kind, DDS::PERSISTENT_DURABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_service_service_cleanup_delay)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_service_service_cleanup_delay(ms100);
+  EXPECT_TRUE(uut.qos().durability_service.service_cleanup_delay == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_service_history_kind)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_service_history_kind(DDS::KEEP_ALL_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().durability_service.history_kind, DDS::KEEP_ALL_HISTORY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_service_keep_last)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_service_keep_last(5);
+  EXPECT_EQ(uut.qos().durability_service.history_kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().durability_service.history_depth, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_service_keep_all)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_service_keep_all();
+  EXPECT_EQ(uut.qos().durability_service.history_kind, DDS::KEEP_ALL_HISTORY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_service_history_depth)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_service_history_depth(5);
+  EXPECT_EQ(uut.qos().durability_service.history_depth, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_service_max_samples)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_service_max_samples(5);
+  EXPECT_EQ(uut.qos().durability_service.max_samples, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_service_max_instances)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_service_max_instances(5);
+  EXPECT_EQ(uut.qos().durability_service.max_instances, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_durability_service_max_samples_per_instance)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.durability_service_max_samples_per_instance(5);
+  EXPECT_EQ(uut.qos().durability_service.max_samples_per_instance, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_deadline_period)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.deadline_period(ms100);
+  EXPECT_TRUE(uut.qos().deadline.period == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_latency_budget_duration)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.latency_budget_duration(ms100);
+  EXPECT_TRUE(uut.qos().latency_budget.duration == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_liveliness_kind)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.liveliness_kind(DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
+  EXPECT_EQ(uut.qos().liveliness.kind, DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_liveliness_automatic)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.liveliness_manual_by_participant().liveliness_automatic();
+  EXPECT_EQ(uut.qos().liveliness.kind, DDS::AUTOMATIC_LIVELINESS_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_liveliness_manual_by_participant)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.liveliness_manual_by_participant().liveliness_manual_by_participant();
+  EXPECT_EQ(uut.qos().liveliness.kind, DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_liveliness_manual_by_topic)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.liveliness_manual_by_topic().liveliness_manual_by_topic();
+  EXPECT_EQ(uut.qos().liveliness.kind, DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_liveliness_lease_duration)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.liveliness_lease_duration(ms100);
+  EXPECT_TRUE(uut.qos().liveliness.lease_duration == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_reliability_kind)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.reliability_kind(DDS::BEST_EFFORT_RELIABILITY_QOS);
+  EXPECT_EQ(uut.qos().reliability.kind, DDS::BEST_EFFORT_RELIABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_reliability_best_effort)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.reliability_best_effort();
+  EXPECT_EQ(uut.qos().reliability.kind, DDS::BEST_EFFORT_RELIABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_reliability_reliable)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.reliability_best_effort().reliability_reliable();
+  EXPECT_EQ(uut.qos().reliability.kind, DDS::RELIABLE_RELIABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_reliability_max_blocking_time)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.reliability_max_blocking_time(zero);
+  EXPECT_TRUE(uut.qos().reliability.max_blocking_time == zero);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_destination_order_kind)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.destination_order_kind(DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
+  EXPECT_EQ(uut.qos().destination_order.kind, DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_destination_order_by_source_timestamp)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.destination_order_by_source_timestamp();
+  EXPECT_EQ(uut.qos().destination_order.kind, DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_destination_order_by_reception_timestamp)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.destination_order_by_source_timestamp().destination_order_by_reception_timestamp();
+  EXPECT_EQ(uut.qos().destination_order.kind, DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_history_kind)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.history_kind(DDS::KEEP_ALL_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().history.kind, DDS::KEEP_ALL_HISTORY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_history_keep_last)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.history_keep_last(5);
+  EXPECT_EQ(uut.qos().history.kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().history.depth, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_history_keep_all)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.history_keep_all();
+  EXPECT_EQ(uut.qos().history.kind, DDS::KEEP_ALL_HISTORY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_history_depth)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.history_depth(5);
+  EXPECT_EQ(uut.qos().history.depth, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_resource_limits_max_samples)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.resource_limits_max_samples(5);
+  EXPECT_EQ(uut.qos().resource_limits.max_samples, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_resource_limits_max_instances)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.resource_limits_max_instances(5);
+  EXPECT_EQ(uut.qos().resource_limits.max_instances, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_resource_limits_max_samples_per_instance)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.resource_limits_max_samples_per_instance(5);
+  EXPECT_EQ(uut.qos().resource_limits.max_samples_per_instance, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_transport_priority_value)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.transport_priority_value(5);
+  EXPECT_EQ(uut.qos().transport_priority.value, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_lifespan_duration)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.lifespan_duration(ms100);
+  EXPECT_TRUE(uut.qos().lifespan.duration == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_ownership_kind)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.ownership_kind(DDS::EXCLUSIVE_OWNERSHIP_QOS);
+  EXPECT_EQ(uut.qos().ownership.kind, DDS::EXCLUSIVE_OWNERSHIP_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_ownership_shared)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.ownership_shared();
+  EXPECT_EQ(uut.qos().ownership.kind, DDS::SHARED_OWNERSHIP_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, TopicQosBuilder_ownership_exclusive)
+{
+  OpenDDS::DCPS::TopicQosBuilder uut;
+  uut.ownership_exclusive();
+  EXPECT_EQ(uut.qos().ownership.kind, DDS::EXCLUSIVE_OWNERSHIP_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_default_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  const OpenDDS::DCPS::DataWriterQosBuilder uut;
+  const DDS::DataWriterQos& qos = uut;
+  EXPECT_EQ(qos.durability.kind, DDS::VOLATILE_DURABILITY_QOS);
+  EXPECT_TRUE(qos.durability_service.service_cleanup_delay == zero);
+  EXPECT_EQ(qos.durability_service.history_kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(qos.durability_service.history_depth, 1);
+  EXPECT_EQ(qos.durability_service.max_samples, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.durability_service.max_instances, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.durability_service.max_samples_per_instance, DDS::LENGTH_UNLIMITED);
+  EXPECT_TRUE(qos.deadline.period == infinite);
+  EXPECT_TRUE(qos.latency_budget.duration == zero);
+  EXPECT_EQ(qos.liveliness.kind, DDS::AUTOMATIC_LIVELINESS_QOS);
+  EXPECT_TRUE(qos.liveliness.lease_duration == infinite);
+  EXPECT_EQ(qos.reliability.kind, DDS::RELIABLE_RELIABILITY_QOS);
+  EXPECT_TRUE(qos.reliability.max_blocking_time == ms100);
+  EXPECT_EQ(qos.destination_order.kind, DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS);
+  EXPECT_EQ(qos.history.kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(qos.history.depth, 1);
+  EXPECT_EQ(qos.resource_limits.max_samples, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.resource_limits.max_instances, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.resource_limits.max_samples_per_instance, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(qos.transport_priority.value, 0);
+  EXPECT_TRUE(qos.lifespan.duration == infinite);
+  EXPECT_EQ(qos.user_data.value.length(), 0u);
+  EXPECT_EQ(qos.ownership.kind, DDS::SHARED_OWNERSHIP_QOS);
+  EXPECT_EQ(qos.ownership_strength.value, 0);
+  EXPECT_EQ(qos.writer_data_lifecycle.autodispose_unregistered_instances, true);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_ctor)
+{
+  using OpenDDS::DCPS::operator==;
+
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.qos().durability.kind = DDS::TRANSIENT_LOCAL_DURABILITY_QOS;
+  DDS::DataWriterQos& qos = uut;
+  qos.history.depth = 3;
+
+  EXPECT_EQ(uut.qos().durability.kind, DDS::TRANSIENT_LOCAL_DURABILITY_QOS);
+  EXPECT_TRUE(uut.qos().durability_service.service_cleanup_delay == zero);
+  EXPECT_EQ(uut.qos().durability_service.history_kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().durability_service.history_depth, 1);
+  EXPECT_EQ(uut.qos().durability_service.max_samples, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(uut.qos().durability_service.max_instances, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(uut.qos().durability_service.max_samples_per_instance, DDS::LENGTH_UNLIMITED);
+  EXPECT_TRUE(uut.qos().deadline.period == infinite);
+  EXPECT_TRUE(uut.qos().latency_budget.duration == zero);
+  EXPECT_EQ(uut.qos().liveliness.kind, DDS::AUTOMATIC_LIVELINESS_QOS);
+  EXPECT_TRUE(uut.qos().liveliness.lease_duration == infinite);
+  EXPECT_EQ(uut.qos().reliability.kind, DDS::RELIABLE_RELIABILITY_QOS);
+  EXPECT_TRUE(uut.qos().reliability.max_blocking_time == ms100);
+  EXPECT_EQ(uut.qos().destination_order.kind, DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS);
+  EXPECT_EQ(uut.qos().history.kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().history.depth, 3);
+  EXPECT_EQ(uut.qos().resource_limits.max_samples, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(uut.qos().resource_limits.max_instances, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(uut.qos().resource_limits.max_samples_per_instance, DDS::LENGTH_UNLIMITED);
+  EXPECT_EQ(uut.qos().transport_priority.value, 0);
+  EXPECT_TRUE(uut.qos().lifespan.duration == infinite);
+  EXPECT_EQ(uut.qos().user_data.value.length(), 0u);
+  EXPECT_EQ(uut.qos().ownership.kind, DDS::SHARED_OWNERSHIP_QOS);
+  EXPECT_EQ(uut.qos().ownership_strength.value, 0);
+  EXPECT_EQ(uut.qos().writer_data_lifecycle.autodispose_unregistered_instances, true);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_kind)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_kind(DDS::TRANSIENT_LOCAL_DURABILITY_QOS);
+  EXPECT_EQ(uut.qos().durability.kind, DDS::TRANSIENT_LOCAL_DURABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_volatile)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_transient_local().durability_volatile();
+  EXPECT_EQ(uut.qos().durability.kind, DDS::VOLATILE_DURABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_transient_local)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_transient_local();
+  EXPECT_EQ(uut.qos().durability.kind, DDS::TRANSIENT_LOCAL_DURABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_transient)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_transient();
+  EXPECT_EQ(uut.qos().durability.kind, DDS::TRANSIENT_DURABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_persistent)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_persistent();
+  EXPECT_EQ(uut.qos().durability.kind, DDS::PERSISTENT_DURABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_service_service_cleanup_delay)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_service_service_cleanup_delay(ms100);
+  EXPECT_TRUE(uut.qos().durability_service.service_cleanup_delay == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_service_history_kind)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_service_history_kind(DDS::KEEP_ALL_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().durability_service.history_kind, DDS::KEEP_ALL_HISTORY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_service_keep_last)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_service_keep_last(5);
+  EXPECT_EQ(uut.qos().durability_service.history_kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().durability_service.history_depth, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_service_keep_all)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_service_keep_all();
+  EXPECT_EQ(uut.qos().durability_service.history_kind, DDS::KEEP_ALL_HISTORY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_service_history_depth)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_service_history_depth(5);
+  EXPECT_EQ(uut.qos().durability_service.history_depth, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_service_max_samples)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_service_max_samples(5);
+  EXPECT_EQ(uut.qos().durability_service.max_samples, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_service_max_instances)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_service_max_instances(5);
+  EXPECT_EQ(uut.qos().durability_service.max_instances, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_durability_service_max_samples_per_instance)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.durability_service_max_samples_per_instance(5);
+  EXPECT_EQ(uut.qos().durability_service.max_samples_per_instance, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_deadline_period)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.deadline_period(ms100);
+  EXPECT_TRUE(uut.qos().deadline.period == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_latency_budget_duration)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.latency_budget_duration(ms100);
+  EXPECT_TRUE(uut.qos().latency_budget.duration == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_liveliness_kind)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.liveliness_kind(DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
+  EXPECT_EQ(uut.qos().liveliness.kind, DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_liveliness_automatic)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.liveliness_manual_by_participant().liveliness_automatic();
+  EXPECT_EQ(uut.qos().liveliness.kind, DDS::AUTOMATIC_LIVELINESS_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_liveliness_manual_by_participant)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.liveliness_manual_by_participant().liveliness_manual_by_participant();
+  EXPECT_EQ(uut.qos().liveliness.kind, DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_liveliness_manual_by_topic)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.liveliness_manual_by_topic().liveliness_manual_by_topic();
+  EXPECT_EQ(uut.qos().liveliness.kind, DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_liveliness_lease_duration)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.liveliness_lease_duration(ms100);
+  EXPECT_TRUE(uut.qos().liveliness.lease_duration == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_reliability_kind)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.reliability_kind(DDS::BEST_EFFORT_RELIABILITY_QOS);
+  EXPECT_EQ(uut.qos().reliability.kind, DDS::BEST_EFFORT_RELIABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_reliability_best_effort)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.reliability_best_effort();
+  EXPECT_EQ(uut.qos().reliability.kind, DDS::BEST_EFFORT_RELIABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_reliability_reliable)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.reliability_best_effort().reliability_reliable();
+  EXPECT_EQ(uut.qos().reliability.kind, DDS::RELIABLE_RELIABILITY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_reliability_max_blocking_time)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.reliability_max_blocking_time(zero);
+  EXPECT_TRUE(uut.qos().reliability.max_blocking_time == zero);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_destination_order_kind)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.destination_order_kind(DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
+  EXPECT_EQ(uut.qos().destination_order.kind, DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_destination_order_by_source_timestamp)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.destination_order_by_source_timestamp();
+  EXPECT_EQ(uut.qos().destination_order.kind, DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_destination_order_by_reception_timestamp)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.destination_order_by_source_timestamp().destination_order_by_reception_timestamp();
+  EXPECT_EQ(uut.qos().destination_order.kind, DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_history_kind)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.history_kind(DDS::KEEP_ALL_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().history.kind, DDS::KEEP_ALL_HISTORY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_history_keep_last)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.history_keep_last(5);
+  EXPECT_EQ(uut.qos().history.kind, DDS::KEEP_LAST_HISTORY_QOS);
+  EXPECT_EQ(uut.qos().history.depth, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_history_keep_all)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.history_keep_all();
+  EXPECT_EQ(uut.qos().history.kind, DDS::KEEP_ALL_HISTORY_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_history_depth)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.history_depth(5);
+  EXPECT_EQ(uut.qos().history.depth, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_resource_limits_max_samples)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.resource_limits_max_samples(5);
+  EXPECT_EQ(uut.qos().resource_limits.max_samples, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_resource_limits_max_instances)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.resource_limits_max_instances(5);
+  EXPECT_EQ(uut.qos().resource_limits.max_instances, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_resource_limits_max_samples_per_instance)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.resource_limits_max_samples_per_instance(5);
+  EXPECT_EQ(uut.qos().resource_limits.max_samples_per_instance, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_transport_priority_value)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.transport_priority_value(5);
+  EXPECT_EQ(uut.qos().transport_priority.value, 5);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_lifespan_duration)
+{
+  using OpenDDS::DCPS::operator==;
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.lifespan_duration(ms100);
+  EXPECT_TRUE(uut.qos().lifespan.duration == ms100);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_user_data_value)
+{
+  using OpenDDS::DCPS::operator==;
+  DDS::OctetSeq user_data;
+  user_data.length(1);
+  user_data[0] = 'A';
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.user_data_value(user_data);
+  EXPECT_TRUE(uut.qos().user_data.value == user_data);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_ownership_kind)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.ownership_kind(DDS::EXCLUSIVE_OWNERSHIP_QOS);
+  EXPECT_EQ(uut.qos().ownership.kind, DDS::EXCLUSIVE_OWNERSHIP_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_ownership_shared)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.ownership_shared();
+  EXPECT_EQ(uut.qos().ownership.kind, DDS::SHARED_OWNERSHIP_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_ownership_exclusive)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.ownership_exclusive();
+  EXPECT_EQ(uut.qos().ownership.kind, DDS::EXCLUSIVE_OWNERSHIP_QOS);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_ownership_strength_value)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.ownership_strength_value(5);
+  EXPECT_EQ(uut.qos().ownership_strength.value, 5);
+}
+
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_writer_data_lifecycle_autodispose_unregistered_instances)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder uut;
+  uut.writer_data_lifecycle_autodispose_unregistered_instances(false);
+  EXPECT_EQ(uut.qos().writer_data_lifecycle.autodispose_unregistered_instances, false);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_Publisher_ctor)
+{
+  OpenDDS::DCPS::DataWriterQosBuilder qos;
+  qos.reliability_best_effort();
+  OpenDDS::DCPS::RcHandle<OpenDDS::Test::MockPublisher> publisher = OpenDDS::DCPS::make_rch<OpenDDS::Test::MockPublisher>();
+  EXPECT_CALL(*publisher, get_default_datawriter_qos(testing::_))
+    .WillOnce(DoAll(testing::SetArgReferee<0>(qos.qos()), testing::Return(DDS::RETCODE_OK)));
+  DDS::Publisher_var publisher_var = DDS::Publisher::_duplicate(publisher.in());
+  OpenDDS::DCPS::DataWriterQosBuilder uut(publisher_var);
+  EXPECT_EQ(qos, uut);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_Publisher_ctor_error)
+{
+  OpenDDS::DCPS::LogRestore restore;
+  OpenDDS::DCPS::log_level.set(OpenDDS::DCPS::LogLevel::Warning);
+
+  OpenDDS::Test::MockLogger logger;
+  EXPECT_CALL(logger, log(testing::_))
+    .Times(1)
+    .WillOnce(testing::Return(0));
+
+  OpenDDS::DCPS::DataWriterQosBuilder qos;
+  qos.reliability_best_effort();
+  OpenDDS::DCPS::RcHandle<OpenDDS::Test::MockPublisher> publisher = OpenDDS::DCPS::make_rch<OpenDDS::Test::MockPublisher>();
+  EXPECT_CALL(*publisher, get_default_datawriter_qos(testing::_))
+    .WillOnce(testing::Return(DDS::RETCODE_ERROR));
+
+  DDS::Publisher_var publisher_var = DDS::Publisher::_duplicate(publisher.in());
+  OpenDDS::DCPS::DataWriterQosBuilder uut(publisher_var);
+  EXPECT_NE(qos, uut);
+}
+
+namespace {
+  void copy_from_topic(DDS::DataWriterQos& dwqos,
+                       const DDS::TopicQos& tqos)
+  {
+    dwqos.durability = tqos.durability;
+    dwqos.durability_service = tqos.durability_service;
+    dwqos.deadline = tqos.deadline;
+    dwqos.latency_budget = tqos.latency_budget;
+    dwqos.liveliness = tqos.liveliness;
+    dwqos.reliability = tqos.reliability;
+    dwqos.destination_order = tqos.destination_order;
+    dwqos.history = tqos.history;
+    dwqos.resource_limits = tqos.resource_limits;
+    dwqos.transport_priority = tqos.transport_priority;
+    dwqos.lifespan = tqos.lifespan;
+  }
+}
+
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_Topic_ctor)
+{
+  OpenDDS::DCPS::TopicQosBuilder topic_qos;
+  topic_qos.durability_transient_local();
+
+  OpenDDS::DCPS::DataWriterQosBuilder datawriter_qos;
+  datawriter_qos.writer_data_lifecycle_autodispose_unregistered_instances(false);
+
+  OpenDDS::DCPS::RcHandle<OpenDDS::Test::MockTopic> topic = OpenDDS::DCPS::make_rch<OpenDDS::Test::MockTopic>();
+  EXPECT_CALL(*topic, get_qos(testing::_))
+    .WillOnce(DoAll(testing::SetArgReferee<0>(topic_qos.qos()), testing::Return(DDS::RETCODE_OK)));
+  DDS::Topic_var topic_var = DDS::Topic::_duplicate(topic.in());
+
+  OpenDDS::DCPS::RcHandle<OpenDDS::Test::MockPublisher> publisher = OpenDDS::DCPS::make_rch<OpenDDS::Test::MockPublisher>();
+  EXPECT_CALL(*publisher, get_default_datawriter_qos(testing::_))
+    .WillOnce(DoAll(testing::SetArgReferee<0>(datawriter_qos.qos()), testing::Return(DDS::RETCODE_OK)));
+  EXPECT_CALL(*publisher, copy_from_topic_qos(testing::_, testing::_))
+    .WillOnce(testing::DoAll(testing::Invoke(copy_from_topic), testing::Return(DDS::RETCODE_OK)));
+  DDS::Publisher_var publisher_var = DDS::Publisher::_duplicate(publisher.in());
+
+  datawriter_qos.durability_transient_local();
+  datawriter_qos.qos().reliability = OpenDDS::DCPS::ReliabilityQosPolicyBuilder();
+
+  OpenDDS::DCPS::DataWriterQosBuilder uut(topic_var, publisher_var);
+  EXPECT_EQ(datawriter_qos, uut);
+}
+
+TEST(dds_DCPS_Qos_Helper, DataWriterQosBuilder_Topic_ctor_error)
+{
+  OpenDDS::DCPS::LogRestore restore;
+  OpenDDS::DCPS::log_level.set(OpenDDS::DCPS::LogLevel::Warning);
+
+  OpenDDS::Test::MockLogger logger;
+  EXPECT_CALL(logger, log(testing::_))
+    .Times(3)
+    .WillRepeatedly(testing::Return(0));
+
+  OpenDDS::DCPS::RcHandle<OpenDDS::Test::MockTopic> topic = OpenDDS::DCPS::make_rch<OpenDDS::Test::MockTopic>();
+  EXPECT_CALL(*topic, get_qos(testing::_))
+    .WillOnce(testing::Return(DDS::RETCODE_ERROR));
+  DDS::Topic_var topic_var = DDS::Topic::_duplicate(topic.in());
+
+  OpenDDS::DCPS::RcHandle<OpenDDS::Test::MockPublisher> publisher = OpenDDS::DCPS::make_rch<OpenDDS::Test::MockPublisher>();
+  EXPECT_CALL(*publisher, get_default_datawriter_qos(testing::_))
+    .WillOnce(testing::Return(DDS::RETCODE_ERROR));
+  EXPECT_CALL(*publisher, copy_from_topic_qos(testing::_, testing::_))
+    .WillOnce(testing::Return(DDS::RETCODE_ERROR));
+  DDS::Publisher_var publisher_var = DDS::Publisher::_duplicate(publisher.in());
+
+  OpenDDS::DCPS::DataWriterQosBuilder uut(topic_var, publisher_var);
 }

--- a/tests/unit-tests/dds/DCPS/SporadicTask.cpp
+++ b/tests/unit-tests/dds/DCPS/SporadicTask.cpp
@@ -9,9 +9,9 @@
 
 #include <dds/DCPS/SporadicTask.h>
 
+#include "MockLogger.h"
+
 #include <ace/Thread_Manager.h>
-#include <ace/Log_Msg_Backend.h>
-#include <ace/Log_Record.h>
 
 using namespace OpenDDS::DCPS;
 
@@ -56,32 +56,6 @@ namespace {
 
     MOCK_METHOD1(myfunc, void(const MonotonicTimePoint&));
     PmfSporadicTask<MyTestClass> sporadic_task_;
-  };
-
-  class MyLogger : public ACE_Log_Msg_Backend {
-  public:
-    MyLogger()
-    {
-      // Install as backend.
-      previous_ = ACE_Log_Msg::msg_backend(this);
-      ACE_Log_Msg::instance()->set_flags(ACE_Log_Msg::CUSTOM);
-      ACE_Log_Msg::instance()->clr_flags(ACE_Log_Msg::STDERR);
-    }
-
-    ~MyLogger()
-    {
-      ACE_Log_Msg::instance()->clr_flags(ACE_Log_Msg::CUSTOM);
-      ACE_Log_Msg::instance()->set_flags(ACE_Log_Msg::STDERR);
-      ACE_Log_Msg::msg_backend(previous_);
-    }
-
-    MOCK_METHOD1(open, int(const ACE_TCHAR*));
-    MOCK_METHOD0(reset, int());
-    MOCK_METHOD0(close, int());
-    MOCK_METHOD1(log, ssize_t(ACE_Log_Record&));
-
-  private:
-    ACE_Log_Msg_Backend* previous_;
   };
 }
 
@@ -135,7 +109,7 @@ TEST(dds_DCPS_SporadicTask, schedule_pmf)
 
 TEST(dds_DCPS_SporadicTask, schedule_error)
 {
-  MyLogger logger;
+  OpenDDS::Test::MockLogger logger;
   MyTimeSource time_source;
   MyReactor reactor;
   RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
@@ -204,7 +178,7 @@ TEST(dds_DCPS_SporadicTask, schedule_later)
 
 TEST(dds_DCPS_SporadicTask, schedule_no_interceptor)
 {
-  MyLogger logger;
+  OpenDDS::Test::MockLogger logger;
   MyTimeSource time_source;
   MyReactor reactor;
   RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);
@@ -257,7 +231,7 @@ TEST(dds_DCPS_SporadicTask, cancel_scheduled)
 
 TEST(dds_DCPS_SporadicTask, cancel_no_interceptor)
 {
-  MyLogger logger;
+  OpenDDS::Test::MockLogger logger;
   MyTimeSource time_source;
   MyReactor reactor;
   RcHandle<MyReactorInterceptor> reactor_interceptor = make_rch<MyReactorInterceptor>(&reactor);

--- a/tests/unit-tests/dds/DCPS/Time_Helper.cpp
+++ b/tests/unit-tests/dds/DCPS/Time_Helper.cpp
@@ -95,3 +95,10 @@ TEST(dds_DCPS_Time_Helper, MonotonicTime_t_equal)
   EXPECT_TRUE(!(tt1 == tt2));
   EXPECT_TRUE(!(tt2 == tt1));
 }
+
+TEST(dds_DCPS_Time_Helper, make_duration)
+{
+  const DDS::Duration_t d = make_duration(1, 2);
+  EXPECT_EQ(d.sec, 1);
+  EXPECT_EQ(d.nanosec, 2u);
+}


### PR DESCRIPTION
Problem
-------

InternalDataWriters will be converted to use DDS::DataWriterQos. InternalDataWriters are often initialized in constructors meaning that we need a way to initialize the DDS::DataWriterQoS.

Solution
--------

Provide a builder to initialize DDS::DataWriterQos.