### PR TITLE
TcpDataLink fails to send association message

### DIFF
--- a/dds/DCPS/transport/framework/TransportControlElement.cpp
+++ b/dds/DCPS/transport/framework/TransportControlElement.cpp
@@ -13,10 +13,11 @@
 #include "TransportControlElement.inl"
 #endif /* __ACE_INLINE__ */
 
-OpenDDS::DCPS::TransportControlElement::TransportControlElement(
-  Message_Block_Ptr msg_block
-) : TransportQueueElement(1),
-    msg_( msg_block.release())
+OpenDDS::DCPS::TransportControlElement::TransportControlElement(Message_Block_Ptr msg_block,
+                                                                const GUID_t& publication_id)
+  : TransportQueueElement(1)
+  , msg_( msg_block.release())
+  , publication_id_(publication_id)
 {
   DBG_ENTRY_LVL("TransportControlElement", "TransportControlElement", 6);
 }

--- a/dds/DCPS/transport/framework/TransportControlElement.h
+++ b/dds/DCPS/transport/framework/TransportControlElement.h
@@ -31,7 +31,8 @@ public:
    * msg_block - chain of ACE_Message_Blocks containing the control
    *             sample held by this queue element, if any.
    */
-  explicit TransportControlElement(Message_Block_Ptr msg_block);
+  explicit TransportControlElement(Message_Block_Ptr msg_block,
+                                   const GUID_t& publication_id = GUID_UNKNOWN);
 
   virtual ~TransportControlElement();
 
@@ -57,6 +58,7 @@ private:
   TransportControlElement(const TransportControlElement&);
   /// The control message.
   Message_Block_Ptr msg_;
+  GUID_t publication_id_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/framework/TransportControlElement.inl
+++ b/dds/DCPS/transport/framework/TransportControlElement.inl
@@ -26,7 +26,7 @@ ACE_INLINE
 OpenDDS::DCPS::GUID_t
 OpenDDS::DCPS::TransportControlElement::publication_id() const
 {
-  return GUID_UNKNOWN;
+  return publication_id_;
 }
 
 ACE_INLINE

--- a/dds/DCPS/transport/tcp/TcpDataLink.cpp
+++ b/dds/DCPS/transport/tcp/TcpDataLink.cpp
@@ -554,7 +554,7 @@ OpenDDS::DCPS::TcpDataLink::send_association_msg(const GUID_t& local, const GUID
   Serializer ser(message.get(), encoding_unaligned_native);
   ser << remote;
 
-  TransportControlElement* send_element = new TransportControlElement(move(message));
+  TransportControlElement* send_element = new TransportControlElement(move(message), local);
 
   this->send_i(send_element, false);
 }


### PR DESCRIPTION
Problem
-------

The `send_association_msg` method creates a special `REQUEST_ACK`
control message to signal that the local reader is ready to receive
data.  On receipt of the message, the remote writer completes the
association and can start sending data.  `send_association_msg` calls
`send_i` which checks if the publication id of the
`TransportControlElement` is for a stopped (local) client.  The
publication id returned by the `TransportControlElement` is always
GUID_UNKNOWN.  Thus, if GUID_UNKNOWN gets put into the stopped client
set then the `TcpDataLink` will never send the association message and
association will stall on the writer side.

`TransportClient` caches its guid when an association is made.
Suppose the `TransportClient` is stopped before an association.  In
this case the guid is `GUID_UNNOWN` and this guid is put in the
stopped client set of the `TcpDataLink`.

Solution
--------

1. Implement support for the publisher id.
2. Guard against usages of an uninitialized `repo_id_` in `TransportClient`.