### PR TITLE
Add Bullets To Top-Level Sidebar Links in Sphinx

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -2,6 +2,22 @@
   width: 100%;
 }
 
+div.sphinxsidebar ul {
+  /* Top-level navigation side bar links are a little hard to distinguish from
+   * one another because some of them will overflow into multiple lines. A ul
+   * tag would have bullets, but that's disabled in the theme's CSS. This
+   * overrides that and readds the bullets.
+   */
+  list-style: square;
+  /* Without this Chrome might draw the bullets out of sight if the window is
+   * too narrow. They do appear in Firefox, but they are right at the edge.
+   */
+  margin-left: 10px;
+}
+
+/* Allows custom elements that aren't code or pre tags to looks like code and
+ * pre tags.
+ */
 .custom_literal {
   font-family: 'Consolas', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
   font-size: 0.9em;


### PR DESCRIPTION
Top-level navigation sidebar links are a little hard to distinguish from one another because some of them will overflow into multiple lines. A `ul` tag would have bullets, but that's disabled in the theme's CSS. This overrides that and readds the bullets.

Here is a screenshot with the added bullets on the right side:

![Screenshot from 2023-04-05 15-08-05](https://user-images.githubusercontent.com/5941194/230202285-a2a16d50-3b4a-40ab-b157-6d02d7e5bac1.png)
