### PR TITLE
Remove Many Uses of `ace/pre.h` and `ace/post.h`

### DIFF
--- a/dds/DCPS/Comparator_T.h
+++ b/dds/DCPS/Comparator_T.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,17 +6,16 @@
 #ifndef OPENDDS_DCPS_COMPARATOR_T_H
 #define OPENDDS_DCPS_COMPARATOR_T_H
 
-#include /**/ "ace/pre.h"
-
-#if !defined (ACE_LACKS_PRAGMA_ONCE)
-# pragma once
-#endif /* ACE_LACKS_PRAGMA_ONCE */
-
-#include "ace/OS_NS_string.h"
+#include <ace/config-macros.h>
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
 
 #include "RcHandle_T.h"
 #include "RcObject.h"
 #include "RakeData.h"
+
+#include <ace/OS_NS_string.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/DataCollector_T.h
+++ b/dds/DCPS/DataCollector_T.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,13 +6,10 @@
 #ifndef OPENDDS_DCPS_DATACOLLECTOR_T_H
 #define OPENDDS_DCPS_DATACOLLECTOR_T_H
 
-// Needed here to avoid the pragma below when necessary.
-#include /**/ "ace/pre.h"
-#include /**/ "ace/config-all.h"
-
-#if !defined (ACE_LACKS_PRAGMA_ONCE)
-#pragma once
-#endif /* ACE_LACKS_PRAGMA_ONCE */
+#include <ace/config-macros.h>
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
 
 #include "PoolAllocator.h"
 #include "SafetyProfileStreams.h"
@@ -125,7 +120,5 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 #if defined (ACE_TEMPLATES_REQUIRE_PRAGMA)
 #pragma implementation ("DataCollector_T.cpp")
 #endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
-
-#include /**/ "ace/post.h"
 
 #endif /* DATA_COLLECTOR_H */

--- a/dds/DCPS/GroupRakeData.h
+++ b/dds/DCPS/GroupRakeData.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,19 +6,18 @@
 #ifndef OPENDDS_DCPS_GROUPRAKEDATA_H
 #define OPENDDS_DCPS_GROUPRAKEDATA_H
 
-#include /**/ "ace/pre.h"
-#include "dcps_export.h"
+#include <ace/config-macros.h>
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
 
-#if !defined (ACE_LACKS_PRAGMA_ONCE)
-# pragma once
-#endif /* ACE_LACKS_PRAGMA_ONCE */
-
-#include "dds/DdsDcpsSubscriptionC.h"
-#include "dds/DdsDcpsInfrastructureC.h"
 #include "RakeData.h"
 #include "Comparator_T.h"
-
 #include "PoolAllocator.h"
+#include "dcps_export.h"
+
+#include <dds/DdsDcpsSubscriptionC.h>
+#include <dds/DdsDcpsInfrastructureC.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/RakeData.h
+++ b/dds/DCPS/RakeData.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,14 +6,13 @@
 #ifndef OPENDDS_DCPS_RAKEDATA_H
 #define OPENDDS_DCPS_RAKEDATA_H
 
-#include /**/ "ace/pre.h"
-#include "dcps_export.h"
 #include "ReceivedDataElementList.h"
 #include "SubscriptionInstance.h"
+#include "dcps_export.h"
 
-#if !defined (ACE_LACKS_PRAGMA_ONCE)
-# pragma once
-#endif /* ACE_LACKS_PRAGMA_ONCE */
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/dds/DCPS/RakeResults_T.h
+++ b/dds/DCPS/RakeResults_T.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,17 +6,17 @@
 #ifndef OPENDDS_DCPS_RAKERESULTS_T_H
 #define OPENDDS_DCPS_RAKERESULTS_T_H
 
-#include /**/ "ace/pre.h"
+#include <ace/config-macros.h>
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
 
-#if !defined (ACE_LACKS_PRAGMA_ONCE)
-# pragma once
-#endif /* ACE_LACKS_PRAGMA_ONCE */
-
-#include "dds/DdsDcpsSubscriptionC.h"
 #include "Comparator_T.h"
 #include "PoolAllocator.h"
 #include "RakeData.h"
 #include "TypeSupportImpl.h"
+
+#include <dds/DdsDcpsSubscriptionC.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -125,7 +123,5 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 #if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #include "RakeResults_T.cpp"
 #endif /* ACE_TEMPLATES_REQUIRE_SOURCE */
-
-#include /**/ "ace/post.h"
 
 #endif /* RAKERESULTS_H  */

--- a/dds/DCPS/ZeroCopyAllocator_T.h
+++ b/dds/DCPS/ZeroCopyAllocator_T.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,15 +6,14 @@
 #ifndef OPENDDS_DCPS_ZEROCOPYALLOCATOR_T_H
 #define OPENDDS_DCPS_ZEROCOPYALLOCATOR_T_H
 
-#include /**/ "ace/pre.h"
-#include "ace/Malloc_Base.h"          /* Need ACE_Allocator */
-// not needed export for templates #include "dcps_export.h"
+#include <ace/config-macros.h>
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
 
-#if !defined (ACE_LACKS_PRAGMA_ONCE)
-# pragma once
-#endif /* ACE_LACKS_PRAGMA_ONCE */
+#include <dds/Versioned_Namespace.h>
 
-#include "dds/Versioned_Namespace.h"
+#include <ace/Malloc_Base.h> /* Need ACE_Allocator */
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -82,7 +79,5 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 #if defined (ACE_TEMPLATES_REQUIRE_PRAGMA)
 #pragma implementation ("ZeroCopyAllocator_T.cpp")
 #endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
-
-#include /**/ "ace/post.h"
 
 #endif /* ZEROCOPYALLOCATOR_H  */

--- a/dds/DCPS/ZeroCopySeq_T.h
+++ b/dds/DCPS/ZeroCopySeq_T.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,14 +6,14 @@
 #ifndef OPENDDS_DCPS_ZEROCOPYSEQ_T_H
 #define OPENDDS_DCPS_ZEROCOPYSEQ_T_H
 
-#if !defined (ACE_LACKS_PRAGMA_ONCE)
-# pragma once
-#endif /* ACE_LACKS_PRAGMA_ONCE */
-
-#include /**/ "ace/pre.h"
+#include <ace/config-macros.h>
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
 
 #include "ZeroCopySeqBase.h"
 #include "ZeroCopyAllocator_T.h"
+
 #include <ace/Vector_T.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -232,7 +230,5 @@ TAO_END_VERSIONED_NAMESPACE_DECL
 #pragma message ("ZeroCopySeq_T.cpp template inst")
 #pragma implementation ("ZeroCopySeq_T.cpp")
 #endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
-
-#include /**/ "ace/post.h"
 
 #endif /* ZEROCOPYSEQ_H  */

--- a/dds/DCPS/transport/framework/DataLinkCleanupTask.h
+++ b/dds/DCPS/transport/framework/DataLinkCleanupTask.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,15 +6,13 @@
 #ifndef OPENDDS_DCPS_TRANSPORT_FRAMEWORK_DATALINKCLEANUPTASK_H
 #define OPENDDS_DCPS_TRANSPORT_FRAMEWORK_DATALINKCLEANUPTASK_H
 
-#include /**/ "ace/pre.h"
-
 #include "QueueTaskBase_T.h"
 #include "DataLink.h"
 #include "DataLink_rch.h"
 
-#if !defined (ACE_LACKS_PRAGMA_ONCE)
-# pragma once
-#endif /* ACE_LACKS_PRAGMA_ONCE */
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -45,7 +41,5 @@ public:
 } // namespace OpenDDS
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
-
-#include /**/ "ace/post.h"
 
 #endif /* OPENDDS_DCPS_DATALINKCLEANUP_H */

--- a/dds/DCPS/transport/tcp/Tcp.h
+++ b/dds/DCPS/transport/tcp/Tcp.h
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
@@ -8,16 +6,16 @@
 #ifndef OPENDDS_DCPS_TRANSPORT_TCP_TCP_H
 #define OPENDDS_DCPS_TRANSPORT_TCP_TCP_H
 
-#include /**/ "ace/pre.h"
-
 #include "Tcp_export.h"
-#include "ace/Service_Object.h"
-#include "ace/Service_Config.h"
-#include "dds/Versioned_Namespace.h"
 
-#if !defined (ACE_LACKS_PRAGMA_ONCE)
-# pragma once
-#endif /* ACE_LACKS_PRAGMA_ONCE */
+#include <dds/Versioned_Namespace.h>
+
+#include <ace/Service_Object.h>
+#include <ace/Service_Config.h>
+
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -36,7 +34,5 @@ static Tcp_Initializer tcp_initializer;
 }
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
-
-#include /**/ "ace/post.h"
 
 #endif /* OPENDDS_TCP_H */

--- a/dds/DCPS/transport/tcp/TcpLoader.h
+++ b/dds/DCPS/transport/tcp/TcpLoader.h
@@ -1,24 +1,21 @@
 /*
- *
- *
  * Distributed under the OpenDDS License.
  * See: http://www.opendds.org/license.html
  */
 
 #ifndef OPENDDS_DCPS_TRANSPORT_TCP_TCPLOADER_H
 #define OPENDDS_DCPS_TRANSPORT_TCP_TCPLOADER_H
-#include /**/ "ace/pre.h"
 
 #include "Tcp_export.h"
 
-#include "ace/Service_Object.h"
-#include "ace/Service_Config.h"
+#include <dds/Versioned_Namespace.h>
 
-#if !defined (ACE_LACKS_PRAGMA_ONCE)
-# pragma once
-#endif /* ACE_LACKS_PRAGMA_ONCE */
+#include <ace/Service_Object.h>
+#include <ace/Service_Config.h>
 
-#include "dds/Versioned_Namespace.h"
+#ifndef ACE_LACKS_PRAGMA_ONCE
+#  pragma once
+#endif
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -44,5 +41,4 @@ ACE_FACTORY_DECLARE(OpenDDS_Tcp, TcpLoader)
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#include /**/ "ace/post.h"
 #endif /* TCP_LOADER_H */

--- a/performance-tests/DCPS/Priority/Options.h
+++ b/performance-tests/DCPS/Priority/Options.h
@@ -4,7 +4,6 @@
 #define OPTIONS_H
 
 // Needed here to avoid the pragma below when necessary.
-#include /**/ "ace/pre.h"
 #include /**/ "ace/config-all.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)

--- a/tests/DCPS/Priority/Options.h
+++ b/tests/DCPS/Priority/Options.h
@@ -4,7 +4,6 @@
 #define OPTIONS_H
 
 // Needed here to avoid the pragma below when necessary.
-#include /**/ "ace/pre.h"
 #include /**/ "ace/config-all.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)

--- a/tools/modeling/codegen/model/Config.h
+++ b/tools/modeling/codegen/model/Config.h
@@ -169,6 +169,7 @@ class OpenDDS_Model_Export Config  {
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
+#include /**/ "ace/post.h"
 
 #if defined (__ACE_INLINE__)
 # include "Config.inl"

--- a/tools/modeling/codegen/model/Entities.h
+++ b/tools/modeling/codegen/model/Entities.h
@@ -171,6 +171,8 @@ class OpenDDS_Model_Export Entities  {
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
+#include /**/ "ace/post.h"
+
 #if defined (__ACE_INLINE__)
 # include "Entities.inl"
 #endif  /* __ACE_INLINE__ */

--- a/tools/modeling/codegen/model/TransportDirectives.h
+++ b/tools/modeling/codegen/model/TransportDirectives.h
@@ -42,5 +42,7 @@ namespace OpenDDS { namespace Model { namespace Transport {
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
+#include /**/ "ace/post.h"
+
 #endif
 

--- a/tools/monitor/Options.h
+++ b/tools/monitor/Options.h
@@ -11,7 +11,6 @@
 #define OPTIONS_H
 
 // Needed here to avoid the pragma below when necessary.
-#include /**/ "ace/pre.h"
 #include /**/ "ace/config-all.h"
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)

--- a/tools/scripts/lint.pl
+++ b/tools/scripts/lint.pl
@@ -218,17 +218,23 @@ print("OpenDDS is $root\n") if ($debug);
 
 $ace = 0 if ($no_ace_arg && !$ace_arg);
 my $ace_root = $ENV{'ACE_ROOT'};
-if ($ace and not $listing_checks and !defined $ace_root) {
-  my @possible_ace_roots = (
-    catfile($root, 'ACE_TAO', 'ACE'),
-    catfile($root, 'ACE_wrappers'),
-  );
+if ($ace and not $listing_checks) {
+  my @possible_ace_roots;
+  if ($ace_root) {
+    push(@possible_ace_roots, $ace_root);
+  }
+  else {
+    @possible_ace_roots = (
+      catfile($root, 'ACE_TAO', 'ACE'),
+      catfile($root, 'ACE_wrappers'),
+    );
+  }
   foreach my $possible_ace_root (@possible_ace_roots) {
     if (-d $possible_ace_root) {
       $ace_root = $possible_ace_root;
     }
   }
-  if ($ace and !defined $ace_root) {
+  if ($ace and !$ace_root) {
     my $common = "ACE_ROOT wasn't defined and we couldn't find ACE on our own.";
     if ($ace_arg) {
       die("${\error()} $common This is a fatal error since --ace was passed.");
@@ -237,7 +243,8 @@ if ($ace and not $listing_checks and !defined $ace_root) {
       "Pass --no-ace to silence this warning.");
     $ace = 0;
   }
-} else {
+}
+else {
   $ace = 0;
 }
 if ($ace) {
@@ -696,7 +703,8 @@ my %all_checks = (
       if ($fix) {
         if ($fixed) {
           write_for_fix($filename, $full_filename, 'missing_include_guard', \@lines);
-        } else {
+        }
+        else {
           print_warning("Tried to fix include guard for $filename, but it " .
             "doesn't have an existing include guard to modify");
         }
@@ -937,7 +945,8 @@ sub process_path_condition {
 
   if ($invert) {
     return !$val;
-  } else {
+  }
+  else {
     return $val;
   }
 }
@@ -1177,7 +1186,8 @@ sub process_path {
       $line_numbers{$check} = [];
       if ($all_checks{$check}->{file_matches}->($filename, $full_filename, \$line_numbers{$check})) {
         $failed = 1;
-      } else {
+      }
+      else {
         delete $line_numbers{$check};
       }
       $checked = 1;
@@ -1234,7 +1244,8 @@ sub process_path {
             my @line_numbers = @{$line_numbers{$check}};
             push(@line_numbers, $.);
             $line_numbers{$check} = \@line_numbers;
-          } else {
+          }
+          else {
             $line_numbers{$check} = [$.];
           }
           if (length $marked_line) {
@@ -1338,7 +1349,8 @@ sub process_path {
               print STDERR (", $last");
             }
             print STDERR ("\n");
-          } else {
+          }
+          else {
             print STDERR ("    - (Applies to the whole file)\n") if $debug;
           }
         }
@@ -1366,6 +1378,7 @@ if ($ace) {
     my $tests = join(',', qw/
       check_for_inline_in_cpp
       check_for_push_and_pop
+      check_for_pre_and_post
       check_for_ORB_init
       check_for_refcountservantbase
       /);


### PR DESCRIPTION
Some headers used `pre.h` without `post.h` which [leaks `pragma pack (push, 8)`]( https://github.com/DOCGroup/ACE_TAO/blob/ab3b192fcda5715a0c92e5627acdeb4e8f71911c/ACE/ace/pre.h#L17) into the code using those headers. Even if this was fixed, it's not clear what is gained by using these headers, except maybe [improved ABI compatibility](
https://github.com/DOCGroup/ACE_TAO/blob/ab3b192fcda5715a0c92e5627acdeb4e8f71911c/ACE/ChangeLogs/ChangeLog-2000a#L9726-L9762), in case the alignment changed somehow. OpenDDS doesn't guarantee ABI compatibility at all though, so this seems like this doesn't do anything for us. Instead of using these headers inconsistently, remove them everywhere except for the libraries that consistently use them, the modeling and the QoS XML libraries.

Also made some tweaks to the lint script:
- Enable the `check_for_pre_and_post` ACE check for the remaining cases of `pre.h` and `post.h`.
- Improve logic for finding ACE using `$ACE_ROOT` by treating it as a candidate instead of automatically accepting it.
- Fix else brackets.