### PR TITLE
OpenDDS Foundation as author of DevGuide

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,8 +32,8 @@ pygments_style = 'manni'
 nitpicky = True
 
 project = 'OpenDDS'
-copyright = '2023, Object Computing, Inc.'
-author = 'Object Computing, Inc.'
+copyright = '2023, OpenDDS Foundation'
+author = 'OpenDDS Foundation'
 github_links_repo = 'OpenDDS/OpenDDS'
 
 # Get Version Info


### PR DESCRIPTION
Not 100% sure, but shouldn't have the DevGuide now have the OpenDDS Foundation as author?