### PR TITLE
DevGuide refers to chapters and sections

### DIFF
--- a/docs/devguide/alternate_interfaces_to_data.rst
+++ b/docs/devguide/alternate_interfaces_to_data.rst
@@ -8,7 +8,7 @@ Alternate Interfaces to Data
     Sect<12>
 
 The DDS-DCPS approach to data transfer using synchronization of strongly-typed caches (DataWriter and DataReader) is not appropriate for all applications.
-Therefore OpenDDS provides two different alternate interface approaches which are described in this chapter.
+Therefore OpenDDS provides two different alternate interface approaches which are described in this section.
 These are not defined by OMG specifications and may change in future releases of OpenDDS, including minor updates.
 The two approaches are:
 
@@ -16,14 +16,14 @@ The two approaches are:
 
   * These interfaces allow the application to create untyped stand-ins for DataReaders and/or DataWriters
 
-  * Recorder can be used with the Dynamic Language Binding XTypes features (see section :ref:`xtypes--dynamic-language-binding-1` and below) to access typed data samples through a reflection-based API
+  * Recorder can be used with the Dynamic Language Binding XTypes features (:ref:`xtypes--dynamic-language-binding-1`) to access typed data samples through a reflection-based API
 
 * Observer
 
   * Observers play a role similar to the spec-defined Listeners (attached to DataReaders and/or DataWriters).
     Unlike the Listeners, Observers don’t need to interact with the DataReader/Writer caches to access the data samples.
 
-The XTypes Dynamic Language Binding (see section :ref:`xtypes--dynamic-language-binding`) provides a set of related features that can be used to create DataWriters and DataReaders that work with a generic data container (DynamicData) instead of a specific IDL-generated data type.
+The XTypes Dynamic Language Binding (:ref:`xtypes--dynamic-language-binding`) provides a set of related features that can be used to create DataWriters and DataReaders that work with a generic data container (DynamicData) instead of a specific IDL-generated data type.
 
 .. _alternate_interfaces_to_data--recorder-and-replayer:
 
@@ -186,7 +186,7 @@ Recorder With XTypes Dynamic Language Binding
 ..
     Sect<12.1.4>
 
-The Recorder class includes support for the Dynamic Language Binding from XTypes (see section :ref:`xtypes--dynamic-language-binding-1`).
+The Recorder class includes support for the Dynamic Language Binding from XTypes (:ref:`xtypes--dynamic-language-binding-1`).
 Type information for each matched DataWriter (that supports XTypes complete TypeObjects) is stored in the Recorder.
 Users can call Recorder::get_dynamic_data, passing a RawDataSample to get back a DynamicData object which includes type information – see DynamicData::type().
 

--- a/docs/devguide/built_in_topics.rst
+++ b/docs/devguide/built_in_topics.rst
@@ -19,7 +19,7 @@ Introduction
 In OpenDDS, Built-In-Topics are created and published by default to exchange information about DDS participants operating in the deployment.
 When OpenDDS is used in a centralized discovery approach using the ``DCPSInfoRepo`` service, the Built-In-Topics are published by this service.
 For DDSI-RTPS discovery, the internal OpenDDS implementation instantiated in a process populates the caches of the Built-In Topic DataReaders.
-See Section :ref:`run_time_configuration--configuring-for-ddsi-rtps-discovery` for a description of RTPS discovery configuration.
+See :ref:`run_time_configuration--configuring-for-ddsi-rtps-discovery` for a description of RTPS discovery configuration.
 
 The IDL struct ``BuiltinTopicKey_t`` is used by the Built-In Topics.
 This structure contains an array of 16 octets (bytes) which corresponds to an InfoRepo identifier or a DDSI-RTPS GUID.
@@ -36,19 +36,18 @@ Built-In Topics for DCPSInfoRepo Configuration
 When starting the ``DCPSInfoRepo`` a command line option of ``-NOBITS`` may be used to suppress publication of built-in topics.
 
 Four separate topics are defined for each domain.
-Each is dedicated to a particular entity (domain participant, topic, data writer, data reader) and publishes instances describing the state for each entity in the domain.
+Each is dedicated to a particular entity (domain participant :ref:`built_in_topics--dcpsparticipant-topic`, topic :ref:`built_in_topics--dcpsparticipant-topic`, data writer :ref:`built_in_topics--dcpspublication-topic`, data reader :ref:`built_in_topics--dcpssubscription-topic`) and publishes instances describing the state for each entity in the domain.
 
 Subscriptions to built-in topics are automatically created for each domain participant.
-A participant’s support for Built-In-Topics can be toggled via the ``DCPSBit`` configuration option (see the table in Section :ref:`run_time_configuration--common-configuration-options`) (Note: this option cannot be used for RTPS discovery).
+A participant’s support for Built-In-Topics can be toggled via the ``DCPSBit`` configuration option (see the table in :ref:`run_time_configuration--common-configuration-options`) (Note: this option cannot be used for RTPS discovery).
 To view the built-in topic data, simply obtain the built-in Subscriber and then use it to access the Data Reader for the built-in topic of interest.
 The Data Reader can then be used like any other Data Reader.
 
-Sections :ref:`built_in_topics--dcpsparticipant-topic` through :ref:`built_in_topics--dcpssubscription-topic` provide details on the data published for each of the four built-in topics.
-An example showing how to read from a built-in topic follows those sections.
+See :ref:`built_in_topics--built-in-topic-subscription-example` for an example showing how to read from a built-in topic.
 
 If you are not planning on using Built-in-Topics in your application, you can configure OpenDDS to remove Built-In-Topic support at build time.
 Doing so can reduce the footprint of the core DDS library by up to 30%.
-See Section :ref:`introduction--disabling-the-building-of-built-in-topic-support` for information on disabling Built-In-Topic support.
+See :ref:`introduction--disabling-the-building-of-built-in-topic-support` for information on disabling Built-In-Topic support.
 
 .. _built_in_topics--dcpsparticipant-topic:
 
@@ -262,7 +261,7 @@ OpenDDSConnectionRecord Topic
     Sect<6.8.2>
 
 The Built-In Topic “OpenDDSConnectionRecord” is published by the DDSI-RTPS discovery implementation and RTPS_UDP transport implementation to give applications visibility into the details of a participant’s connection to an RtpsRelay instance.
-Security must be enabled in the build of OpenDDS (see section :ref:`dds_security--building-opendds-with-security-enabled`) to use this topic.
+Security must be enabled in the build of OpenDDS (:ref:`dds_security--building-opendds-with-security-enabled`) to use this topic.
 
 The topic type ConnectionRecord is defined in :ghfile:`dds/OpenddsDcpsExt.idl` in the ``OpenDDS::DCPS`` module:
 
@@ -284,7 +283,7 @@ OpenDDSInternalThread Topic
 ..
     Sect<6.8.3>
 
-The Built-In Topic “OpenDDSInternalThread” is published when OpenDDS is configured with DCPSThreadStatusInterval (see section :ref:`run_time_configuration--common-configuration-options`).
+The Built-In Topic "OpenDDSInternalThread" is published when OpenDDS is configured with DCPSThreadStatusInterval (:ref:`run_time_configuration--common-configuration-options`).
 When enabled, the DataReader for this Built-In Topic will report the status of threads created and managed by OpenDDS within the current process.
 The timestamp associated with samples can be used to determine the health (responsiveness) of the thread.
 

--- a/docs/devguide/conditions_and_listeners.rst
+++ b/docs/devguide/conditions_and_listeners.rst
@@ -687,7 +687,7 @@ Query Conditions
 
 Query conditions are a specialized form of read conditions that are created with a limited form of an SQL-like query.
 This allows applications to filter the data samples that trigger the condition and then are read use the normal read condition mechanisms.
-See Section :ref:`content_subscription_profile--query-condition` for more information about query conditions.
+See :ref:`content_subscription_profile--query-condition` for more information about query conditions.
 
 .. _conditions_and_listeners--guard-conditions:
 

--- a/docs/devguide/content_subscription_profile.rst
+++ b/docs/devguide/content_subscription_profile.rst
@@ -31,8 +31,7 @@ Content-filtered topic and query condition allow filtering (selection) of data s
 Additionally, query condition allows sorting the result set returned from a data reader’s ``read()`` or ``take()`` operation.
 Multi topic also has this selection capability as well as the ability to aggregate data from different data writers into a single data type and data reader.
 
-If you are not planning on using the Content-Subscription Profile features in your application, you can configure OpenDDS to remove support for it at build time.
-See section :ref:`introduction--content-subscription-profile` for more on how to do this.
+If you are not planning on using the Content-Subscription Profile features in your application, you can configure OpenDDS to remove support for it at build time (:ref:`introduction--content-subscription-profile`).
 
 .. _content_subscription_profile--content-filtered-topic:
 
@@ -57,7 +56,7 @@ Creating a content-filtered topic requires the following parameters:
 
 * Filter expression
 
-  An SQL-like expression (see section :ref:`content_subscription_profile--filter-expressions`) which defines the subset of samples published on the related topic that should be received by the content-filtered topic’s data readers.
+  An SQL-like expression (:ref:`content_subscription_profile--filter-expressions`) which defines the subset of samples published on the related topic that should be received by the content-filtered topic’s data readers.
 
 * Expression parameters
 
@@ -196,7 +195,7 @@ Query Condition
     Sect<5.3>
 
 The query condition interface inherits from the read condition interface, therefore query conditions have all of the capabilities of read conditions along with the additional capabilities described in this section.
-One of those inherited capabilities is that the query condition can be used like any other condition with a wait set (see Section :ref:`conditions_and_listeners--conditions`).
+One of those inherited capabilities is that the query condition can be used like any other condition with a wait set (:ref:`conditions_and_listeners--conditions`).
 
 The ``DataReader`` interface contains operations for creating (``create_querycondition``) and deleting (``delete_readcondition``) a query condition.
 Creating a query condition requires the following parameters:
@@ -229,7 +228,7 @@ Query Expressions
 ..
     Sect<5.3.1>
 
-Query expressions are a super set of filter expressions (see section :ref:`content_subscription_profile--filter-expressions`).
+Query expressions are a super set of filter expressions (:ref:`content_subscription_profile--filter-expressions`).
 Following the filter expression, the query expression can optionally have an ``ORDER BY`` keyword followed by a comma-separated list of field references.
 If the ``ORDER BY`` clause is present, the filter expression may be empty.
 The following strings are examples of query expressions:
@@ -241,7 +240,7 @@ The following strings are examples of query expressions:
 * NOT v LIKE 'z%'
 
 Query expressions can use parameter placeholders in the same way that filter expressions (for content-filtered topics) use them.
-See section :ref:`content_subscription_profile--expression-parameters` for details.
+See :ref:`content_subscription_profile--expression-parameters` for details.
 
 .. _content_subscription_profile--query-condition-example:
 
@@ -293,7 +292,7 @@ A data reader created for the multi topic is known as a “multi topic data read
 These topics are known as its “constituent topics.” The multi topic has a DCPS data type known as the “resulting type.” The multi topic data reader implements the type-specific data reader interface for the resulting type.
 For example, if the resulting type is Message, then the multi topic data reader can be narrowed to the ``MessageDataReader`` interface.
 
-The multi topic’s topic expression (see section :ref:`content_subscription_profile--topic-expressions`) describes how the distinct fields of the incoming data (on the constituent topics) are mapped to the fields of the resulting type.
+The multi topic’s topic expression (:ref:`content_subscription_profile--topic-expressions`) describes how the distinct fields of the incoming data (on the constituent topics) are mapped to the fields of the resulting type.
 
 The domain participant interface contains operations for creating and deleting a multi topic.
 Creating a multi topic requires the following parameters:
@@ -309,7 +308,7 @@ Creating a multi topic requires the following parameters:
 
 * Topic expression (also known as subscription expression)
 
-  An SQL-like expression (see section :ref:`content_subscription_profile--topic-expressions`) which defines the mapping of constituent topic fields to resulting type fields.
+  An SQL-like expression (:ref:`content_subscription_profile--topic-expressions`) which defines the mapping of constituent topic fields to resulting type fields.
   It can also specify a filter (``WHERE`` clause).
 
 * Expression parameters
@@ -320,7 +319,7 @@ Creating a multi topic requires the following parameters:
 
 Once the multi topic has been created, it is used by the subscriber’s ``create_datareader()`` operation to obtain a multi topic data reader.
 This data reader is used by the application to receive the constructed samples of the resulting type.
-The manner in which these samples are constructed is described below in section :ref:`content_subscription_profile--how-resulting-samples-are-constructed`.
+The manner in which these samples are constructed is described in :ref:`content_subscription_profile--how-resulting-samples-are-constructed`.
 
 .. _content_subscription_profile--topic-expressions:
 
@@ -341,7 +340,7 @@ Topic expressions use a syntax that is very similar to a complete SQL query:
 
 * * <constituent_field> [[AS] <resulting_field>]]
 
-  * ``constituent_field`` is a field reference (see section :ref:`content_subscription_profile--filter-expressions`) to a field in one of the constituent topics (which topic is not specified).
+  * ``constituent_field`` is a field reference (:ref:`content_subscription_profile--filter-expressions`) to a field in one of the constituent topics (which topic is not specified).
 
   * The optional resulting_field is a field reference to a field in the resulting type.
     If present, the ``resulting_field`` is the destination for the constituent_field in the constructed sample.
@@ -360,12 +359,12 @@ Topic expressions use a syntax that is very similar to a complete SQL query:
   * The natural join operation is commutative and associative, thus the order of topics has no impact.
 
   * The semantics of the natural join are that any fields with the same name are treated as “join keys” for the purpose of combining data from the topics in which those keys appear.
-    The join operation is described in more detail in the subsequent sections of this chapter.
+    The join operation is described in more detail in subsequent sections.
 
-* The condition has the exact same syntax and semantics as the filter expression (see section :ref:`content_subscription_profile--filter-expressions`).
+* The condition has the exact same syntax and semantics as the filter expression (:ref:`content_subscription_profile--filter-expressions`).
   Field references in the condition must match field names in the resulting types, not field names in the constituent topic types.
   The condition in the topic expression can use parameter placeholders in the same way that filter expressions (for content-filtered topics) use them.
-  See section :ref:`content_subscription_profile--expression-parameters` for details.
+  See :ref:`content_subscription_profile--expression-parameters` for details.
 
 .. _content_subscription_profile--usage-notes:
 
@@ -383,11 +382,11 @@ Join Keys and DCPS Data Keys
 ..
     Sect<5.4.2.1>
 
-The concept of DCPS data keys (``@key``) has already been discussed in Section :ref:`getting_started--defining-data-types-with-idl`.
+The concept of DCPS data keys (``@key``) has already been discussed in :ref:`getting_started--defining-data-types-with-idl`.
 Join keys for the multi topic are a distinct but related concept.
 
 A join key is any field name that occurs in the struct for more than one constituent topic.
-The existence of the join key enforces a constraint on how data samples of those topics are combined into a constructed sample (see section :ref:`content_subscription_profile--how-resulting-samples-are-constructed`).
+The existence of the join key enforces a constraint on how data samples of those topics are combined into a constructed sample (:ref:`content_subscription_profile--how-resulting-samples-are-constructed`).
 Specifically, the value of that key must be equal for those data samples from the constituent topics to be combined into a sample of the resulting type.
 If multiple join keys are common to the same two or more topics, the values of all keys must be equal in order for the data to be combined.
 
@@ -398,7 +397,7 @@ Additionally, OpenDDS imposes two requirements on how the IDL must define DCPS d
 
 #. The resulting type must contain each of the join keys, and those fields must be DCPS data keys for the resulting type.
 
-The example in section :ref:`content_subscription_profile--idl-and-topic-expression` meets both of these requirements.
+The example in :ref:`content_subscription_profile--idl-and-topic-expression` meets both of these requirements.
 Note that it is not necessary to list the join keys in the aggregation (``SELECT`` clause).
 
 .. _content_subscription_profile--how-resulting-samples-are-constructed:

--- a/docs/devguide/dds_security.rst
+++ b/docs/devguide/dds_security.rst
@@ -908,7 +908,7 @@ The default rule is the rule applied if none of the grant’s allow rules or den
 
 Every allow or deny rule must contain a set of domain ids to which it applies.
 The syntax is the same as the domain id set found in the governance document.
-See section :ref:`dds_security--key-governance-elements` for details.
+See :ref:`dds_security--key-governance-elements` for details.
 
 **Publish / Subscribe / Relay Rules (PSR rules)**
 
@@ -916,7 +916,8 @@ Every allow or deny rule may optionally contain a list of publish, subscribe, or
 Each rule applies to a collection of topics in a set of partitions with a particular set of data tags.
 As such, each rule must then meet these three conditions (topics, partitions, and (when implemented) data tags) in order to apply to a given operation.
 These conditions are governed by their relevant subsection, but the exact meaning and default values will vary depending on the both the PSR type (publish, subscribe, relay) as well as whether this is an allow rule or a deny rule.
-Each condition is summarized below, but please refer to the OMG DDS Security specification for full details.
+Each condition is summarized below.
+See the DDS Security specification for full details.
 OpenDDS does not currently support relay-only behavior and consequently ignores allow and deny relay rules for both local and remote entities.
 Additionally, OpenDDS does not currently support data tags, and so the data tag condition applied is always the “default” behavior described below.
 

--- a/docs/devguide/getting_started.rst
+++ b/docs/devguide/getting_started.rst
@@ -16,11 +16,11 @@ Using DCPS
 ..
     Sect<2.1>
 
-This chapter focuses on an example application using DCPS to distribute data from a single publisher process to a single subscriber process.
+This section focuses on an example application using DCPS to distribute data from a single publisher process to a single subscriber process.
 It is based on a simple messenger application where a single publisher publishes messages and a single subscriber subscribes to them.
 We use the default QoS properties and the default TCP/IP transport.
 Full source code for this example may be found under the :ghfile:`DevGuideExamples/DCPS/Messenger/` directory.
-Additional DDS and DCPS features are discussed in later chapters.
+Additional DDS and DCPS features are discussed in later sections.
 
 .. _getting_started--defining-data-types-with-idl:
 
@@ -31,7 +31,7 @@ Defining Data Types with IDL
     Sect<2.1.1>
 
 In this example, data types for topics will be defined using the OMG Interface Definition Language (IDL).
-For details on how to build OpenDDS applications that don't use IDL for topic data types, see section :ref:`xtypes--dynamicdatawriters-and-dynamicdatareaders`.
+For details on how to build OpenDDS applications that don't use IDL for topic data types, see :ref:`xtypes--dynamicdatawriters-and-dynamicdatareaders`.
 
 .. _getting_started--identifying-topic-types:
 
@@ -64,7 +64,7 @@ The ``@topic`` annotation marks a data type that can be used as a topic’s type
 This must be a structure or a union.
 The structure or union may contain basic types (short, long, float, etc.
 ), enumerations, strings, sequences, arrays, structures, and unions.
-See section :ref:`introduction--idl-compliance` for more details on the use of IDL for OpenDDS topic types.
+See :ref:`introduction--idl-compliance` for more details on the use of IDL for OpenDDS topic types.
 The IDL above defines the structure Message in the Messenger module for use in this example.
 
 .. _getting_started--keys:
@@ -200,7 +200,7 @@ In addition to ``@topic``, the set of IDL types OpenDDS can use can also be cont
 Types that are “nested” are the opposite of topic types; they can’t be used for the top-level type of a topic, but they can be nested inside the top-level type (at any level of nesting).
 All types are nested by default in OpenDDS to reduce the code generated for type support, but there a number of ways to change this:
 
-* The type can be annotated with ``@topic`` (see section :ref:`getting_started--identifying-topic-types`), or with ``@nested(FALSE)``, which is equivalent to ``@topic``.
+* The type can be annotated with ``@topic`` (see :ref:`getting_started--identifying-topic-types`), or with ``@nested(FALSE)``, which is equivalent to ``@topic``.
 
 * The enclosing module can be annotated with ``@default_nested(FALSE)``.
 
@@ -224,7 +224,7 @@ Processing the IDL
     Sect<2.1.2>
 
 This section uses the OMG IDL-to-C++ mapping (“C++ classic”) as part of the walk-through.
-OpenDDS also supports the OMG IDL-to-C++11 mapping, see section :ref:`opendds_idl--using-the-idl-to-c-11-mapping` for details.
+OpenDDS also supports the OMG IDL-to-C++11 mapping, see :ref:`opendds_idl--using-the-idl-to-c-11-mapping` for details.
 
 The OpenDDS IDL is first processed by the TAO IDL compiler.
 
@@ -255,7 +255,7 @@ The implementation files contain implementations for these interfaces.
 The generated IDL file should itself be compiled with the TAO IDL compiler to generate stubs and skeletons.
 These and the implementation file should be linked with your OpenDDS applications that use the Message type.
 The OpenDDS IDL compiler has a number of options that specialize the generated code.
-These options are described in Chapter :ref:`opendds_idl--opendds-idl`.
+These options are described in :ref:`opendds_idl--opendds-idl`.
 
 Typically, you do not directly invoke the TAO or OpenDDS IDL compilers as above, but let your build system do it for you.
 Two different build systems are supported for projects that use OpenDDS:
@@ -368,7 +368,7 @@ The first section of ``main()`` initializes the current process as an OpenDDS pa
 The ``TheParticipantFactoryWithArgs`` macro is defined in ``Service_Participant.h`` and initializes the Domain Participant Factory with the command line arguments.
 These command line arguments are used to initialize the ORB that the OpenDDS service uses as well as the service itself.
 This allows us to pass ``ORB_init()`` options on the command line as well as OpenDDS configuration options of the form ``-DCPS*``.
-Available OpenDDS options are fully described in Chapter :ref:`run_time_configuration--run-time-configuration`.
+Available OpenDDS options are fully described in :ref:`run_time_configuration--run-time-configuration`.
 
 The ``create_participant()`` operation uses the domain participant factory to register this process as a participant in the domain specified by the ID of 42.
 The participant uses the default QoS policies and no listeners.
@@ -533,7 +533,7 @@ Here is the corresponding code:
 
         ws->detach_condition(condition);
 
-For more details about status, conditions, and wait sets, see Chapter :ref:`conditions_and_listeners--conditions-and-listeners`.
+For more details about status, conditions, and wait sets, see :ref:`conditions_and_listeners--conditions-and-listeners`.
 
 .. _getting_started--sample-publication:
 
@@ -569,7 +569,7 @@ Since the subject_id is the key for Message, each time subject_id is incremented
 The second argument to ``write()`` specifies the instance on which we are publishing the sample.
 It should be passed either a handle returned by ``register_instance()`` or ``DDS::HANDLE_NIL``.
 Passing a ``DDS::HANDLE_NIL`` value indicates that the data writer should determine the instance by inspecting the key of the sample.
-See Section :ref:`getting_started--registering-and-using-instances-in-the-publisher` for details on using instance handles during publication.
+See :ref:`getting_started--registering-and-using-instances-in-the-publisher` for details on using instance handles during publication.
 
 .. _getting_started--setting-up-the-subscriber:
 
@@ -804,7 +804,7 @@ The dispose notification is delivered with the instance state set to ``NOT_ALIVE
 If additional samples are available, the service calls this function again.
 However, reading values a single sample at a time is not the most efficient way to process incoming data.
 The Data Reader interface provides a number of different options for processing data in a more efficient manner.
-We discuss some of these operations in Section :ref:`getting_started--data-handling-optimizations`.
+We discuss some of these operations in :ref:`getting_started--data-handling-optimizations`.
 
 .. _getting_started--cleaning-up-in-opendds-clients:
 
@@ -911,9 +911,9 @@ Unix
 The publisher connects to the ``DCPSInfoRepo`` to find the location of any subscribers and begins to publish messages as well as write them to the console.
 In the subscriber window, you should also now be seeing console output from the subscriber that is reading messages from the topic demonstrating a simple publish and subscribe application.
 
-You can read more about configuring your application for RTPS and other more advanced configuration options in Section :ref:`run_time_configuration--configuring-for-ddsi-rtps-discovery` and Section :ref:`run_time_configuration--rtps-udp-transport-configuration-options` .
-To read more about configuring and using the ``DCPSInfoRepo`` go to Section :ref:`run_time_configuration--discovery-configuration` and Chapter :ref:`the_dcps_information_repository--the-dcps-information-repository`.
-To find more about setting and using QoS features that modify the behavior of your application read Chapter :ref:`quality_of_service--quality-of-service`.
+You can read more about configuring your application for RTPS and other more advanced configuration options in :ref:`run_time_configuration--configuring-for-ddsi-rtps-discovery` and :ref:`run_time_configuration--rtps-udp-transport-configuration-options` .
+See :ref:`run_time_configuration--discovery-configuration` and :ref:`the_dcps_information_repository--the-dcps-information-repository` for configuring and using the ``DCPSInfoRepo`` .
+See :ref:`quality_of_service--quality-of-service` for setting and using QoS features that modify the behavior of your application.
 
 .. _getting_started--running-our-example-with-rtps:
 
@@ -928,8 +928,9 @@ The following details what is needed to run the same example using RTPS for disc
 This is important in scenarios when your OpenDDS application needs to interoperate with a non-OpenDDS implementation of the DDS specification or if you do not want to use centralized discovery in your deployment of OpenDDS.
 
 The coding and building of the Messenger example above is not changed for using RTPS, so you will not need to modify or rebuild your publisher and subscriber services.
-This is a strength of the OpenDDS architecture in that to enable the RTPS capabilities, it is an exercise of configuration.
-Chapter :ref:`run_time_configuration--run-time-configuration` will cover more details concerning the configuration of all the available transports including RTPS, however, for this exercise we will enable RTPS for the Messenger example using a configuration file that the publisher and subscriber will share.
+This is a strength of the OpenDDS architecture in that to enable the RTPS capabilities, it is an exercise in configuration.
+For this exercise, we will enable RTPS for the Messenger example using a configuration file that the publisher and subscriber will share.
+More details concerning the configuration of all the available transports including RTPS are described in :ref:`run_time_configuration--run-time-configuration`.
 
 Navigate to the directory where your publisher and subscriber have been built.
 Create a new text file named ``rtps.ini`` and populate it with the following content:
@@ -943,7 +944,7 @@ Create a new text file named ``rtps.ini`` and populate it with the following con
     [transport/the_rtps_transport]
     transport_type=rtps_udp
 
-More details of configuration files are specified in upcoming chapters, but the two lines of interest are called out for setting the discovery method  and the data transport protocol to RTPS.
+The two lines of interest are the one that sets the discovery method and the one that sets the data transport protocol to RTPS.
 
 Now lets re-run our example with RTPS enabled by starting the subscriber process first and then the publisher to begin sending data.
 It is best to start them in separate windows to see the two working separately.
@@ -979,7 +980,7 @@ Unix:
 Since there is no centralized discovery in the RTPS specification, there are provisions to allow for wait times to allow discovery to occur.
 The specification sets the default to 30 seconds.
 When the two above processes are started there may be up to a 30 second delay depending on how far apart they are started from each other.
-This time can be adjusted in OpenDDS configuration files discussed later Section :ref:`run_time_configuration--configuring-for-ddsi-rtps-discovery`.
+This time can be adjusted in OpenDDS configuration files and is discussed in :ref:`run_time_configuration--configuring-for-ddsi-rtps-discovery`.
 
 Because the architecture of OpenDDS allows for pluggable discovery and pluggable transports the two configuration entries called out in the ``rtps.ini`` file above can be changed independently with one using RTPS and the other not using RTPS (e.g.
 centralized discovery using ``DCPSInfoRepo``).

--- a/docs/devguide/internet_enabled_rtps.rst
+++ b/docs/devguide/internet_enabled_rtps.rst
@@ -23,7 +23,7 @@ Multicast is not supported on the public Internet which precludes the use of RTP
 Second, SPDP and SEDP advertise locators (IP and port pairs) for endpoints (DDS readers and writer).
 If the participant is behind a firewall that performs network address translation, then the locators advertised by the participant are useless to participants on the public side of the firewall.
 
-This chapter describes different tools and techniques for getting around these limitations.
+This section describes different tools and techniques for getting around these limitations.
 First, we introduce the *RtpsRelay* as a service for forwarding RTPS messages according to application-defined groups.
 The RtpsRelay can be used to connect participants that are deployed in environments that don't support multicast and whose packets are subject to NAT.
 Second, we introduce Interactive Connection Establishment (ICE) for RTPS.
@@ -113,7 +113,7 @@ Usage
 The RtpsRelay itself is an OpenDDS application.
 The source code is located in ``tools/rtpsrelay``.
 Security must be enabled to build the RtpsRelay.
-See section :ref:`dds_security--building-opendds-with-security-enabled`.
+See :ref:`dds_security--building-opendds-with-security-enabled`.
 Each RtpsRelay process has a set of ports for exchanging RTPS messages with the participants called the "vertical" ports and a set of ports for exchanging RTPS messages with other relays called the “horizontal” ports.
 
 The RtpsRelay contains an embedded webserver called the meta discovery server.
@@ -363,7 +363,7 @@ Most applications have common objectives with respect to data security:
 
 * Privacy - The content of a sample cannot be read by an unauthorized third party.
 
-If an application is subject to any of these security objectives, then it should use the DDS Security features described in Chapter :ref:`dds_security--dds-security`.
+If an application is subject to any of these security objectives, then it should use the DDS Security features described in :ref:`dds_security--dds-security`.
 Using a non-secure discovery mechanism or a non-secure transport leaves the application exposed to data security breaches.
 
 .. _internet_enabled_rtps--understand-the-weaknesses-of-secure-rtps-discovery:

--- a/docs/devguide/introduction.rst
+++ b/docs/devguide/introduction.rst
@@ -23,10 +23,10 @@ OpenDDS is an open source implementation of a group of related Object Management
    This specification describes the requirements for interoperability between DDS implementations.
 
 #. **DDS Security v1.1** (OMG document ``formal/2018-04-01``) extends DDS with capabilities for authentication and encryption.
-   OpenDDS’s support for the DDS Security specification is described below in Chapter :ref:`dds_security--dds-security`.
+   OpenDDS’s support for the DDS Security specification is described in :ref:`dds_security--dds-security`.
 
 #. **Extensible and Dynamic Topic Types for DDS (XTypes) v1.3** (OMG document ``formal/2020-02-04``) defines details of the type system used for the data exchanged on DDS Topics, including how schema and data are encoded for network transmission.
-   Details of DDS-XTypes are below in Chapter :ref:`xtypes--xtypes`.
+   OpenDDS's support for DDS-XTypes is described in :ref:`xtypes--xtypes`.
 
 OpenDDS is implemented in C++ and contains support for Java.
 Users in the OpenDDS community have contributed and maintain bindings for other languages include C#, nodejs, and Python.
@@ -297,7 +297,7 @@ Each data writer is bound to a particular topic.
 The application uses the data writer’s type-specific interface to publish samples on that topic.
 The data writer is responsible for marshaling the data and passing it to the publisher for transmission.
 
-Dynamic data writers (see section :ref:`xtypes--creating-and-using-a-dynamicdatawriter-or-dynamicdatareader`) can be used when code generated from IDL is not available or desired.
+Dynamic data writers (:ref:`xtypes--creating-and-using-a-dynamicdatawriter-or-dynamicdatareader`) can be used when code generated from IDL is not available or desired.
 Dynamic data writers are also type-safe, but type checking happens at runtime.
 
 .. _introduction--publisher:
@@ -333,7 +333,7 @@ The *data reader* takes data from the subscriber, demarshals it into the appropr
 Each data reader is bound to a particular topic.
 The application uses the data reader’s type-specific interfaces to receive the samples.
 
-Dynamic data readers (see section :ref:`xtypes--creating-and-using-a-dynamicdatawriter-or-dynamicdatareader`) can be used when code generated from IDL is not available or desired.
+Dynamic data readers (:ref:`xtypes--creating-and-using-a-dynamicdatawriter-or-dynamicdatareader`) can be used when code generated from IDL is not available or desired.
 Dynamic data readers are also type-safe, but type checking happens at runtime.
 
 .. _introduction--built-in-topics:
@@ -394,7 +394,7 @@ Subscribers *request* a set of policies that are minimally required.
 Publishers *offer* a set of QoS policies to potential subscribers.
 The DDS implementation then attempts to match the requested policies with the offered policies; if these policies are compatible then the association is formed.
 
-The QoS policies currently implemented by OpenDDS are discussed in detail in Chapter :ref:`quality_of_service--quality-of-service`.
+The QoS policies currently implemented by OpenDDS are discussed in detail in :ref:`quality_of_service--quality-of-service`.
 
 .. _introduction--listeners:
 
@@ -449,8 +449,8 @@ Compliance
 OpenDDS complies with the OMG DDS and the OMG DDSI-RTPS specifications.
 Details of that compliance follows here.
 OpenDDS also implements the OMG DDS Security specification.
-Details of compliance to that specification are in section :ref:`dds_security--dds-security-implementation-status`.
-Details of XTypes compliance are in sections :ref:`xtypes--unimplemented-features` and :ref:`xtypes--differences-from-the-specification`.
+Details of compliance to that specification are in :ref:`dds_security--dds-security-implementation-status`.
+Details of XTypes compliance are in :ref:`xtypes--unimplemented-features` and :ref:`xtypes--differences-from-the-specification`.
 
 .. _introduction--dds-compliance:
 
@@ -559,7 +559,7 @@ OpenDDS supports the following building blocks, with notes/caveats listed below 
 
 * Annotations
 
-  * See sections :ref:`getting_started--defining-data-types-with-idl` and :ref:`xtypes--idl-annotations` for details on which built-in annotations are supported.
+  * See :ref:`getting_started--defining-data-types-with-idl` and :ref:`xtypes--idl-annotations` for details on which built-in annotations are supported.
 
   * User-defined annotation types are also supported.
 
@@ -584,7 +584,7 @@ Data types, interfaces, and constants in the **DDS** IDL module (C++ namespace, 
 * Type-specific DataReaders (including those for Built-in Topics) have additional operations ``read_instance_w_condition()`` and ``take_instance_w_condition()``.
 
 Additional extended behavior is provided by various classes and interfaces in the OpenDDS module/namespace/package.
-Those include features like Recorder and Replayer (see chapter :ref:`alternate_interfaces_to_data--alternate-interfaces-to-data`) and also:
+Those include features like Recorder and Replayer (:ref:`alternate_interfaces_to_data--alternate-interfaces-to-data`) and also:
 
 * ``OpenDDS::DCPS::TypeSupport`` adds the ``unregister_type()`` operation not found in the DDS spec.
 
@@ -631,7 +631,7 @@ Data transmission is accomplished via an OpenDDS-specific transport framework th
 This is referred to as *pluggable transports* and makes the extensibility of OpenDDS an important part of its architecture.
 OpenDDS currently supports TCP/IP, UDP/IP, IP multicast, shared-memory, and RTPS_UDP transport protocols as shown in :ref:`Figure 1-2 <introduction--reffigure1>`.
 Transports are typically specified via configuration files and are attached to various entities in the publisher and subscriber processes.
-Refer to Section :ref:`run_time_configuration--transport-configuration-options` for details on configuring ETF components.
+See :ref:`run_time_configuration--transport-configuration-options` for details on configuring ETF components.
 
 .. _introduction--reffigure1:
 
@@ -706,7 +706,7 @@ This style of discovery is accomplished only through the use of the RTPS protoco
 This simple form of discovery is accomplished through simple configuration of DDS application data readers and data writers running in application processes as shown in :ref:`Figure 1-4 <introduction--reffigure3>`.
 As each participating process activates the DDSI-RTPS discovery mechanisms in OpenDDS for their data readers and writers, network endpoints are created with either default or configured network ports such that DDS participants can begin advertising the availability of their data readers and data writers.
 After a period of time, those seeking one another based on criteria will find each other and establish a connection based on the configured pluggable transport as discussed in Extensible Transport Framework (ETF).
-A more detailed description of this flexible configuration approach is discussed in Section :ref:`run_time_configuration--transport-concepts` and Section :ref:`run_time_configuration--rtps-udp-transport-configuration-options`.
+A more detailed description of this flexible configuration approach is discussed in :ref:`run_time_configuration--transport-concepts` and :ref:`run_time_configuration--rtps-udp-transport-configuration-options`.
 
 .. _introduction--reffigure3:
 
@@ -740,7 +740,7 @@ Your application may get called back from these threads via the Listener mechani
 
 When publishing a sample via DDS, OpenDDS normally attempts to send the sample to any connected subscribers using the calling thread.
 If the send call blocks, then the sample may be queued for sending on a separate service thread.
-This behavior depends on the QoS policies described in Chapter :ref:`quality_of_service--quality-of-service`.
+This behavior depends on the QoS policies described in :ref:`quality_of_service--quality-of-service`.
 
 All incoming data in the subscriber is read by a service thread and queued for reading by the application.
 DataReader listeners are called from the service thread.
@@ -755,7 +755,7 @@ Configuration
 
 OpenDDS includes a file-based configuration framework for configuring both global items such as debug level, memory allocation, and discovery, as well as transport implementation details for publishers and subscribers.
 Configuration can also be achieved directly in code, however, it is recommended that configuration be externalized for ease of maintenance and reduction in runtime errors.
-The complete set of configuration options are described in Chapter :ref:`run_time_configuration--run-time-configuration`.
+The complete set of configuration options are described in :ref:`run_time_configuration--run-time-configuration`.
 
 .. _introduction--installation:
 
@@ -768,12 +768,12 @@ Installation
 
 The steps on how to build OpenDDS can be found in :ghfile:`INSTALL.md`.
 
-To build OpenDDS with DDS Security, see section :ref:`dds_security--building-opendds-with-security-enabled` below.
+To build OpenDDS with DDS Security, see :ref:`dds_security--building-opendds-with-security-enabled`.
 
 To avoid compiling OpenDDS code that you will not be using, there are certain features than can be excluded from being built.
 The features are discussed below.
 
-Users requiring a small-footprint configuration or compatibility with safety-oriented platforms should consider using the OpenDDS Safety Profile, which is described in chapter :ref:`safety_profile--safety-profile` of this guide.
+Users requiring a small-footprint configuration or compatibility with safety-oriented platforms should consider using the OpenDDS Safety Profile, which is described in :ref:`safety_profile--safety-profile` of this guide.
 
 .. _introduction--building-with-a-feature-enabled-or-disabled:
 
@@ -817,7 +817,7 @@ Disabling the Building of Built-In Topic Support
 Feature Name: ``built_in_topics``
 
 You can reduce the footprint of the core DDS library by up to 30% by disabling Built-in Topic Support.
-See Chapter :ref:`built_in_topics--built-in-topics` for a description of Built-In Topics.
+See :ref:`built_in_topics--built-in-topics` for a description of Built-In Topics.
 
 .. _introduction--disabling-the-building-of-compliance-profile-features:
 
@@ -844,7 +844,7 @@ Content-Subscription Profile
 
 Feature Name: ``content_subscription``
 
-This profile adds the classes ``ContentFilteredTopic``, ``QueryCondition``, and ``MultiTopic`` discussed in Chapter :ref:`content_subscription_profile--content-subscription-profile`.
+This profile adds the classes ``ContentFilteredTopic``, ``QueryCondition``, and ``MultiTopic`` discussed in :ref:`content_subscription_profile--content-subscription-profile`.
 
 In addition, individual classes can be excluded by using the features given in the table below.
 
@@ -928,7 +928,7 @@ Building Applications that use OpenDDS
     Sect<1.4>
 
 This section applies to any C++ code that directly or indirectly includes OpenDDS headers.
-For Java applications, see Chapter :ref:`java_bindings--java-bindings` below.
+For Java applications, see :ref:`java_bindings--java-bindings`.
 
 C++ source code that includes OpenDDS headers can be built using either build system: MPC or CMake.
 
@@ -946,7 +946,7 @@ This environment contains the ``PATH`` and ``MPC_ROOT`` settings necessary to us
 
 MPC’s source tree (in ``MPC_ROOT``) contains a "docs" directory with both HTML and plain text documentation (``USAGE`` and ``README`` files).
 
-The example walk-through in section :ref:`getting_started--using-dcps` uses MPC as its build system.
+The example walk-through in :ref:`getting_started--using-dcps` uses MPC as its build system.
 The OpenDDS source tree contains many tests and examples that are built with MPC.
 These can be used as starting points for application MPC files.
 

--- a/docs/devguide/java_bindings.rst
+++ b/docs/devguide/java_bindings.rst
@@ -619,7 +619,7 @@ The ``[transport/1]`` section contains configuration information for the transpo
 It is defined to be of type ``tcp``.
 The global transport configuration setting above causes this transport instance to be used by all readers and writers in the process.
 
-See Chapter :ref:`run_time_configuration--run-time-configuration` for a complete description of all OpenDDS configuration parameters.
+See :ref:`run_time_configuration--run-time-configuration` for a complete description of all OpenDDS configuration parameters.
 
 .. _java_bindings--running-the-example:
 

--- a/docs/devguide/modeling_sdk.rst
+++ b/docs/devguide/modeling_sdk.rst
@@ -68,8 +68,7 @@ Code generation is performed on a single model at a time and includes the abilit
 
 It is possible to generate model variations (distinct customizations of the same model) that can then be created within the same application or different applications.
 It is also possible to specify locations to search for header files and link libraries at build time.
-
-See section :ref:`modeling_sdk--generated-code`, “Generated Code” for details.
+See :ref:`modeling_sdk--generated-code` for details.
 
 .. _modeling_sdk--programming:
 
@@ -82,8 +81,7 @@ Programming
 In order to use the middleware defined by models, applications need to link in the generated code.
 This is done through header files and link libraries.
 Support for building applications using the MPC portable build tool is included in the generated files for a model.
-
-See section :ref:`modeling_sdk--developing-applications`, “Developing Applications” for details.
+See :ref:`modeling_sdk--developing-applications` for details.
 
 .. _modeling_sdk--installation-and-getting-started:
 
@@ -270,7 +268,7 @@ The process of generating code is documented in the Eclipse help.
 
    * - ``<ModelName>_paths.mpb``
 
-     - MPC base project with paths, see section :ref:`modeling_sdk--dependencies-between-models`
+     - MPC base project with paths, see :ref:`modeling_sdk--dependencies-between-models`
 
    * - ``<ModelName>Traits.h``
 
@@ -413,7 +411,7 @@ It is recommended that Modeling SDK applications catch both ``CORBA::Exception``
     int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     {
       try {
-        // Create and use OpenDDS Modeling SDK (see sections below)
+        // Create and use OpenDDS Modeling SDK (see below)
       } catch (const CORBA::Exception& e) {
         // Handle exception and return non-zero
       } catch (const OpenDDS::DCPS::Transport::Exception& te) {

--- a/docs/devguide/opendds_idl.rst
+++ b/docs/devguide/opendds_idl.rst
@@ -9,7 +9,7 @@ opendds_idl
 
 opendds_idl is one of the code generators used in the process of building OpenDDS and OpenDDS applications.
 It can be used in a number of different ways to customize how source code is generated from IDL files.
-See section :ref:`getting_started--processing-the-idl` for an overview of the default usage pattern.
+See :ref:`getting_started--processing-the-idl` for an overview of the default usage pattern.
 
 The OpenDDS IDL compiler is invoked using the ``opendds_idl`` executable, located in :ghfile:`bin/` (on the ``PATH``).
 It parses a single IDL file and generates the serialization and key support code that OpenDDS requires to marshal and demarshal the types described in the IDL file, as well as the type support code for the data readers and writers.
@@ -21,7 +21,7 @@ For example,
 
     opendds_idl [options...] Foo.idl
 
-The remaining sections of this chapter describe all of the command-line options and the ways that ``opendds_idl`` can be used to generate alternate mappings.
+Subsequent sections describe all of the command-line options and the ways that ``opendds_idl`` can be used to generate alternate mappings.
 
 .. _opendds_idl--opendds-idl-command-line-options:
 
@@ -160,7 +160,7 @@ The following table summarizes the options supported by ``opendds_idl``.
        ``-Gxtypes-complete``
 
      - Generate complete XTypes TypeObjects which can be used to provide type information to applications that don’t have compile-time knowledge of the IDL.
-       See section :ref:`xtypes--dynamic-language-binding-1`.
+       See :ref:`xtypes--dynamic-language-binding-1`.
 
      - Only minimal TypeObjects are generated
 
@@ -218,7 +218,7 @@ The following table summarizes the options supported by ``opendds_idl``.
    * - ``--[no-]default-nested``
 
      - Un-annotated types/modules are treated as nested.
-       See section :ref:`getting_started--topic-types-vs-nested-types` for details.
+       See :ref:`getting_started--topic-types-vs-nested-types` for details.
 
      - Types are nested by default.
 
@@ -241,13 +241,13 @@ The following table summarizes the options supported by ``opendds_idl``.
 
    * - ``--default-autoid VAL``
 
-     - Set the default XTypes auto member-id assignment strategy: sequential or hash – see section :ref:`xtypes--autoid-value`
+     - Set the default XTypes auto member-id assignment strategy: sequential or hash – see :ref:`xtypes--autoid-value`
 
      - ``sequential``
 
    * - ``--default-try-construct VAL``
 
-     - Set the default XTypes try-construct strategy: ``discard``, ``use-default``, or ``trim`` – see section :ref:`xtypes--customizing-xtypes-per-member`
+     - Set the default XTypes try-construct strategy: ``discard``, ``use-default``, or ``trim`` – see :ref:`xtypes--customizing-xtypes-per-member`
 
      - ``discard``
 
@@ -280,7 +280,7 @@ Since the IDL-to-C++11 Mapping assumes a C++11 (or higher) compiler and standard
 For example, IDL strings, arrays, and sequences map to their equivalents in the ``std`` namespace: ``string``, ``array``, and ``vector``.
 All of the details of the mapping are spelled out in the specification document (available at https://www.omg.org/spec/CPP11), however the easiest way to get started with the mapping is to generate code from IDL and examine the generated header file.
 
-In ``opendds_idl``’s default mode (as described in section :ref:`getting_started--processing-the-idl`), responsibility for generating the language mapping is delegated to ``tao_idl`` (using the IDL-to-C++ classic mapping).
+In the default mode of ``opendds_idl`` (as described in :ref:`getting_started--processing-the-idl`), responsibility for generating the language mapping is delegated to ``tao_idl`` (using the IDL-to-C++ classic mapping).
 In this case, ``opendds_idl`` is only responsible for generating the OpenDDS-specific additions such as ``TypeSupport.idl`` and the marshal/demarshal functions.
 
 Contrast this with using ``opendds_idl`` for IDL-to-C++11.
@@ -326,7 +326,7 @@ Unlike when using the classic mapping, ``Foo.idl`` is not processed by ``tao_idl
   * Bounded strings and sequences are supported, but bounds checks are not currently enforced.
     Due to this limitation, distinct types are not used for bounded instantiations.
 
-* annotations – see section :ref:`getting_started--defining-data-types-with-idl`
+* annotations – see :ref:`getting_started--defining-data-types-with-idl`
 
 * #includes of IDL files that are also used with the IDL-to-C++11 mapping
 

--- a/docs/devguide/quality_of_service.rst
+++ b/docs/devguide/quality_of_service.rst
@@ -17,8 +17,8 @@ Introduction
     Sect<3.1>
 
 The previous examples use default QoS policies for the various entities.
-This chapter discusses the QoS policies which are implemented in OpenDDS and the details of their usage.
-See the DDS specification for further information about the policies discussed in this chapter.
+This section discusses the QoS policies which are implemented in OpenDDS and the details of their usage.
+See the DDS specification for further information about the policies discussed in this section.
 
 .. _quality_of_service--qos-policies:
 
@@ -46,7 +46,7 @@ For example, the Publisher’s QoS structure is defined in the specification’s
     };
 
 Setting policies is as simple as obtaining a structure with the default values already set, modifying the individual policy structures as necessary, and then applying the QoS structure to an entity (usually when it is created).
-We show examples of how to obtain the default QoS policies for various entity types in Section :ref:`quality_of_service--default-qos-policy-values`.
+See :ref:`quality_of_service--default-qos-policy-values` for examples of how to obtain the default QoS policies for various entity types.
 
 Applications can change the QoS of any entity by calling the set_qos() operation on the entity.
 If the QoS is changeable, existing associations are removed if they are no longer compatible and new associations are added if they become compatible.

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -18,7 +18,7 @@ Configuration Approach
 
 OpenDDS includes a file-based configuration framework for configuring global options and options related to specific publishers and subscribers such as discovery and transport configuration.
 OpenDDS also allows configuration via the command line for a limited number of options and via a configuration API.
-This chapter summarizes the configuration options supported by OpenDDS.
+This section summarizes the configuration options supported by OpenDDS.
 
 OpenDDS configuration is concerned with three main areas:
 
@@ -27,7 +27,7 @@ OpenDDS configuration is concerned with three main areas:
    all readers and writers should use RTPS discovery).
 
 #. **Discovery Configuration Options** – configure the behavior of the discovery mechanism(s).
-   OpenDDS supports multiple approaches for discovering and associating writers and readers as detailed in Section :ref:`run_time_configuration--discovery-configuration`.
+   OpenDDS supports multiple approaches for discovering and associating writers and readers as detailed in :ref:`run_time_configuration--discovery-configuration`.
 
 #. **Transport Configuration Options** – configure the Extensible Transport Framework (ETF) which abstracts the transport layer from the DCPS layer of OpenDDS.
    Each pluggable transport can be configured separately.
@@ -82,7 +82,7 @@ For each of the section types with the exception of ``[common]``, the syntax of 
 For example, a ``[repository]`` section type would always be used in a configuration file like so:
 
 ``[repository/repo_1]`` where ``repository`` is the section type and ``repo_1`` is an instance name of a repository configuration.
-How to use instances to configure discovery and transports is explained further in Sections :ref:`run_time_configuration--discovery-configuration` and :ref:`run_time_configuration--transport-configuration`.
+How to use instances to configure discovery and transports is explained further in :ref:`run_time_configuration--discovery-configuration` and :ref:`run_time_configuration--transport-configuration`.
 
 The ``-DCPSConfigFile`` command-line argument can be used to pass the location of a configuration file to OpenDDS.
 For example:
@@ -279,7 +279,7 @@ The following table summarizes the ``[common]`` configuration options:
        ``DEFAULT_REPO`` translates to using the ``DCPSInfoRepo``.
        ``DEFAULT_RTPS`` specifies the use of RTPS for discovery.
        ``DEFAULT_STATIC`` specifies the use of static discovery.
-       See Section :ref:`run_time_configuration--discovery-configuration` for details about configuring discovery.
+       See :ref:`run_time_configuration--discovery-configuration` for details about configuring discovery.
 
      - ``DEFAULT_REPO``
 
@@ -320,7 +320,7 @@ The following table summarizes the ``[common]`` configuration options:
        ``debug``
 
      - General logging control.
-       See section :ref:`run_time_configuration--logging` for details.
+       See :ref:`run_time_configuration--logging` for details.
 
      - ``warning``
 
@@ -356,7 +356,7 @@ The following table summarizes the ``[common]`` configuration options:
      - This setting is only available when OpenDDS is compiled with DDS Security enabled.
        If set to 1, enable DDS Security framework and built-in plugins.
        Each Domain Participant using security must be created with certain QoS policy values.
-       See chapter :ref:`dds_security--dds-security`: DDS Security for more information.
+       See :ref:`dds_security--dds-security`: DDS Security for more information.
 
      - ``0``
 
@@ -364,7 +364,7 @@ The following table summarizes the ``[common]`` configuration options:
 
      - This setting is only available when OpenDDS is compiled with DDS Security enabled.
        This controls the security debug logging granularity by category.
-       See Section :ref:`run_time_configuration--security-debug-logging` for details.
+       See :ref:`run_time_configuration--security-debug-logging` for details.
 
      - ``0``
 
@@ -372,7 +372,7 @@ The following table summarizes the ``[common]`` configuration options:
 
      - This setting is only available when OpenDDS is compiled with DDS Security enabled.
        This controls the security debug logging granularity by debug level.
-       See section :ref:`run_time_configuration--security-debug-logging` for details.
+       See :ref:`run_time_configuration--security-debug-logging` for details.
 
      - ``N/A``
 
@@ -387,7 +387,7 @@ The following table summarizes the ``[common]`` configuration options:
    * - ``DCPSTransportDebugLevel=n``
 
      - Integer value that controls the amount of debug information the transport layer prints.
-       See section :ref:`run_time_configuration--transport-layer-debug-logging` for details.
+       See :ref:`run_time_configuration--transport-layer-debug-logging` for details.
 
      - ``0``
 
@@ -435,7 +435,7 @@ The following table summarizes the ``[common]`` configuration options:
 
    * - ``DCPSThreadStatusInterval=sec``
 
-     - Enable internal thread status reporting (see section :ref:`built_in_topics--openddsinternalthread-topic`) using the specified reporting interval, in seconds.
+     - Enable internal thread status reporting (:ref:`built_in_topics--openddsinternalthread-topic`) using the specified reporting interval, in seconds.
 
      - ``0 (disabled)``
 
@@ -513,7 +513,7 @@ The static discovery mechanism does not have a dedicated section.
 Instead, users are expected to refer to the ``DEFAULT_STATIC`` instance.
 A single domain can refer to only one type of discovery section.
 
-See Sections :ref:`run_time_configuration--configuring-applications-for-dcpsinforepo` for configuring ``[repository]`` sections, :ref:`run_time_configuration--configuring-for-ddsi-rtps-discovery` for configuring ``[rtps_discovery]``, and :ref:`run_time_configuration--configuring-for-static-discovery` for configuring static discovery.
+See :ref:`run_time_configuration--configuring-applications-for-dcpsinforepo` for configuring InfoRepo Discovery, :ref:`run_time_configuration--configuring-for-ddsi-rtps-discovery` for configuring RTPS Discovery, and :ref:`run_time_configuration--configuring-for-static-discovery` for configuring Static Discovery.
 
 Ultimately a domain is assigned an integer value and a configuration file can support this in two ways.
 The first is to simply make the instance value the integer value assigned to the domain as shown here:
@@ -556,7 +556,7 @@ Here is an extension of our example:
     RepositoryIor=host1.mydomain.com:12345
 
 In this case our domain points to a ``[repository]`` section which is used for an OpenDDS ``DCPSInfoRepo`` service.
-See Section :ref:`run_time_configuration--configuring-applications-for-dcpsinforepo` for more details.
+See :ref:`run_time_configuration--configuring-applications-for-dcpsinforepo` for more details.
 
 There are going to be occasions when specific domains are not identified in the configuration file.
 For example, if an OpenDDS application assigns a domain ID of 3 to its participants and the above example does not supply a configuration for domain id of 3 then the following can be used:
@@ -600,7 +600,7 @@ Here is an example:
     RepositoryIor=host2.mydomain.com:12345
 
 By adding the ``DCPSDefaultDiscovery`` property to the ``[common]`` section, any participant that hasn’t been assigned to a domain id of ``1`` or ``2`` will use the configuration of ``DiscoveryConfig2``.
-For more explanation of a similar configuration for RTPS discovery see Section :ref:`run_time_configuration--configuring-for-ddsi-rtps-discovery`.
+For more explanation of a similar configuration for RTPS discovery see :ref:`run_time_configuration--configuring-for-ddsi-rtps-discovery`.
 
 Here are the available properties for the [domain] section.
 
@@ -634,7 +634,7 @@ Here are the available properties for the [domain] section.
    * - ``DefaultTransportConfig=config``
 
      - A user-defined string that refers to the instance name of a ``[config]`` section.
-       See Section :ref:`run_time_configuration--transport-configuration`.
+       See :ref:`run_time_configuration--transport-configuration`.
 
 .. _run_time_configuration--configuring-applications-for-dcpsinforepo:
 
@@ -767,7 +767,7 @@ The DDS entities in a single OpenDDS process can be associated with multiple DCP
 The repository information and domain associations can be configured using a configuration file, or via application API.
 Internal defaults, command line arguments, and configuration file options will work as-is for existing applications that do not want to use multiple ``DCPSInfoRepo`` associations.
 
-Refer to :ref:`Figure 7-1 <run_time_configuration--reffigure4>` as an example of a process that uses multiple ``DCPSInfoRepo`` repositories.
+See :ref:`Figure 7-1 <run_time_configuration--reffigure4>` for an example of a process that uses multiple ``DCPSInfoRepo`` repositories.
 Processes ``A`` and ``B`` are typical application processes that have been configured to communicate with one another and discover one another in ``InfoRepo_1``.
 This is a simple use of basic discovery.
 However, an additional layer of context has been applied with the use of a specified domain (Domain ``1``).
@@ -868,7 +868,7 @@ Apart from this causality relationship, both protocols can be considered indepen
 
 The configuration options discussed in this section allow a user to specify property values to change the behavior of the Simple Participant Discovery Protocol (SPDP) and/or the Simple Endpoint Discovery Protocol (SEDP) default settings.
 
-DDSI-RTPS can be configured for a single domain or for multiple domains as was done in Section :ref:`run_time_configuration--configuring-for-multiple-dcpsinforepo-instances`.
+DDSI-RTPS can be configured for a single domain or for multiple domains as was done in :ref:`run_time_configuration--configuring-for-multiple-dcpsinforepo-instances`.
 
 A simple configuration is achieved by specifying a property in the ``[common]`` section of our example configuration file.
 
@@ -1158,28 +1158,28 @@ Those properties, along with options specific to OpenDDS’s RTPS Discovery impl
    * - ``SpdpRtpsRelayAddress=host:port``
 
      - Specifies the address of the RtpsRelay for SPDP messages.
-       See section :ref:`internet_enabled_rtps--the-rtpsrelay`.
+       See :ref:`internet_enabled_rtps--the-rtpsrelay`.
 
      -
 
    * - ``SpdpRtpsRelaySendPeriod=period``
 
      - Specifies the interval between SPDP announcements sent to the RtpsRelay.
-       See section :ref:`internet_enabled_rtps--the-rtpsrelay`.
+       See :ref:`internet_enabled_rtps--the-rtpsrelay`.
 
      - 30 seconds
 
    * - ``SedpRtpsRelayAddress=host:port``
 
      - Specifies the address of the RtpsRelay for SEDP messages.
-       See section :ref:`internet_enabled_rtps--the-rtpsrelay`.
+       See :ref:`internet_enabled_rtps--the-rtpsrelay`.
 
      -
 
    * - ``RtpsRelayOnly=[0|1]``
 
      - Only send RTPS message to the RtpsRelay (for debugging).
-       See section :ref:`internet_enabled_rtps--the-rtpsrelay`.
+       See :ref:`internet_enabled_rtps--the-rtpsrelay`.
 
      - 0
 
@@ -1187,91 +1187,91 @@ Those properties, along with options specific to OpenDDS’s RTPS Discovery impl
 
      - Send messages to the RtpsRelay.
        Messages will only be sent if SpdpRtpsRelayAddress and/or SedpRtpsRelayAddress is set.
-       See section :ref:`internet_enabled_rtps--the-rtpsrelay`.
+       See :ref:`internet_enabled_rtps--the-rtpsrelay`.
 
      - 0
 
    * - ``SpdpStunServerAddress=host:port``
 
      - Specifies the address of the STUN server to use for SPDP when using ICE.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`
 
      -
 
    * - ``SedpStunServerAddress=host:port``
 
      - Specifies the address of the STUN server to use for SEDP when using ICE.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      -
 
    * - ``UseIce=[0|1]``
 
      - Enable or disable ICE for both SPDP and SEDP.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      - 0
 
    * - ``IceTa=msec``
 
      - Minimum interval between ICE sends.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      - 50
 
    * - ``IceConnectivityCheckTTL=sec``
 
      - Maximum duration of connectivity check.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      - 300
 
    * - ``IceChecklistPeriod=sec``
 
      - Attempt to cycle through all of the connectivity checks for a candidate in this amount of time.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      - 10
 
    * - ``IceIndicationPeriod=sec``
 
      - Send STUN indications to peers to maintain NAT bindings at this period.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      - 15
 
    * - ``IceNominatedTTL=sec``
 
      - Forget a valid candidate if an indication is not received in this amount of time.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      - 300
 
    * - ``IceServerReflexiveAddressPeriod=sec``
 
      - Send a messages to the STUN server at this period.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      - 30
 
    * - ``IceServerReflexiveIndicationCount=integer``
 
      - Send this many indications before sending a new binding request to the STUN server.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      - 10
 
    * - ``IceDeferredTriggeredCheckTTL=sec``
 
      - Purge deferred checks after this amount of time.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      - 300
 
    * - ``IceChangePasswordPeriod=sec``
 
      - Change the ICE password after this amount of time.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      - 300
 
@@ -1395,7 +1395,7 @@ Additional DDSI-RTPS Discovery Features
     Sect<7.3.3.1>
 
 The DDSI_RTPS discovery implementation creates and manages a transport instance –  specifically an object of class ``RtpsUdpInst``.
-In order for applications to access this object and enable advanced features (see :ref:`Additional RTPS_UDP Features <run_time_configuration--additional-rtps-udp-features>`), the ``RtpsDiscovery`` class provides the method ``sedp_transport_inst(domainId, participant)``.
+In order for applications to access this object and enable advanced features (:ref:`Additional RTPS_UDP Features <run_time_configuration--additional-rtps-udp-features>`), the ``RtpsDiscovery`` class provides the method ``sedp_transport_inst(domainId, participant)``.
 
 .. _run_time_configuration--configuring-for-static-discovery:
 
@@ -1473,7 +1473,7 @@ The code to configure the DataReaderQos is similar:
 The domain id, which is 34 in the example, should be passed to the call to ``create_participant``.
 
 In the example, the endpoint configuration for ``MyReader`` references ``MyConfig`` which in turn references ``MyTransport``.
-Transport configuration is described in Section :ref:`run_time_configuration--transport-configuration`.
+Transport configuration is described in :ref:`run_time_configuration--transport-configuration`.
 The important detail for static discovery is that at least one of the transports contains a known network address (``1.2.3.4:30000``).
 An error will be issued if an address cannot be determined for an endpoint.
 The static discovery implementation also checks that the QoS of a data reader or data writer object matches the QoS specified in the configuration file.
@@ -1521,7 +1521,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``VOLATILE|TRANSIENT_LOCAL]``
 
-     - See Section :ref:`quality_of_service--durability`.
+     - See :ref:`quality_of_service--durability`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1529,7 +1529,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_SEC]``
 
-     - See Section :ref:`quality_of_service--deadline`.
+     - See :ref:`quality_of_service--deadline`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1537,7 +1537,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_NANOSEC]``
 
-     - See Section :ref:`quality_of_service--deadline`.
+     - See :ref:`quality_of_service--deadline`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1545,7 +1545,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_SEC]``
 
-     - See Section :ref:`quality_of_service--latency-budget`.
+     - See :ref:`quality_of_service--latency-budget`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1553,7 +1553,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_NANOSEC]``
 
-     - See Section :ref:`quality_of_service--latency-budget`.
+     - See :ref:`quality_of_service--latency-budget`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1565,7 +1565,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``MANUAL_BY_PARTICIPANT]``
 
-     - See Section :ref:`quality_of_service--liveliness`.
+     - See :ref:`quality_of_service--liveliness`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1573,7 +1573,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_SEC]``
 
-     - See Section :ref:`quality_of_service--liveliness`.
+     - See :ref:`quality_of_service--liveliness`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1581,13 +1581,13 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_NANOSEC]``
 
-     - See Section :ref:`quality_of_service--liveliness`.
+     - See :ref:`quality_of_service--liveliness`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
    * - ``reliability.kind=[BEST_EFFORT|RELIABILE]``
 
-     - See Section :ref:`quality_of_service--reliability`.
+     - See :ref:`quality_of_service--reliability`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1595,7 +1595,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_SEC]``
 
-     - See Section :ref:`quality_of_service--reliability`.
+     - See :ref:`quality_of_service--reliability`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1603,7 +1603,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_NANOSEC]``
 
-     - See Section :ref:`quality_of_service--reliability`.
+     - See :ref:`quality_of_service--reliability`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1613,31 +1613,31 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``BY_RECEPTION_TIMESTAMP]``
 
-     - See Section :ref:`quality_of_service--destination-order`.
+     - See :ref:`quality_of_service--destination-order`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
    * - ``history.kind=[KEEP_LAST|KEEP_ALL]``
 
-     - See Section :ref:`quality_of_service--history`.
+     - See :ref:`quality_of_service--history`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
    * - ``history.depth=numeric``
 
-     - See Section :ref:`quality_of_service--history`.
+     - See :ref:`quality_of_service--history`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
    * - ``resource_limits.max_samples=numeric``
 
-     - See Section :ref:`quality_of_service--resource-limits`.
+     - See :ref:`quality_of_service--resource-limits`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
    * - ``resource_limits.max_instances=numeric``
 
-     - See Section :ref:`quality_of_service--resource-limits`.
+     - See :ref:`quality_of_service--resource-limits`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1645,13 +1645,13 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric``
 
-     - See Section :ref:`quality_of_service--resource-limits`.
+     - See :ref:`quality_of_service--resource-limits`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
    * - ``transport_priority.value=numeric``
 
-     - See Section :ref:`quality_of_service--transport-priority`.
+     - See :ref:`quality_of_service--transport-priority`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1659,7 +1659,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_SEC]``
 
-     - See Section :ref:`quality_of_service--lifespan`.
+     - See :ref:`quality_of_service--lifespan`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1667,19 +1667,19 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_NANOSEC]``
 
-     - See Section :ref:`quality_of_service--lifespan`.
+     - See :ref:`quality_of_service--lifespan`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
    * - ``ownership.kind=[SHARED|EXCLUSIVE]``
 
-     - See Section :ref:`quality_of_service--ownership`.
+     - See :ref:`quality_of_service--ownership`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
    * - ``ownership_strength.value=numeric``
 
-     - See Section :ref:`quality_of_service--ownership-strength`.
+     - See :ref:`quality_of_service--ownership-strength`.
 
      - See :ref:`Table 3-5 <quality_of_service--reftable6>`.
 
@@ -1700,7 +1700,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``VOLATILE|TRANSIENT_LOCAL]``
 
-     - See Section :ref:`quality_of_service--durability`.
+     - See :ref:`quality_of_service--durability`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1708,7 +1708,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_SEC]``
 
-     - See Section :ref:`quality_of_service--deadline`.
+     - See :ref:`quality_of_service--deadline`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1716,7 +1716,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_NANOSEC]``
 
-     - See Section :ref:`quality_of_service--deadline`.
+     - See :ref:`quality_of_service--deadline`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1724,7 +1724,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_SEC]``
 
-     - See Section :ref:`quality_of_service--latency-budget`.
+     - See :ref:`quality_of_service--latency-budget`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1732,7 +1732,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_NANOSEC]``
 
-     - See Section :ref:`quality_of_service--latency-budget`.
+     - See :ref:`quality_of_service--latency-budget`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1744,7 +1744,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``MANUAL_BY_PARTICIPANT]``
 
-     - See Section :ref:`quality_of_service--liveliness`.
+     - See :ref:`quality_of_service--liveliness`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1752,7 +1752,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_SEC]``
 
-     - See Section :ref:`quality_of_service--liveliness`.
+     - See :ref:`quality_of_service--liveliness`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1760,13 +1760,13 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_NANOSEC]``
 
-     - See Section :ref:`quality_of_service--liveliness`.
+     - See :ref:`quality_of_service--liveliness`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
    * - ``reliability.kind=[BEST_EFFORT|RELIABILE]``
 
-     - See Section :ref:`quality_of_service--reliability`.
+     - See :ref:`quality_of_service--reliability`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1774,7 +1774,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_SEC]``
 
-     - See Section :ref:`quality_of_service--reliability`.
+     - See :ref:`quality_of_service--reliability`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1782,7 +1782,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_NANOSEC]``
 
-     - See Section :ref:`quality_of_service--reliability`.
+     - See :ref:`quality_of_service--reliability`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1792,31 +1792,31 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``BY_RECEPTION_TIMESTAMP]``
 
-     - See Section :ref:`quality_of_service--destination-order`.
+     - See :ref:`quality_of_service--destination-order`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
    * - ``history.kind=[KEEP_LAST|KEEP_ALL]``
 
-     - See Section :ref:`quality_of_service--history`.
+     - See :ref:`quality_of_service--history`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
    * - ``history.depth=numeric``
 
-     - See Section :ref:`quality_of_service--history`.
+     - See :ref:`quality_of_service--history`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
    * - ``resource_limits.max_samples=numeric``
 
-     - See Section :ref:`quality_of_service--resource-limits`.
+     - See :ref:`quality_of_service--resource-limits`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
    * - ``resource_limits.max_instances=numeric``
 
-     - See Section :ref:`quality_of_service--resource-limits`.
+     - See :ref:`quality_of_service--resource-limits`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1824,7 +1824,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric``
 
-     - See Section :ref:`quality_of_service--resource-limits`.
+     - See :ref:`quality_of_service--resource-limits`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1832,7 +1832,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_SEC]``
 
-     - See Section :ref:`quality_of_service--time-based-filter`.
+     - See :ref:`quality_of_service--time-based-filter`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1840,7 +1840,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_NANOSEC]``
 
-     - See Section :ref:`quality_of_service--time-based-filter`.
+     - See :ref:`quality_of_service--time-based-filter`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1849,7 +1849,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_SEC]``
 
-     - See Section :ref:`quality_of_service--reader-data-lifecycle`.
+     - See :ref:`quality_of_service--reader-data-lifecycle`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1858,7 +1858,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_NANOSEC]``
 
-     - See Section :ref:`quality_of_service--reader-data-lifecycle`.
+     - See :ref:`quality_of_service--reader-data-lifecycle`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1867,7 +1867,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_SEC]``
 
-     - See Section :ref:`quality_of_service--reader-data-lifecycle`.
+     - See :ref:`quality_of_service--reader-data-lifecycle`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1876,7 +1876,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
        ``numeric|DURATION_INFINITE_NANOSEC]``
 
-     - See Section :ref:`quality_of_service--reader-data-lifecycle`.
+     - See :ref:`quality_of_service--reader-data-lifecycle`.
 
      - See :ref:`Table 3-6 <quality_of_service--reftable7>`.
 
@@ -1895,25 +1895,25 @@ The static discovery implementation also checks that the QoS of a data reader or
 
    * - ``presentation.access_scope=[INSTANCE|TOPIC|GROUP]``
 
-     - See Section :ref:`quality_of_service--presentation`.
+     - See :ref:`quality_of_service--presentation`.
 
      - See :ref:`Table 3-3 <quality_of_service--reftable4>`.
 
    * - ``presentation.coherent_access=[true|false]``
 
-     - See Section :ref:`quality_of_service--presentation`.
+     - See :ref:`quality_of_service--presentation`.
 
      - See :ref:`Table 3-3 <quality_of_service--reftable4>`.
 
    * - ``presentation.ordered_access=[true|false]``
 
-     - See Section :ref:`quality_of_service--presentation`.
+     - See :ref:`quality_of_service--presentation`.
 
      - See :ref:`Table 3-3 <quality_of_service--reftable4>`.
 
    * - ``partition.name=name0,name1,...``
 
-     - See Section :ref:`quality_of_service--partition`.
+     - See :ref:`quality_of_service--partition`.
 
      - See :ref:`Table 3-3 <quality_of_service--reftable4>`.
 
@@ -1932,25 +1932,25 @@ The static discovery implementation also checks that the QoS of a data reader or
 
    * - ``presentation.access_scope=[INSTANCE|TOPIC|GROUP]``
 
-     - See Section :ref:`quality_of_service--presentation`.
+     - See :ref:`quality_of_service--presentation`.
 
      - See :ref:`Table 3-4 <quality_of_service--reftable5>`.
 
    * - ``presentation.coherent_access=[true|false]``
 
-     - See Section :ref:`quality_of_service--presentation`.
+     - See :ref:`quality_of_service--presentation`.
 
      - See :ref:`Table 3-4 <quality_of_service--reftable5>`.
 
    * - ``presentation.ordered_access=[true|false]``
 
-     - See Section :ref:`quality_of_service--presentation`.
+     - See :ref:`quality_of_service--presentation`.
 
      - See :ref:`Table 3-4 <quality_of_service--reftable5>`.
 
    * - ``partition.name=name0,name1,...``
 
-     - See Section :ref:`quality_of_service--partition`.
+     - See :ref:`quality_of_service--partition`.
 
      - See :ref:`Table 3-4 <quality_of_service--reftable5>`.
 
@@ -2252,7 +2252,7 @@ Any Data Writers or Readers owned by this Domain Participant should now use the 
 
 .. note:: When directly binding a configuration to a data writer or reader, the ``bind_config`` call must occur before the reader or writer is enabled.
   This is not an issue when binding configurations to Domain Participants, Publishers, or Subscribers.
-  See Section :ref:`quality_of_service--entity-factory` for details on how to create entities that are not enabled.
+  See :ref:`quality_of_service--entity-factory` for details on how to create entities that are not enabled.
 
 .. _run_time_configuration--transport-registry-example:
 
@@ -2874,7 +2874,7 @@ The OpenDDS implementation of the OMG DDSI-RTPS (``formal/2014-09-01``) specific
 The ``rtps_udp`` transport is one of the pluggable transports available to a developer and is necessary for interoperable communication between implementations.
 This section will discuss the options available to the developer for configuring OpenDDS to use this transport.
 
-To provide an RTPS variant of the single configuration example from Section :ref:`run_time_configuration--single-transport-configuration`, the configuration file below simply introduces the ``myrtps`` transport and modifies the ``transport_type`` property to the value ``rtps_udp``.
+To provide an RTPS variant of the single configuration example from :ref:`run_time_configuration--single-transport-configuration`, the configuration file below simply introduces the ``myrtps`` transport and modifies the ``transport_type`` property to the value ``rtps_udp``.
 All other items remain the same.
 
 .. code-block:: ini
@@ -2889,7 +2889,7 @@ All other items remain the same.
     transport_type=rtps_udp
     local_address=myhost
 
-To extend our examples to a mixed transport configuration as shown in Section :ref:`run_time_configuration--using-mixed-transports`, below shows the use of an ``rtps_udp`` transport mixed with a ``tcp`` transport.
+To extend our examples to a mixed transport configuration as shown in :ref:`run_time_configuration--using-mixed-transports`, below shows the use of an ``rtps_udp`` transport mixed with a ``tcp`` transport.
 The interesting pattern that this allows for is a deployed OpenDDS application that can be, for example, communicating using ``tcp`` with other OpenDDS participants while communicating in an interoperability configuration with a non-OpenDDS participant using ``rtps_udp``.
 
 .. code-block:: ini
@@ -3042,14 +3042,14 @@ Some implementation notes related to using the ``rtps_udp`` transport protocol a
    * - ``DataRtpsRelayAddress=host:port``
 
      - Specifies the address of the RtpsRelay for RTPS messages.
-       See section :ref:`internet_enabled_rtps--the-rtpsrelay`.
+       See :ref:`internet_enabled_rtps--the-rtpsrelay`.
 
      -
 
    * - ``RtpsRelayOnly=[0|1]``
 
      - Only send RTPS message to the RtpsRelay (for debugging).
-       See section :ref:`internet_enabled_rtps--the-rtpsrelay`.
+       See :ref:`internet_enabled_rtps--the-rtpsrelay`.
 
      - 0
 
@@ -3057,21 +3057,21 @@ Some implementation notes related to using the ``rtps_udp`` transport protocol a
 
      - Send messages to the RtpsRelay.
        Messages will only be sent if DataRtpsRelayAddress is set.
-       See section :ref:`internet_enabled_rtps--the-rtpsrelay`.
+       See :ref:`internet_enabled_rtps--the-rtpsrelay`.
 
      - 0
 
    * - ``DataStunServerAddress=host:port``
 
      - Specifies the address of the STUN server to use for RTPS when using ICE.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      -
 
    * - ``UseIce=[0|1]``
 
      - Enable or disable ICE for this transport instance.
-       See section :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
+       See :ref:`internet_enabled_rtps--interactive-connectivity-establishment-ice-for-rtps`.
 
      - ``0``
 
@@ -3204,7 +3204,7 @@ Shared-Memory Transport Configuration Options
 The following table summarizes the transport configuration options that are unique to the ``shmem`` transport.
 This transport type is supported Unix-like platforms with POSIX/XSI shared memory and on Windows platforms.
 The shared memory transport type can only provide communication between transport instances on the same host.
-As part of transport negotiation (see :ref:`run_time_configuration--using-mixed-transports`), if there are multiple transport instances available for communication between hosts, the shared memory transport instances will be skipped so that other types can be used.
+As part of transport negotiation (:ref:`run_time_configuration--using-mixed-transports`), if there are multiple transport instances available for communication between hosts, the shared memory transport instances will be skipped so that other types can be used.
 
 .. _run_time_configuration--reftable25:
 
@@ -3280,7 +3280,7 @@ Domain range sections are similar to domain sections and use the same configurat
 
 * Domain ranges can have an optional ``Customization`` property that maps to a named ``[Customization]`` section
 
-See section :ref:`run_time_configuration--example-config-ini` for a ``[DomainRange]`` example.
+See :ref:`run_time_configuration--example-config-ini` for a ``[DomainRange]`` example.
 
 .. _run_time_configuration--configuring-a-set-of-similar-transports:
 
@@ -3316,11 +3316,11 @@ and the partial transport template would be
     transport_type=rtps_udp
 
 Domain participants that belong to a domain that is configured by a template can bind to non-global transport configurations using the ``bind_config`` function.
-See section :ref:`run_time_configuration--using-multiple-configurations` for a discussion of ``bind_config``.
+See :ref:`run_time_configuration--using-multiple-configurations` for a discussion of ``bind_config``.
 
 If the ``[transport_template]`` sets the property ``instantiation_rule=per_participant``, a separate transport instance will be created for each participant in the domain.
 
-See section :ref:`run_time_configuration--example-config-ini` for a ``[transport_template]`` example.
+See :ref:`run_time_configuration--example-config-ini` for a ``[transport_template]`` example.
 
 .. _run_time_configuration--adding-customizations:
 
@@ -3586,7 +3586,7 @@ Security Debug Logging
 ..
     Sect<7.6.3>
 
-When OpenDDS is compiled with security enabled, debug logging for security can be enabled using ``DCPSecurityDebug``(See :ref:`Table 7-2 Common Configuration Options <run_time_configuration--reftable9>`).
+When OpenDDS is compiled with security enabled, debug logging for security can be enabled using ``DCPSecurityDebug``(:ref:`Table 7-2 Common Configuration Options <run_time_configuration--reftable9>`).
 Security logging is divided into categories, although ``DCPSSecurityDebugLevel`` is also provided, which controls the categories in a similar manner and using the same scale as ``DCPSDebugLevel``.
 
 .. _run_time_configuration--reftable28:

--- a/docs/devguide/safety_profile.rst
+++ b/docs/devguide/safety_profile.rst
@@ -52,12 +52,12 @@ When developing the Safety Profile, the following DDS Compliance Profiles were d
 
 * persistence_profile
 
-See Section :ref:`introduction--disabling-the-building-of-compliance-profile-features` for more details on compliance profiles.
+See :ref:`introduction--disabling-the-building-of-compliance-profile-features` for more details on compliance profiles.
 It is possible that enabling any of these compliance profiles in a Safety Profile build will result in a compile-time or run-time error.
 
 To build OpenDDS Safety Profile, pass the command line argument “--safety-profile” to the configure script along with any other arguments needed for your platform or configuration.
 When safety profile is enabled in the configure script, the four compliance profiles listed above default to disabled.
-See section :ref:`introduction--installation` and the ``INSTALL.md`` file in the source distribution for more information about the configure script.
+See :ref:`introduction--installation` and the ``INSTALL.md`` file in the source distribution for more information about the configure script.
 
 .. _safety_profile--safety-profile-configurations-of-ace:
 
@@ -96,7 +96,7 @@ Run-time Configurable Options
     Sect<13.4>
 
 The memory pool used by OpenDDS can be configured by setting values in the [common] section of the configuration file.
-See section :ref:`run_time_configuration--common-configuration-options` and the pool_size and pool_granularity rows of table :ref:`Table 7-2 <run_time_configuration--reftable9>`.
+See :ref:`run_time_configuration--common-configuration-options` and the pool_size and pool_granularity rows of table :ref:`Table 7-2 <run_time_configuration--reftable9>`.
 
 .. _safety_profile--running-ace-and-opendds-tests:
 

--- a/docs/devguide/the_dcps_information_repository.rst
+++ b/docs/devguide/the_dcps_information_repository.rst
@@ -170,7 +170,7 @@ The default domain used for federation is defined by the constant ``Federator::D
 
 Currently only static specification of federation topology is available.
 This means that each DCPS Information Repository, as well as each application using a federated DDS service, needs to include federation configuration as part of its configuration data.
-This is done by specifying each available repository within the federation to each participating process and assigning each repository to a different key value in the configuration files as described in Section :ref:`run_time_configuration--configuring-for-multiple-dcpsinforepo-instances`.
+This is done by specifying each available repository within the federation to each participating process and assigning each repository to a different key value in the configuration files as described in :ref:`run_time_configuration--configuring-for-multiple-dcpsinforepo-instances`.
 
 Each application and repository must include the same set of repositories in its configuration information.
 Failover sequencing will attempt to reach the next repository in numeric sequence (wrapping from the last to the first) of the repository key values.
@@ -188,7 +188,7 @@ Only repositories which are started with a federation identification number may 
 The first repository started should not be given a ``-FederateWith`` command line directive.
 All others are required to have this directive in order to establish the initial federation.
 There is a command line tool (``federation``) supplied that can be used to establish federation associations if this is not done at startup.
-See Section :ref:`the_dcps_information_repository--federation-management` for a description.
+See :ref:`the_dcps_information_repository--federation-management` for a description.
 It is possible, with the current static-only implementation, that the failure of a repository before a federation topology is entirely established could result in a partially unusable service.
 Due to this current limitation, it is highly recommended to always establish the federation topology of repositories prior to starting the applications.
 
@@ -307,7 +307,7 @@ Federation Example
 ..
     Sect<9.2.2>
 
-In order to illustrate the setup and use of a federation, this section walks through a simple example that establishes a federation and a working service that uses it.
+To illustrate the setup and use of a federation, this section walks through a simple example that establishes a federation and a working service that uses it.
 
 This example is based on a two repository federation, with the simple Message publisher and subscriber from :ref:`getting_started--using-dcps` configured to use the federated repositories.
 
@@ -341,7 +341,6 @@ The Message Publisher configuration ``pub.ini`` for this example is as follows:
         RepositoryIor=file://repo.ior
 
 Note that the ``DCPSInfo`` attribute/value pair has been omitted from the ``[common]`` section.
-This has been replaced by the ``[domain/user]`` section as described in 7.5.
 The user domain is 42, so that domain is configured to use the primary repository for service metadata and events.
 
 The ``[repository/primary]`` and ``[repository/secondary]`` sections define the primary and secondary repositories to use within the federation (of two repositories) for this application.
@@ -384,7 +383,7 @@ Running the Federation Example
 ..
     Sect<9.2.2.2>
 
-The example is executed by first starting the repositories and federating them, then starting the application publisher and subscriber processes the same way as was done in the example of  Section :ref:`getting_started--running-the-example`.
+The example is executed by first starting the repositories and federating them, then starting the application publisher and subscriber processes the same way as was done in the example of :ref:`getting_started--running-the-example`.
 
 Start the first repository as:
 
@@ -408,5 +407,4 @@ The ``-ORBListenEndpoints iiop://localhost:2112`` option ensures that the reposi
 The ``-FederationId 2048`` option assigns the value 2048 as the repositories unique id within the federation.
 The ``-FederateWith file://repo.ior`` option initiates federation with the repository located at the IOR contained within the named file - which was written by the previously started repository.
 
-Once the repositories have been started and federation has been established (this will be done automatically after the second repository has initialized), the application publisher and subscriber processes can be started and should execute as they did for the previous example in Section :ref:`getting_started--running-the-example`.
-
+Once the repositories have been started and federation has been established (this will be done automatically after the second repository has initialized), the application publisher and subscriber processes can be started and should execute as they did for the previous example in :ref:`getting_started--running-the-example`.

--- a/docs/devguide/xtypes.rst
+++ b/docs/devguide/xtypes.rst
@@ -26,8 +26,8 @@ Using XTypes, the application developer adds IDL annotations that indicate where
 
 OpenDDS implements the XTypes specification version 1.3 at the Basic Conformance level, with a partial implementation of the Dynamic Language Binding.
 Some features described by the specification are not yet implemented in OpenDDS - those are noted in :ref:`xtypes--unimplemented-features`.
-This includes IDL annotations that are not yet implemented, see :ref:`xtypes--annotations`.
-:ref:`xtypes--differences-from-the-specification` describes situations where the implementation of XTypes in OpenDDS departs from or infers something about the specification.
+This includes IDL annotations that are not yet implemented (:ref:`xtypes--annotations`).
+See :ref:`xtypes--differences-from-the-specification` for situations where the implementation of XTypes in OpenDDS departs from or infers something about the specification.
 Specification issues have been raised for these situations.
 
 .. _xtypes--features:
@@ -834,9 +834,9 @@ This section describes the features of the Dynamic Language Binding that OpenDDS
 
 There are two main usage patterns supported:
 
-* Applications can receive DynamicData from a Recorder object (see :ref:`alternate_interfaces_to_data--recorder-and-replayer`)
+* Applications can receive DynamicData from a Recorder object (:ref:`alternate_interfaces_to_data--recorder-and-replayer`)
 
-* Applications can use XTypes DynamicDataWriter and/or DynamicDataReader (see :ref:`xtypes--dynamicdatawriters-and-dynamicdatareaders`)
+* Applications can use XTypes DynamicDataWriter and/or DynamicDataReader (:ref:`xtypes--dynamicdatawriters-and-dynamicdatareaders`)
 
 To use DynamicDataWriter and/or DynamicDataReader for a given topic, the data type definition for that topic must be available to the local DomainParticipant.
 There are a few ways this can be achieved, see :ref:`xtypes--obtaining-dynamictype-and-registering-typesupport` for details.
@@ -927,9 +927,9 @@ Consider the following example:
 
 The samples for MyStruct are written by a normal, statically-typed DataWriter.
 The writer application needs to have the IDL-generated code including the "complete" form of TypeObjects.
-Use a command-line option to opendds_idl to enable CompleteTypeObjects since the default is to generate MinimalTypeObjects (see :ref:`opendds_idl--opendds-idl-command-line-options`).
+Use a command-line option to opendds_idl to enable CompleteTypeObjects since the default is to generate MinimalTypeObjects (:ref:`opendds_idl--opendds-idl-command-line-options`).
 
-One way to obtain a DynamicData object representing a data sample received by the participant is using the Recorder and RecorderListener classes (see :ref:`alternate_interfaces_to_data--recorder-and-replayer`).
+One way to obtain a DynamicData object representing a data sample received by the participant is using the Recorder and RecorderListener classes (:ref:`alternate_interfaces_to_data--recorder-and-replayer`).
 Recorder's get_dynamic_data can be used to construct a DynamicData object for each received sample from the writer.
 Internally, the CompleteTypeObjects received from discovering that writer are converted to DynamicTypes and they are then used to construct the DynamicData objects.
 Once a DynamicData object for a MyStruct sample is constructed, its members can be read as described in the following sections.
@@ -944,7 +944,7 @@ Reading Basic Types
     Sect<16.7.2.1>
 
 DynamicData provides methods for reading members whose types are basic such as integers, floating point numbers, characters, boolean.
-For a complete list of basic types for which DynamicData provides an interface, please refer to the XTypes specification.
+See the XTypes specification for a complete list of basic types for which DynamicData provides an interface.
 To call a correct method for reading a member, we need to know the type of the member as well as its id.
 For our example, we first want to get the number of members that the sample contains.
 In these examples, the ``data`` object is an instance of DynamicData.
@@ -1108,14 +1108,14 @@ To create a DynamicData object, use the DynamicDataFactory API defined by the XT
 Like other data types defined by IDL interfaces (for example, the ``*TypeSupportImpl`` types), the "dynamic" object's lifetime is managed with a smart pointer - in this case ``DDS::DynamicData_var``.
 
 The "type" input parameter to ``create_data()`` is an object that implements the ``DDS::DynamicType`` interface.
-The DynamicType representation of any type that's supported as a topic data type is available from its corresponding TypeSupport object (see :ref:`xtypes--obtaining-dynamictype-and-registering-typesupport`) using the ``get_type()`` operation.
+The DynamicType representation of any type that's supported as a topic data type is available from its corresponding TypeSupport object (:ref:`xtypes--obtaining-dynamictype-and-registering-typesupport`) using the ``get_type()`` operation.
 Once the application has access to that top-level type, the DynamicType interface can be used to obtain complete information about the type including nested and referenced data types.
 See the file :ghfile:`dds/DdsDynamicData.idl` in OpenDDS for the definition of the DynamicType and related interfaces.
 
 Once the application has created the DynamicData object, it can be populated with data members of any type.
 The operations used for this include the DynamicData operations named "set_*" for the various data types.
 They are analogous to the "get_*" operations that are described in :ref:`xtypes--interpreting-data-samples-with-dynamicdata`.
-When populating the DynamicData of complex data types, use get_complex_value() (see :ref:`xtypes--reading-members-of-more-complex-types`) to navigate from DynamicData representing containing types to DynamicData representing contained types.
+When populating the DynamicData of complex data types, use get_complex_value() (:ref:`xtypes--reading-members-of-more-complex-types`) to navigate from DynamicData representing containing types to DynamicData representing contained types.
 
 Setting the value of a member of a DynamicData union using a ``set_*`` method implicitly 1) activates the branch corresponding to the member and 2) sets the discriminator to a value corresponding to the active branch.
 After a branch has been activated, the value of the discriminator can be changed using a ``set_*`` method.
@@ -1141,7 +1141,7 @@ DynamicDataWriters and DynamicDataReaders
 DynamicDataWriters and DataReaders are designed to work like any other DataWriter and DataReader except that their APIs are defined in terms of the DynamicData type instead of a type generated from IDL.
 Each DataWriter and DataReader has an associated Topic and that Topic has a data type (represented by a TypeSupport object).
 Behavior related to keys, QoS policies, discovery and built-in topics, DDS Security, and transport is not any different for a DynamicDataWriter or DataReader.
-One exception is that in the current implementation, Content-Subscription features (Chapter :ref:`content_subscription_profile--content-subscription-profile`) are not supported for DynamicDataWriters and DataReaders.
+One exception is that in the current implementation, Content-Subscription features (:ref:`content_subscription_profile--content-subscription-profile`) are not supported for DynamicDataWriters and DataReaders.
 
 .. _xtypes--obtaining-dynamictype-and-registering-typesupport:
 
@@ -1180,7 +1180,7 @@ But, crucially, it does have the DynamicType object that we'll need to set up a 
     DDS::DynamicTypeSupport_var ts_dynamic = new DynamicTypeSupport(type);
     DDS::ReturnCode_t ret = ts_dynamic->register_type(participant, "");
 
-Now the type support object ``ts_dynamic`` can be used in the usual DataWriter/DataReader setup sequence (creating a Topic first, etc.) but the created DataWriters and DataReaders will be DynamicDataWriters and DynamicDataReaders (see :ref:`xtypes--creating-and-using-a-dynamicdatawriter-or-dynamicdatareader`).
+Now the type support object ``ts_dynamic`` can be used in the usual DataWriter/DataReader setup sequence (creating a Topic first, etc.) but the created DataWriters and DataReaders will be DynamicDataWriters and DynamicDataReaders (:ref:`xtypes--creating-and-using-a-dynamicdatawriter-or-dynamicdatareader`).
 
 The other approach to obtaining TypeSupport objects for use with the Dynamic Language Binding is to have DDS discovery's built-in endpoints get TypeObjects from remote domain participants.
 To do this, use the ``get_dynamic_type`` method on the singleton ``Service_Participant`` object.
@@ -1298,7 +1298,7 @@ IDL4 defines many standardized annotations and XTypes uses some of them.
 The Annotations recognized by XTypes are in Table 21 in XTypes 1.3.
 Of those listed in that table, the following are not supported in OpenDDS.
 They are listed in groups defined by the rows of that table.
-Some annotations in that table, and not listed here, can only be used with new capabilities of the Type System (see :ref:`xtypes--type-system`).
+Some annotations in that table, and not listed here, can only be used with new capabilities of the Type System (:ref:`xtypes--type-system`).
 
 * Struct members
 


### PR DESCRIPTION
Problem
-------

The conversion of the DevGuide means that the concept of a "chapter" is no longer well defined.  Many references are introduced as "see section X".

Solution
--------

- Where possible remove the descriptor (chapter/section) of the target of the reference.

- Change generic references to be section.