### PR TITLE
`Service_Participant` does not use `ConfigStore`

### DIFF
--- a/dds/DCPS/DataDurabilityCache.cpp
+++ b/dds/DCPS/DataDurabilityCache.cpp
@@ -35,7 +35,7 @@
 namespace {
 
 void cleanup_directory(const OPENDDS_VECTOR(OPENDDS_STRING) & path,
-                       const ACE_CString & data_dir)
+                       const OpenDDS::DCPS::String& data_dir)
 {
   if (path.empty()) return;
 
@@ -73,7 +73,7 @@ public:
                   list_difference_type index,
                   ACE_Allocator * allocator,
                   const OPENDDS_VECTOR(OPENDDS_STRING) & path,
-                  const ACE_CString & data_dir)
+                  const OpenDDS::DCPS::String& data_dir)
   : sample_list_(sample_list)
   , index_(index)
   , allocator_(allocator)
@@ -162,7 +162,7 @@ private:
 
   OPENDDS_VECTOR(OPENDDS_STRING) path_;
 
-  ACE_CString data_dir_;
+  OpenDDS::DCPS::String data_dir_;
 };
 
 } // namespace
@@ -296,9 +296,8 @@ OpenDDS::DCPS::DataDurabilityCache::DataDurabilityCache(
   init();
 }
 
-OpenDDS::DCPS::DataDurabilityCache::DataDurabilityCache(
-  DDS::DurabilityQosPolicyKind kind,
-  ACE_CString & data_dir)
+OpenDDS::DCPS::DataDurabilityCache::DataDurabilityCache(DDS::DurabilityQosPolicyKind kind,
+                                                        const String& data_dir)
   : allocator_(new ACE_New_Allocator)
   , kind_(kind)
   , data_dir_(data_dir)

--- a/dds/DCPS/DataDurabilityCache.h
+++ b/dds/DCPS/DataDurabilityCache.h
@@ -190,7 +190,7 @@ public:
   DataDurabilityCache(DDS::DurabilityQosPolicyKind kind);
 
   DataDurabilityCache(DDS::DurabilityQosPolicyKind kind,
-                      ACE_CString & data_dir);
+                      const String& data_dir);
 
   ~DataDurabilityCache();
 
@@ -228,7 +228,7 @@ private:
 
   DDS::DurabilityQosPolicyKind kind_;
 
-  ACE_CString data_dir_;
+  String data_dir_;
 
   /// Map of all data samples.
   sample_map_type * samples_;

--- a/dds/DCPS/DomainParticipantFactoryImpl.cpp
+++ b/dds/DCPS/DomainParticipantFactoryImpl.cpp
@@ -88,11 +88,11 @@ DomainParticipantFactoryImpl::create_participant(
 
   // if the specified transport is a transport template then create a new transport
   // instance for the new participant if per_participant is set (checked before creating instance).
-  ACE_TString transport_base_config_name;
+  String transport_base_config_name;
   TheServiceParticipant->get_transport_base_config_name(domainId, transport_base_config_name);
 
   if (TheTransportRegistry->config_has_transport_template(transport_base_config_name)) {
-    OPENDDS_STRING transport_config_name = ACE_TEXT_ALWAYS_CHAR(transport_base_config_name.c_str());
+    OPENDDS_STRING transport_config_name = transport_base_config_name;
     OPENDDS_STRING transport_instance_name = dp->get_unique_id();
 
     // unique config and instance names are returned in transport_config_name and transport_instance_name

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -27,21 +27,22 @@
 #  include "security/framework/SecurityRegistry.h"
 #endif
 
-#include <ace/config.h>
-#include <ace/Singleton.h>
 #include <ace/Arg_Shifter.h>
-#include <ace/Reactor.h>
-#include <ace/Select_Reactor.h>
-#include <ace/Configuration_Import_Export.h>
-#include <ace/Service_Config.h>
 #include <ace/Argv_Type_Converter.h>
 #include <ace/Auto_Ptr.h>
-#include <ace/Sched_Params.h>
-#include <ace/Malloc_Allocator.h>
-#include <ace/OS_NS_unistd.h>
-#include <ace/Version.h>
 #include <ace/Configuration.h>
+#include <ace/Configuration_Import_Export.h>
+#include <ace/Malloc_Allocator.h>
+#include <ace/OS_NS_ctype.h>
 #include <ace/OS_NS_sys_utsname.h>
+#include <ace/OS_NS_unistd.h>
+#include <ace/Reactor.h>
+#include <ace/Sched_Params.h>
+#include <ace/Select_Reactor.h>
+#include <ace/Service_Config.h>
+#include <ace/Singleton.h>
+#include <ace/Version.h>
+#include <ace/config.h>
 
 #include <cstring>
 #ifdef OPENDDS_SAFETY_PROFILE
@@ -107,71 +108,159 @@ namespace DCPS {
 
 int Service_Participant::zero_argc = 0;
 
-const size_t DEFAULT_NUM_CHUNKS = 20;
-
-const size_t DEFAULT_CHUNK_MULTIPLIER = 10;
-
-const int DEFAULT_FEDERATION_RECOVERY_DURATION       = 900; // 15 minutes in seconds.
-const int DEFAULT_FEDERATION_INITIAL_BACKOFF_SECONDS = 1;   // Wait only 1 second.
-const int DEFAULT_FEDERATION_BACKOFF_MULTIPLIER      = 2;   // Exponential backoff.
-const int DEFAULT_FEDERATION_LIVELINESS              = 60;  // 1 minute hearbeat.
-
-const int BIT_LOOKUP_DURATION_MSEC = 2000;
-
-static ACE_TString config_fname(ACE_TEXT(""));
-
 static const ACE_TCHAR DEFAULT_REPO_IOR[] = ACE_TEXT("file://repo.ior");
 
-#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
-static const char DEFAULT_PERSISTENT_DATA_DIR[] = "OpenDDS-durable-data-dir";
-#endif
-
-static const ACE_TCHAR COMMON_SECTION_NAME[] = ACE_TEXT("common");
 static const ACE_TCHAR DOMAIN_SECTION_NAME[] = ACE_TEXT("domain");
 static const ACE_TCHAR DOMAIN_RANGE_SECTION_NAME[] = ACE_TEXT("DomainRange");
 static const ACE_TCHAR REPO_SECTION_NAME[]   = ACE_TEXT("repository");
 static const ACE_TCHAR RTPS_SECTION_NAME[]   = ACE_TEXT("rtps_discovery");
 
-static bool got_debug_level = false;
-static bool got_use_rti_serialization = false;
-static bool got_info = false;
-static bool got_chunks = false;
-static bool got_chunk_association_multiplier = false;
-static bool got_liveliness_factor = false;
-static bool got_bit_transport_port = false;
-static bool got_bit_transport_ip = false;
-static bool got_bit_lookup_duration_msec = false;
-static bool got_global_transport_config = false;
-static bool got_bit_flag = false;
+namespace {
 
-#if defined(OPENDDS_SECURITY)
-static bool got_security_flag = false;
-static bool got_security_debug = false;
-static bool got_security_fake_encryption = false;
-#endif
+OPENDDS_VECTOR(String) split(const String& str, const char delim)
+{
+  OPENDDS_VECTOR(String) retval;
 
-static bool got_publisher_content_filter = false;
-static bool got_transport_debug_level = false;
-static bool got_pending_timeout = false;
-#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
-static bool got_persistent_data_dir = false;
-#endif
-static bool got_default_discovery = false;
-#ifndef DDS_DEFAULT_DISCOVERY_METHOD
-# ifdef OPENDDS_SAFETY_PROFILE
-#  define DDS_DEFAULT_DISCOVERY_METHOD Discovery::DEFAULT_RTPS
-# else
-#  define DDS_DEFAULT_DISCOVERY_METHOD Discovery::DEFAULT_REPO
-# endif
-#endif
-static bool got_log_fname = false;
-static bool got_log_verbose = false;
-static bool got_default_address = false;
-static bool got_bidir_giop = false;
-static bool got_thread_status_interval = false;
-static bool got_monitor = false;
-static bool got_type_object_encoding = false;
-static bool got_log_level = false;
+  std::string::size_type pos = 0;
+  while (pos < str.size()) {
+    const std::string::size_type limit = str.find_first_of(delim, pos);
+    if (limit == std::string::npos) {
+      retval.push_back(str.substr(pos));
+      break;
+    } else {
+      retval.push_back(str.substr(pos, limit - pos));
+      pos = limit + 1;
+    }
+  }
+
+  return retval;
+}
+
+String toupper(const String& x)
+{
+  String retval;
+  for (String::const_iterator pos = x.begin(), limit = x.end(); pos != limit; ++pos) {
+    retval.push_back(ACE_OS::ace_toupper(*pos));
+  }
+  return retval;
+}
+
+char
+canonicalize(char x)
+{
+  if (ACE_OS::ace_isalnum(x)) {
+    return ACE_OS::ace_toupper(x);
+  }
+
+  return '_';
+}
+
+String
+canonicalize(const String& key)
+{
+  OPENDDS_ASSERT(!key.empty());
+
+  String retval;
+  retval += canonicalize(key[0]);
+
+  // Insert underscores before camelcase.
+  for (size_t idx = 1; idx + 1 < key.length(); ++idx) {
+    const ACE_TCHAR x = key[idx];
+    const ACE_TCHAR y = key[idx + 1];
+    if (ACE_OS::ace_isupper(x) && ACE_OS::ace_islower(y)) {
+      retval += '_';
+    }
+
+    retval += canonicalize(x);
+  }
+
+  if (key.length() > 1) {
+    retval += canonicalize(key[key.length() - 1]);
+  }
+
+  return retval;
+}
+
+void
+process_section(ConfigStoreImpl& config_store,
+                ConfigReader_rch reader,
+                ConfigReaderListener_rch listener,
+                const String& key_prefix,
+                ACE_Configuration_Heap& config,
+                const ACE_Configuration_Section_Key& base,
+                const String& filename,
+                bool allow_overwrite)
+{
+  // Process the values.
+  int status = 0;
+  for (int idx = 0; status == 0; ++idx) {
+    ACE_TString key;
+    ACE_Configuration_Heap::VALUETYPE value_type;
+    status = config.enumerate_values(base, idx, key, value_type);
+    if (status == 0) {
+      switch (value_type) {
+      case ACE_Configuration_Heap::STRING:
+        {
+          ACE_TString value;
+          if (config.get_string_value(base, key.c_str(), value) == 0) {
+            const String key_name = key_prefix + "_" + canonicalize(ACE_TEXT_ALWAYS_CHAR(key.c_str()));
+            String value_str = ACE_TEXT_ALWAYS_CHAR(value.c_str());
+            value_str = value_str == "$file" ? filename : value_str;
+            if (allow_overwrite || !config_store.has(key_name.c_str())) {
+              config_store.set(key_name.c_str(), value_str);
+              listener->on_data_available(reader);
+            } else if (log_level >= LogLevel::Notice) {
+              ACE_DEBUG((LM_NOTICE,
+                         "(%P|%t) NOTICE: process_section: "
+                         "value from commandline or user for %s overrides value in config file\n",
+                         key.c_str()));
+            }
+          } else {
+            if (log_level >= LogLevel::Error) {
+              ACE_ERROR((LM_ERROR,
+                         "(%P|%t) ERROR: process_section: "
+                         "get_string_value() failed for key \"%s\"\n",
+                         key.c_str()));
+            }
+          }
+        }
+        break;
+      case ACE_Configuration_Heap::INTEGER:
+      case ACE_Configuration_Heap::BINARY:
+      case ACE_Configuration_Heap::INVALID:
+        if (log_level >= LogLevel::Error) {
+          ACE_ERROR((LM_ERROR,
+                     "(%P|%t) ERROR: process_section: "
+                     "unsupported value type for key \"%s\"\n",
+                     key.c_str()));
+        }
+        break;
+      }
+    }
+  }
+
+  // Recur on the subsections.
+  status = 0;
+  for (int idx = 0; status == 0; ++idx) {
+    ACE_TString section_name;
+    status = config.enumerate_sections(base, idx, section_name);
+    if (status == 0) {
+      ACE_Configuration_Section_Key key;
+      if (config.open_section(base, section_name.c_str(), 0, key) == 0) {
+        process_section(config_store, reader, listener, key_prefix + "_" + canonicalize(ACE_TEXT_ALWAYS_CHAR(section_name.c_str())), config, key, filename, allow_overwrite);
+      } else {
+        if (log_level >= LogLevel::Error) {
+          ACE_ERROR((LM_ERROR,
+                     "(%P|%t) ERROR: process_section: "
+                     "open_section() failed for name \"%s\"\n",
+                     section_name.c_str()));
+        }
+      }
+    }
+  }
+}
+
+}
 
 Service_Participant::Service_Participant()
   :
@@ -180,47 +269,16 @@ Service_Participant::Service_Participant()
 #endif
   time_source_()
   , reactor_task_(false)
-  , defaultDiscovery_(DDS_DEFAULT_DISCOVERY_METHOD)
-  , n_chunks_(DEFAULT_NUM_CHUNKS)
-  , association_chunk_multiplier_(DEFAULT_CHUNK_MULTIPLIER)
-  , liveliness_factor_(80)
-  , bit_transport_port_(0)
-  , bit_enabled_(
-#ifdef DDS_HAS_MINIMUM_BIT
-      false
-#else
-      true
-#endif
-    )
-#ifdef OPENDDS_SECURITY
-  , security_enabled_(false)
-#endif
-  , bit_lookup_duration_msec_(BIT_LOOKUP_DURATION_MSEC)
-  , global_transport_config_(ACE_TEXT(""))
   , monitor_factory_(0)
-  , federation_recovery_duration_(DEFAULT_FEDERATION_RECOVERY_DURATION)
-  , federation_initial_backoff_seconds_(DEFAULT_FEDERATION_INITIAL_BACKOFF_SECONDS)
-  , federation_backoff_multiplier_(DEFAULT_FEDERATION_BACKOFF_MULTIPLIER)
-  , federation_liveliness_(DEFAULT_FEDERATION_LIVELINESS)
-#if OPENDDS_POOL_ALLOCATOR
-  , pool_size_(1024 * 1024 * 16)
-  , pool_granularity_(8)
-#endif
-  , scheduler_(-1)
   , priority_min_(0)
   , priority_max_(0)
-  , publisher_content_filter_(true)
-#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
-  , persistent_data_dir_(DEFAULT_PERSISTENT_DATA_DIR)
-#endif
-  , bidir_giop_(true)
-  , monitor_enabled_(false)
   , shut_down_(false)
-  , default_configuration_file_(ACE_TEXT(""))
-  , type_object_encoding_(Encoding_Normal)
   , network_interface_address_topic_(make_rch<InternalTopic<NetworkInterfaceAddress> >())
-  , printer_value_writer_indent_(4)
+  , config_reader_(make_rch<InternalDataReader<ConfigPair> >(DataReaderQosBuilder().reliability_reliable().durability_transient_local()))
+  , config_reader_listener_(make_rch<ConfigReaderListener>(ref(*this)))
+  , set_repo_ior_result_(false)
 {
+  config_store_.connect(config_reader_);
   initialize();
 }
 
@@ -260,6 +318,8 @@ Service_Participant::~Service_Participant()
         retcode_to_string(shutdown_status)));
     }
   }
+
+  config_store_.disconnect(config_reader_);
 }
 
 Service_Participant*
@@ -458,11 +518,16 @@ Service_Participant::get_domain_participant_factory(int &argc,
         return DDS::DomainParticipantFactory::_nil();
       }
 
-      if (config_fname.is_empty() && !default_configuration_file_.is_empty()) {
-        config_fname = default_configuration_file_;
+      String config_fname = config_store_.get(OPENDDS_COMMON_DCPS_CONFIG_FILE,
+                                              OPENDDS_COMMON_DCPS_CONFIG_FILE_default);
+      const String default_configuration_file = config_store_.get(OPENDDS_DEFAULT_CONFIGURATION_FILE,
+                                                                  OPENDDS_DEFAULT_CONFIGURATION_FILE_default);
+
+      if (config_fname.empty() && !default_configuration_file.empty()) {
+        config_fname = default_configuration_file;
       }
 
-      if (config_fname.is_empty()) {
+      if (config_fname.empty()) {
         if (DCPS_debug_level) {
           ACE_DEBUG((LM_NOTICE,
                      ACE_TEXT("(%P|%t) NOTICE: not using file configuration - no configuration ")
@@ -491,7 +556,7 @@ Service_Participant::get_domain_participant_factory(int &argc,
                         config_fname.c_str()));
           }
 
-          if (this->load_configuration() != 0) {
+          if (this->load_configuration(config_fname) != 0) {
             ACE_ERROR((LM_ERROR,
                        ACE_TEXT("(%P|%t) ERROR: Service_Participant::get_domain_participant_factory: ")
                        ACE_TEXT("load_configuration() failed.\n")));
@@ -499,6 +564,9 @@ Service_Participant::get_domain_participant_factory(int &argc,
           }
         }
       }
+
+      config_reader_listener_->on_data_available(config_reader_);
+
 #if OPENDDS_POOL_ALLOCATOR
       // For non-FACE tests, configure pool
       configure_pool();
@@ -542,7 +610,10 @@ Service_Participant::get_domain_participant_factory(int &argc,
 
       job_queue_ = make_rch<JobQueue>(reactor_task_.get_reactor());
 
-      if (this->monitor_enabled_) {
+      const bool monitor_enabled = config_store_.get_boolean(OPENDDS_COMMON_DCPS_MONITOR,
+                                                             OPENDDS_COMMON_DCPS_MONITOR_default);
+
+      if (monitor_enabled) {
 #if !defined(ACE_AS_STATIC_LIBS)
         ACE_TString directive = ACE_TEXT("dynamic OpenDDS_Monitor Service_Object * OpenDDS_monitor:_make_MonitorFactoryImpl()");
         ACE_Service_Config::process_directive(directive.c_str());
@@ -551,11 +622,9 @@ Service_Participant::get_domain_participant_factory(int &argc,
           ACE_Dynamic_Service<MonitorFactory>::instance ("OpenDDS_Monitor");
 
         if (this->monitor_factory_ == 0) {
-          if (this->monitor_enabled_) {
-            ACE_ERROR((LM_ERROR,
-                       ACE_TEXT("ERROR: Service_Participant::get_domain_participant_factory, ")
-                       ACE_TEXT("Unable to enable monitor factory.\n")));
-          }
+          ACE_ERROR((LM_ERROR,
+                     ACE_TEXT("ERROR: Service_Participant::get_domain_participant_factory, ")
+                     ACE_TEXT("Unable to enable monitor factory.\n")));
         }
       }
 
@@ -565,7 +634,7 @@ Service_Participant::get_domain_participant_factory(int &argc,
         this->monitor_factory_ =
           ACE_Dynamic_Service<MonitorFactory>::instance ("OpenDDS_Monitor_Default");
       }
-      if (this->monitor_enabled_) {
+      if (monitor_enabled) {
         this->monitor_factory_->initialize();
       }
 
@@ -633,14 +702,14 @@ int Service_Participant::parse_args(int& argc, ACE_TCHAR* argv[])
     const ACE_TCHAR* currentArg = 0;
 
     if ((currentArg = log_arg_shifter.get_the_parameter(ACE_TEXT("-ORBLogFile"))) != 0) {
-      set_log_file_name(ACE_TEXT_ALWAYS_CHAR(currentArg));
+      config_store_.set_string(OPENDDS_COMMON_ORB_LOG_FILE, ACE_TEXT_ALWAYS_CHAR(currentArg));
+      config_reader_listener_->on_data_available(config_reader_);
       log_arg_shifter.consume_arg();
-      got_log_fname = true;
 
     } else if ((currentArg = log_arg_shifter.get_the_parameter(ACE_TEXT("-ORBVerboseLogging"))) != 0) {
-      set_log_verbose(ACE_OS::atoi(currentArg));
+      config_store_.set_string(OPENDDS_COMMON_ORB_VERBOSE_LOGGING, ACE_TEXT_ALWAYS_CHAR(currentArg));
+      config_reader_listener_->on_data_available(config_reader_);
       log_arg_shifter.consume_arg();
-      got_log_verbose = true;
 
     } else {
       log_arg_shifter.ignore_arg();
@@ -649,182 +718,39 @@ int Service_Participant::parse_args(int& argc, ACE_TCHAR* argv[])
 
   ACE_Arg_Shifter arg_shifter(argc, argv);
   while (arg_shifter.is_anything_left()) {
-    const ACE_TCHAR* currentArg = 0;
 
-    if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSDebugLevel"))) != 0) {
-      set_DCPS_debug_level(ACE_OS::atoi(currentArg));
+    const String current = ACE_TEXT_ALWAYS_CHAR(arg_shifter.get_current());
+    if (toupper(current.substr(0, 5)) == "-DCPS" || toupper(current.substr(0, 11)) == "-FEDERATION") {
       arg_shifter.consume_arg();
-      got_debug_level = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSInfoRepo"))) != 0) {
-      this->set_repo_ior(currentArg, Discovery::DEFAULT_REPO);
-      arg_shifter.consume_arg();
-      got_info = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSRTISerialization"))) != 0) {
-      if (ACE_OS::atoi(currentArg) == 0) {
-        ACE_ERROR((LM_WARNING,
-          ACE_TEXT("(%P|%t) WARNING: Service_Participant::parse_args ")
-          ACE_TEXT("Argument ignored: DCPSRTISerialization is required to be enabled\n")));
+      if (!arg_shifter.is_anything_left()) {
+        break;
       }
-      arg_shifter.consume_arg();
-      got_use_rti_serialization = true;
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSChunks"))) != 0) {
-      n_chunks_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-      got_chunks = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSChunkAssociationMultiplier"))) != 0) {
-      association_chunk_multiplier_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-      got_chunk_association_multiplier = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSConfigFile"))) != 0) {
-      config_fname = currentArg;
-      arg_shifter.consume_arg();
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSLivelinessFactor"))) != 0) {
-      liveliness_factor_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-      got_liveliness_factor = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSBitTransportPort"))) != 0) {
-      /// No need to guard this insertion as we are still single
-      /// threaded here.
-      this->bit_transport_port_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-      got_bit_transport_port = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSBitTransportIPAddress"))) != 0) {
-      /// No need to guard this insertion as we are still single
-      /// threaded here.
-      this->bit_transport_ip_ = currentArg;
-      arg_shifter.consume_arg();
-      got_bit_transport_ip = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSBitLookupDurationMsec"))) != 0) {
-      bit_lookup_duration_msec_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-      got_bit_lookup_duration_msec = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSGlobalTransportConfig"))) != 0) {
-      global_transport_config_ = currentArg;
-      arg_shifter.consume_arg();
-      got_global_transport_config = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSBit"))) != 0) {
-      bit_enabled_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-      got_bit_flag = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSTransportDebugLevel"))) != 0) {
-      OpenDDS::DCPS::Transport_debug_level = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-      got_transport_debug_level = true;
-
-#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSPersistentDataDir"))) != 0) {
-      this->persistent_data_dir_ = ACE_TEXT_ALWAYS_CHAR(currentArg);
-      arg_shifter.consume_arg();
-      got_persistent_data_dir = true;
-#endif
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSPendingTimeout"))) != 0) {
-      pending_timeout_ = TimeDuration(ACE_OS::atoi(currentArg));
-      arg_shifter.consume_arg();
-      got_pending_timeout = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSPublisherContentFilter"))) != 0) {
-      this->publisher_content_filter_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-      got_publisher_content_filter = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSDefaultDiscovery"))) != 0) {
-      this->defaultDiscovery_ = ACE_TEXT_ALWAYS_CHAR(currentArg);
-      arg_shifter.consume_arg();
-      got_default_discovery = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSBidirGIOP"))) != 0) {
-      bidir_giop_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-      got_bidir_giop = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSThreadStatusInterval"))) != 0) {
-      thread_status_manager_.thread_status_interval(TimeDuration(ACE_OS::atoi(currentArg)));
-      arg_shifter.consume_arg();
-      got_thread_status_interval = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-FederationRecoveryDuration"))) != 0) {
-      this->federation_recovery_duration_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-FederationInitialBackoffSeconds"))) != 0) {
-      this->federation_initial_backoff_seconds_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-FederationBackoffMultiplier"))) != 0) {
-      this->federation_backoff_multiplier_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-FederationLivelinessDuration"))) != 0) {
-      this->federation_liveliness_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSDefaultAddress"))) != 0) {
-      ACE_INET_Addr addr;
-      if (addr.set(u_short(0), currentArg)) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("(%P|%t) ERROR: Service_Participant::parse_args: ")
-                          ACE_TEXT("failed to parse default address %C\n"),
-                          currentArg),
-                         -1);
+      const String key = "OPENDDS_COMMON" + canonicalize(current);
+      if (arg_shifter.is_parameter_next()) {
+        config_store_.set_string(key.c_str(), ACE_TEXT_ALWAYS_CHAR(arg_shifter.get_current()));
+        config_reader_listener_->on_data_available(config_reader_);
+        arg_shifter.consume_arg();
+      } else {
+        arg_shifter.ignore_arg();
       }
-      default_address_ = NetworkAddress(addr);
+    } else if (current.substr(0, 8) == "-OpenDDS") {
       arg_shifter.consume_arg();
-      got_default_address = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSMonitor"))) != 0) {
-      this->monitor_enabled_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-      got_monitor = true;
-
-#if defined(OPENDDS_SECURITY)
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSSecurityDebugLevel"))) != 0) {
-      security_debug.set_debug_level(ACE_OS::atoi(currentArg));
-      arg_shifter.consume_arg();
-      got_security_debug = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSSecurityDebug"))) != 0) {
-      security_debug.parse_flags(currentArg);
-      arg_shifter.consume_arg();
-      got_security_debug = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSSecurityFakeEncryption"))) != 0) {
-      security_debug.fake_encryption = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-      got_security_fake_encryption = true;
-
-    // Must be last "-DCPSSecurity*" option, see comment above this arg parsing loop
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSSecurity"))) != 0) {
-      security_enabled_ = ACE_OS::atoi(currentArg);
-      arg_shifter.consume_arg();
-      got_security_flag = true;
-
-#endif
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSTypeObjectEncoding"))) != 0) {
-      type_object_encoding(ACE_TEXT_ALWAYS_CHAR(currentArg));
-      arg_shifter.consume_arg();
-      got_type_object_encoding = true;
-
-    } else if ((currentArg = arg_shifter.get_the_parameter(ACE_TEXT("-DCPSLogLevel"))) != 0) {
-      log_level.set_from_string(ACE_TEXT_ALWAYS_CHAR(currentArg));
-      arg_shifter.consume_arg();
-      got_log_level = true;
-
+      if (!arg_shifter.is_anything_left()) {
+        break;
+      }
+      const String key = "OPENDDS_" + canonicalize(current.substr(8));
+      if (arg_shifter.is_parameter_next()) {
+        config_store_.set_string(key.c_str(), ACE_TEXT_ALWAYS_CHAR(arg_shifter.get_current()));
+        config_reader_listener_->on_data_available(config_reader_);
+        arg_shifter.consume_arg();
+      } else {
+        arg_shifter.ignore_arg();
+      }
     } else {
       arg_shifter.ignore_arg();
     }
   }
+
   // Indicates successful parsing of the command line
   return 0;
 }
@@ -892,11 +818,6 @@ Service_Participant::initialize()
   initial_SubscriberQos_.partition = initial_PartitionQosPolicy_;
   initial_SubscriberQos_.group_data = initial_GroupDataQosPolicy_;
   initial_SubscriberQos_.entity_factory = initial_EntityFactoryQosPolicy_;
-
-  bit_autopurge_nowriter_samples_delay_.sec = DDS::DURATION_INFINITE_SEC;
-  bit_autopurge_nowriter_samples_delay_.nanosec = DDS::DURATION_INFINITE_NSEC;
-  bit_autopurge_disposed_samples_delay_.sec = DDS::DURATION_INFINITE_SEC;
-  bit_autopurge_disposed_samples_delay_.nanosec = DDS::DURATION_INFINITE_NSEC;
 }
 
 void
@@ -905,7 +826,17 @@ Service_Participant::initializeScheduling()
   //
   // Establish the scheduler if specified.
   //
-  if (this->schedulerString_.length() == 0) {
+  const String scheduler_str = config_store_.get(OPENDDS_COMMON_SCHEDULER,
+                                                 OPENDDS_COMMON_SCHEDULER_default);
+
+  suseconds_t usec = config_store_.get_int32(OPENDDS_COMMON_SCHEDULER_SLICE,
+                                             OPENDDS_COMMON_SCHEDULER_SLICE_default);
+  if (usec < 0) {
+    usec = 0;
+  }
+  const TimeDuration scheduler_quantum(0, usec);
+
+  if (scheduler_str.length() == 0) {
     if (DCPS_debug_level > 0) {
       ACE_DEBUG((LM_NOTICE,
                  ACE_TEXT("(%P|%t) NOTICE: Service_Participant::intializeScheduling() - ")
@@ -917,25 +848,21 @@ Service_Participant::initializeScheduling()
     // Translate the scheduling policy to a usable value.
     //
     int ace_scheduler = ACE_SCHED_OTHER;
-    this->scheduler_  = THR_SCHED_DEFAULT;
 
-    if (this->schedulerString_ == ACE_TEXT("SCHED_RR")) {
-      this->scheduler_ = THR_SCHED_RR;
+    if (scheduler_str == "SCHED_RR") {
       ace_scheduler    = ACE_SCHED_RR;
 
-    } else if (this->schedulerString_ == ACE_TEXT("SCHED_FIFO")) {
-      this->scheduler_ = THR_SCHED_FIFO;
+    } else if (scheduler_str == "SCHED_FIFO") {
       ace_scheduler    = ACE_SCHED_FIFO;
 
-    } else if (this->schedulerString_ == ACE_TEXT("SCHED_OTHER")) {
-      this->scheduler_ = THR_SCHED_DEFAULT;
+    } else if (scheduler_str == "SCHED_OTHER") {
       ace_scheduler    = ACE_SCHED_OTHER;
 
     } else {
       ACE_DEBUG((LM_WARNING,
                  ACE_TEXT("(%P|%t) WARNING: Service_Participant::initializeScheduling() - ")
-                 ACE_TEXT("unrecognized scheduling policy: %s, set to SCHED_OTHER.\n"),
-                 this->schedulerString_.c_str()));
+                 ACE_TEXT("unrecognized scheduling policy: %C, set to SCHED_OTHER.\n"),
+                 scheduler_str.c_str()));
     }
 
     //
@@ -951,7 +878,7 @@ Service_Participant::initializeScheduling()
       ace_scheduler,
       ACE_Sched_Params::priority_min(ace_scheduler),
       ACE_SCOPE_THREAD,
-      schedulerQuantum_.value());
+      scheduler_quantum.value());
 
     if (ACE_OS::sched_params(params) != 0) {
       if (ACE_OS::last_error() == EPERM) {
@@ -966,14 +893,14 @@ Service_Participant::initializeScheduling()
       }
 
       // Reset the scheduler value(s) if we did not succeed.
-      this->scheduler_ = -1;
+      this->scheduler(-1);
       ace_scheduler    = ACE_SCHED_OTHER;
 
     } else if (DCPS_debug_level > 0) {
       ACE_DEBUG((LM_DEBUG,
                  ACE_TEXT("(%P|%t) Service_Participant::initializeScheduling() - ")
-                 ACE_TEXT("scheduling policy set to %s(%d).\n"),
-                 this->schedulerString_.c_str()));
+                 ACE_TEXT("scheduling policy set to %C.\n"),
+                 scheduler_str.c_str()));
     }
 
     //
@@ -998,51 +925,65 @@ Service_Participant::set_repo_ior(const wchar_t* ior,
 bool
 Service_Participant::set_repo_ior(const char* ior,
                                   Discovery::RepoKey key,
-                                  bool attach_participant)
+                                  bool attach_participant,
+                                  bool write_config)
 {
-  if (DCPS_debug_level > 0) {
-    ACE_DEBUG((LM_DEBUG,
-               ACE_TEXT("(%P|%t) Service_Participant::set_repo_ior: Repo[%C] == %C\n"),
-               key.c_str(), ior));
+  if (write_config) {
+    String value = ior;
+    value += String("^") + key;
+    value += String("^") + (attach_participant ? "true" : "false");
+    config_store_.set_string(OPENDDS_COMMON_DCPS_INFO_REPO, value.c_str());
+    config_reader_listener_->on_data_available(config_reader_);
+    return set_repo_ior_result_;
+  } else {
+    if (DCPS_debug_level > 0) {
+      ACE_DEBUG((LM_DEBUG,
+                 ACE_TEXT("(%P|%t) Service_Participant::set_repo_ior: Repo[%C] == %C\n"),
+                 key.c_str(), ior));
+    }
+
+    if (key == "-1") {
+      key = Discovery::DEFAULT_REPO;
+    }
+
+    const OPENDDS_STRING repo_type = ACE_TEXT_ALWAYS_CHAR(REPO_SECTION_NAME);
+    if (!discovery_types_.count(repo_type)) {
+      // Re-use a transport registry function to attempt a dynamic load of the
+      // library that implements the 'repo_type' (InfoRepoDiscovery)
+      TheTransportRegistry->load_transport_lib(repo_type);
+    }
+
+    if (discovery_types_.count(repo_type)) {
+      ACE_Configuration_Heap cf;
+      cf.open();
+      ACE_Configuration_Section_Key sect_key;
+      ACE_TString section = REPO_SECTION_NAME;
+      section += ACE_TEXT('\\');
+      section += ACE_TEXT_CHAR_TO_TCHAR(key.c_str());
+      cf.open_section(cf.root_section(), section.c_str(), true /*create*/, sect_key);
+      cf.set_string_value(sect_key, ACE_TEXT("RepositoryIor"),
+                          ACE_TEXT_CHAR_TO_TCHAR(ior));
+
+      discovery_types_[repo_type]->discovery_config(cf);
+
+      this->remap_domains(key, key, attach_participant);
+      set_repo_ior_result_ = true;
+      return true;
+    }
+
+    set_repo_ior_result_ = false;
+    ACE_ERROR_RETURN((LM_ERROR,
+                      ACE_TEXT("(%P|%t) Service_Participant::set_repo_ior ")
+                      ACE_TEXT("ERROR - no discovery type registered for ")
+                      ACE_TEXT("InfoRepoDiscovery\n")),
+                     false);
   }
+}
 
-  // This is a global used for the bizarre commandline/configfile
-  // processing done for this class.
-  got_info = true;
-
-  if (key == "-1") {
-    key = Discovery::DEFAULT_REPO;
-  }
-
-  const OPENDDS_STRING repo_type = ACE_TEXT_ALWAYS_CHAR(REPO_SECTION_NAME);
-  if (!discovery_types_.count(repo_type)) {
-    // Re-use a transport registry function to attempt a dynamic load of the
-    // library that implements the 'repo_type' (InfoRepoDiscovery)
-    TheTransportRegistry->load_transport_lib(repo_type);
-  }
-
-  if (discovery_types_.count(repo_type)) {
-    ACE_Configuration_Heap cf;
-    cf.open();
-    ACE_Configuration_Section_Key sect_key;
-    ACE_TString section = REPO_SECTION_NAME;
-    section += ACE_TEXT('\\');
-    section += ACE_TEXT_CHAR_TO_TCHAR(key.c_str());
-    cf.open_section(cf.root_section(), section.c_str(), true /*create*/, sect_key);
-    cf.set_string_value(sect_key, ACE_TEXT("RepositoryIor"),
-                        ACE_TEXT_CHAR_TO_TCHAR(ior));
-
-    discovery_types_[repo_type]->discovery_config(cf);
-
-    this->remap_domains(key, key, attach_participant);
-    return true;
-  }
-
-  ACE_ERROR_RETURN((LM_ERROR,
-                    ACE_TEXT("(%P|%t) Service_Participant::set_repo_ior ")
-                    ACE_TEXT("ERROR - no discovery type registered for ")
-                    ACE_TEXT("InfoRepoDiscovery\n")),
-                   false);
+bool
+Service_Participant::use_bidir_giop() const
+{
+  return config_store_.get_boolean(OPENDDS_COMMON_DCPS_BIDIR_GIOP, OPENDDS_COMMON_DCPS_BIDIR_GIOP_default);
 }
 
 void
@@ -1270,13 +1211,13 @@ Service_Participant::repository_lost(Discovery::RepoKey key)
 void
 Service_Participant::set_default_discovery(const Discovery::RepoKey& key)
 {
-  this->defaultDiscovery_ = key;
+  config_store_.set_string(OPENDDS_COMMON_DCPS_DEFAULT_DISCOVERY, key.c_str());
 }
 
 Discovery::RepoKey
 Service_Participant::get_default_discovery()
 {
-  return this->defaultDiscovery_;
+  return config_store_.get(OPENDDS_COMMON_DCPS_DEFAULT_DISCOVERY, OPENDDS_COMMON_DCPS_DEFAULT_DISCOVERY_default);
 }
 
 Discovery_rch
@@ -1286,7 +1227,7 @@ Service_Participant::get_discovery(const DDS::DomainId_t domain)
 
   // Default to the Default InfoRepo-based discovery unless the user has
   // changed defaultDiscovery_ using the API or config file
-  Discovery::RepoKey repo = defaultDiscovery_;
+  Discovery::RepoKey repo = get_default_discovery();
   bool in_range = false;
   const Discovery::RepoKey instance_name = get_discovery_template_instance_name(domain);
   DomainRange dr_inst;
@@ -1426,76 +1367,228 @@ Service_Participant::get_discovery(const DDS::DomainId_t domain)
   return location->second;
 }
 
+void
+Service_Participant::federation_recovery_duration(int duration)
+{
+  config_store_.set_int32(OPENDDS_COMMON_FEDERATION_RECOVERY_DURATION, duration);
+}
+
+int
+Service_Participant::federation_recovery_duration() const
+{
+  return config_store_.get_int32(OPENDDS_COMMON_FEDERATION_RECOVERY_DURATION,
+                                 OPENDDS_COMMON_FEDERATION_RECOVERY_DURATION_default);
+}
+
+void
+Service_Participant::federation_initial_backoff_seconds(int value)
+{
+  config_store_.set_int32(OPENDDS_COMMON_FEDERATION_INITIAL_BACKOFF_SECONDS, value);
+}
+
+int
+Service_Participant::federation_initial_backoff_seconds() const
+{
+  return config_store_.get_int32(OPENDDS_COMMON_FEDERATION_INITIAL_BACKOFF_SECONDS,
+                                 OPENDDS_COMMON_FEDERATION_INITIAL_BACKOFF_SECONDS_default);
+}
+
+void
+Service_Participant::federation_backoff_multiplier(int value)
+{
+  config_store_.set_int32(OPENDDS_COMMON_FEDERATION_BACKOFF_MULTIPLIER, value);
+}
+
+int
+Service_Participant::federation_backoff_multiplier() const
+{
+  return config_store_.get_int32(OPENDDS_COMMON_FEDERATION_BACKOFF_MULTIPLIER,
+                                 OPENDDS_COMMON_FEDERATION_BACKOFF_MULTIPLIER_default);
+}
+
+void
+Service_Participant::federation_liveliness(int value)
+{
+  config_store_.set_int32(OPENDDS_COMMON_FEDERATION_LIVELINESS_DURATION, value);
+}
+
+int
+Service_Participant::federation_liveliness() const
+{
+  return config_store_.get_int32(OPENDDS_COMMON_FEDERATION_LIVELINESS_DURATION, OPENDDS_COMMON_FEDERATION_LIVELINESS_DURATION_default);
+}
+
+void
+Service_Participant::scheduler(long value)
+{
+  // Using a switch results in a compilation error since THR_SCHED_DEFAULT could be THR_SCHED_RR or THR_SCHED_FIFO.
+  if (value == THR_SCHED_DEFAULT) {
+    config_store_.set(OPENDDS_COMMON_SCHEDULER, "SCHED_OTHER");
+  } else if (value == THR_SCHED_RR) {
+    config_store_.set(OPENDDS_COMMON_SCHEDULER, "SCHED_RR");
+  } else if (value == THR_SCHED_FIFO) {
+    config_store_.set(OPENDDS_COMMON_SCHEDULER, "SCHED_FIFO");
+  } else {
+    if (log_level >= LogLevel::Warning) {
+      ACE_ERROR((LM_WARNING,
+                 "(%P|%t) WARNING: Service_Participant::scheduler: cannot translate scheduler value %d\n",
+                 value));
+    }
+    config_store_.set(OPENDDS_COMMON_SCHEDULER, "");
+  }
+}
+
+long
+Service_Participant::scheduler() const
+{
+  const String str = config_store_.get(OPENDDS_COMMON_SCHEDULER, "");
+  if (str == "SCHED_RR") {
+    return THR_SCHED_RR;
+  } else if (str == "SCHED_FIFO") {
+    return THR_SCHED_FIFO;
+  } else if (str == "SCHED_OTHER") {
+    return THR_SCHED_DEFAULT;
+  }
+
+  return -1;
+}
+
+void
+Service_Participant::publisher_content_filter(bool flag)
+{
+  config_store_.set_boolean(OPENDDS_COMMON_DCPS_PUBLISHER_CONTENT_FILTER, flag);
+}
+
+bool
+Service_Participant::publisher_content_filter() const
+{
+  return config_store_.get_boolean(OPENDDS_COMMON_DCPS_PUBLISHER_CONTENT_FILTER,
+                                   OPENDDS_COMMON_DCPS_PUBLISHER_CONTENT_FILTER_default);
+}
+
+TimeDuration
+Service_Participant::pending_timeout() const
+{
+  return config_store_.get(OPENDDS_COMMON_DCPS_PENDING_TIMEOUT,
+                           OPENDDS_COMMON_DCPS_PENDING_TIMEOUT_default,
+                           ConfigStoreImpl::Format_IntegerSeconds);
+}
+
+void Service_Participant::pending_timeout(const TimeDuration& value)
+{
+  config_store_.set(OPENDDS_COMMON_DCPS_PENDING_TIMEOUT, value, ConfigStoreImpl::Format_IntegerSeconds);
+}
+
+MonotonicTimePoint
+Service_Participant::new_pending_timeout_deadline() const
+{
+  const TimeDuration pt = pending_timeout();
+  return pt.is_zero() ?
+    MonotonicTimePoint() : MonotonicTimePoint::now() + pt;
+}
+
+
 OPENDDS_STRING
 Service_Participant::bit_transport_ip() const
 {
-  return ACE_TEXT_ALWAYS_CHAR(this->bit_transport_ip_.c_str());
+  return config_store_.get(OPENDDS_COMMON_DCPS_BIT_TRANSPORT_IP_ADDRESS,
+                           OPENDDS_COMMON_DCPS_BIT_TRANSPORT_IP_ADDRESS_default);
 }
 
 int
 Service_Participant::bit_transport_port() const
 {
-  return this->bit_transport_port_;
+  return config_store_.get_int32(OPENDDS_COMMON_DCPS_BIT_TRANSPORT_PORT,
+                                 OPENDDS_COMMON_DCPS_BIT_TRANSPORT_PORT_default);
 }
 
 void
 Service_Participant::bit_transport_port(int port)
 {
-  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->maps_lock_);
-  this->bit_transport_port_ = port;
-  got_bit_transport_port = true;
+  config_store_.set_int32(OPENDDS_COMMON_DCPS_BIT_TRANSPORT_PORT, port);
 }
 
 int
 Service_Participant::bit_lookup_duration_msec() const
 {
-  return bit_lookup_duration_msec_;
+  return config_store_.get_int32(OPENDDS_COMMON_DCPS_BIT_LOOKUP_DURATION_MSEC, OPENDDS_COMMON_DCPS_BIT_LOOKUP_DURATION_MSEC_default);
 }
 
 void
-Service_Participant::bit_lookup_duration_msec(int sec)
+Service_Participant::bit_lookup_duration_msec(int msec)
 {
-  bit_lookup_duration_msec_ = sec;
-  got_bit_lookup_duration_msec = true;
+  config_store_.set_int32(OPENDDS_COMMON_DCPS_BIT_LOOKUP_DURATION_MSEC, msec);
+}
+
+#ifdef OPENDDS_SECURITY
+bool
+Service_Participant::get_security() const
+{
+  return config_store_.get_boolean(OPENDDS_COMMON_DCPS_SECURITY, OPENDDS_COMMON_DCPS_SECURITY_default);
+}
+
+void
+Service_Participant::set_security(bool b)
+{
+  config_store_.set_boolean(OPENDDS_COMMON_DCPS_SECURITY, b);
+}
+#endif
+
+bool
+Service_Participant::get_BIT() const
+{
+  return config_store_.get_boolean(OPENDDS_COMMON_DCPS_BIT, OPENDDS_COMMON_DCPS_BIT_default);
+}
+
+void
+Service_Participant::set_BIT(bool b)
+{
+  config_store_.set_boolean(OPENDDS_COMMON_DCPS_BIT, b);
+}
+
+NetworkAddress
+Service_Participant::default_address() const
+{
+  return config_store_.get(OPENDDS_COMMON_DCPS_DEFAULT_ADDRESS, OPENDDS_COMMON_DCPS_DEFAULT_ADDRESS_default);
 }
 
 size_t
 Service_Participant::n_chunks() const
 {
-  return n_chunks_;
+  return config_store_.get_uint32(OPENDDS_COMMON_DCPS_CHUNKS, OPENDDS_COMMON_DCPS_CHUNKS_default);
 }
 
 void
 Service_Participant::n_chunks(size_t chunks)
 {
-  n_chunks_ = chunks;
-  got_chunks = true;
+  config_store_.set_uint32(OPENDDS_COMMON_DCPS_CHUNKS, static_cast<DDS::UInt32>(chunks));
 }
 
 size_t
 Service_Participant::association_chunk_multiplier() const
 {
-  return association_chunk_multiplier_;
+  return config_store_.get_uint32(OPENDDS_COMMON_DCPS_CHUNK_ASSOCIATION_MULTIPLIER,
+                                  config_store_.get_uint32(OPENDDS_COMMON_DCPS_CHUNK_ASSOCIATION_MUTLTIPLIER,
+                                                           OPENDDS_COMMON_DCPS_CHUNK_ASSOCIATION_MULTIPLIER_default));
 }
 
 void
 Service_Participant::association_chunk_multiplier(size_t multiplier)
 {
-  association_chunk_multiplier_ = multiplier;
-  got_chunk_association_multiplier = true;
+  config_store_.set_uint32(OPENDDS_COMMON_DCPS_CHUNK_ASSOCIATION_MULTIPLIER, static_cast<DDS::UInt32>(multiplier));
 }
 
 void
 Service_Participant::liveliness_factor(int factor)
 {
-  liveliness_factor_ = factor;
-  got_liveliness_factor = true;
+  config_store_.set_int32(OPENDDS_COMMON_DCPS_LIVELINESS_FACTOR, factor);
 }
 
 int
 Service_Participant::liveliness_factor() const
 {
-  return liveliness_factor_;
+  return config_store_.get_int32(OPENDDS_COMMON_DCPS_LIVELINESS_FACTOR,
+                                 OPENDDS_COMMON_DCPS_LIVELINESS_FACTOR_default);
 }
 
 void
@@ -1506,7 +1599,7 @@ Service_Participant::register_discovery_type(const char* section_name,
 }
 
 int
-Service_Participant::load_configuration()
+Service_Participant::load_configuration(const String& config_fname)
 {
   ACE_Configuration_Heap cf;
   int status = 0;
@@ -1519,7 +1612,7 @@ Service_Participant::load_configuration()
                      -1);
 
   ACE_Ini_ImpExp import(cf);
-  status = import.import_config(config_fname.c_str());
+  status = import.import_config(ACE_TEXT_CHAR_TO_TCHAR(config_fname.c_str()));
 
   if (status != 0) {
     ACE_ERROR_RETURN((LM_ERROR,
@@ -1528,7 +1621,7 @@ Service_Participant::load_configuration()
                       status),
                      -1);
   } else {
-    status = this->load_configuration(cf, config_fname.c_str());
+    status = this->load_configuration(cf, ACE_TEXT_CHAR_TO_TCHAR(config_fname.c_str()));
   }
 
   return status;
@@ -1539,27 +1632,19 @@ Service_Participant::load_configuration(
   ACE_Configuration_Heap& config,
   const ACE_TCHAR* filename)
 {
+  process_section(config_store_, config_reader_, config_reader_listener_, "OPENDDS", config, config.root_section(), ACE_TEXT_ALWAYS_CHAR(filename), false);
+
   // Domain config is loaded after Discovery (see below). Since the domain
   // could be a domain_range that specifies the DiscoveryTemplate, check
   // for config templates before loading any config information.
   ACE_TString section_name;
-
-  int status = this->load_common_configuration(config, filename);
-
-  if (status != 0) {
-    ACE_ERROR_RETURN((LM_ERROR,
-                      ACE_TEXT("(%P|%t) ERROR: Service_Participant::load_configuration ")
-                      ACE_TEXT("load_common_configuration () returned %d\n"),
-                      status),
-                     -1);
-  }
 
   // Register static discovery.
   this->add_discovery(static_rchandle_cast<Discovery>(StaticDiscovery::instance()));
 
   // load any discovery configuration templates before rtps discovery
   // this will populate the domain_range_templates_
-  status = this->load_domain_ranges(config);
+  int status = this->load_domain_ranges(config);
 
   // load any rtps_discovery templates
   status = this->load_discovery_templates(config);
@@ -1605,24 +1690,25 @@ Service_Participant::load_configuration(
 
   status = TransportRegistry::instance()->load_transport_configuration(
              ACE_TEXT_ALWAYS_CHAR(filename), config);
-  if (this->global_transport_config_ != ACE_TEXT("")) {
-    TransportConfig_rch config = TransportRegistry::instance()->get_config(
-      ACE_TEXT_ALWAYS_CHAR(this->global_transport_config_.c_str()));
+  const String global_transport_config = config_store_.get(OPENDDS_COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG,
+                                                           OPENDDS_COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG_default);
+  if (!global_transport_config.empty()) {
+    TransportConfig_rch config = TransportRegistry::instance()->get_config(global_transport_config);
     if (config) {
       TransportRegistry::instance()->global_config(config);
-    } else if (TheTransportRegistry->config_has_transport_template(global_transport_config_)) {
+    } else if (TheTransportRegistry->config_has_transport_template(global_transport_config)) {
       if (DCPS_debug_level > 0) {
         // This is not an error.
         ACE_DEBUG((LM_NOTICE,
                    ACE_TEXT("(%P|%t) NOTICE: Service_Participant::load_configuration ")
                    ACE_TEXT("DCPSGlobalTransportConfig %C is a transport_template\n"),
-                   this->global_transport_config_.c_str()));
+                   global_transport_config.c_str()));
       }
     } else {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("(%P|%t) ERROR: Service_Participant::load_configuration ")
                         ACE_TEXT("Unable to locate specified global transport config: %C\n"),
-                        this->global_transport_config_.c_str()),
+                        global_transport_config.c_str()),
                        -1);
     }
   }
@@ -1672,305 +1758,6 @@ Service_Participant::load_configuration(
     ex._tao_print_exception("Exception caught in Service_Participant::load_configuration: "
       "trying to load_discovery_configuration()");
     return -1;
-  }
-
-  return 0;
-}
-
-int
-Service_Participant::load_common_configuration(ACE_Configuration_Heap& cf,
-                                               const ACE_TCHAR* filename)
-{
-  const ACE_Configuration_Section_Key &root = cf.root_section();
-  ACE_Configuration_Section_Key sect;
-
-  if (cf.open_section(root, COMMON_SECTION_NAME, false, sect) != 0) {
-    if (DCPS_debug_level > 0) {
-      // This is not an error if the configuration file does not have
-      // a common section. The code default configuration will be used.
-      ACE_DEBUG((LM_NOTICE,
-                 ACE_TEXT("(%P|%t) NOTICE: Service_Participant::load_common_configuration ")
-                 ACE_TEXT("failed to open section %s\n"),
-                 COMMON_SECTION_NAME));
-    }
-
-    return 0;
-
-  } else {
-    const ACE_TCHAR* message =
-      ACE_TEXT("(%P|%t) NOTICE: using %s value from command option (overrides value if it's in config file)\n");
-
-    if (got_debug_level) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSDebugLevel")));
-    } else {
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSDebugLevel"), DCPS_debug_level, int)
-    }
-
-    if (got_info) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSInfoRepo")));
-    } else {
-      ACE_TString value;
-      GET_CONFIG_TSTRING_VALUE(cf, sect, ACE_TEXT("DCPSInfoRepo"), value)
-      if (!value.empty()) {
-        this->set_repo_ior(value.c_str(), Discovery::DEFAULT_REPO);
-      }
-    }
-
-    if (got_use_rti_serialization) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSRTISerialization")));
-    } else {
-      bool should_use = true;
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSRTISerialization"), should_use, bool)
-      if (!should_use) {
-        ACE_ERROR((LM_WARNING,
-          ACE_TEXT("(%P|%t) WARNING: Service_Participant::load_common_configuration ")
-          ACE_TEXT("Argument ignored: DCPSRTISerialization is required to be enabled\n")));
-      }
-    }
-
-    if (got_chunks) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSChunks")));
-    } else {
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSChunks"), this->n_chunks_, size_t)
-    }
-
-    if (got_chunk_association_multiplier) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSChunkAssociationMultiplier")));
-    } else {
-      // This is legacy support for a misspelling of the config option.
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSChunkAssociationMutltiplier"), this->association_chunk_multiplier_, size_t)
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSChunkAssociationMultiplier"), this->association_chunk_multiplier_, size_t)
-    }
-
-    if (got_bit_transport_port) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSBitTransportPort")));
-    } else {
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSBitTransportPort"), this->bit_transport_port_, int)
-    }
-
-    if (got_bit_transport_ip) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSBitTransportIPAddress")));
-    } else {
-      GET_CONFIG_TSTRING_VALUE(cf, sect, ACE_TEXT("DCPSBitTransportIPAddress"), this->bit_transport_ip_)
-    }
-
-    if (got_liveliness_factor) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSLivelinessFactor")));
-    } else {
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSLivelinessFactor"), this->liveliness_factor_, int)
-    }
-
-    if (got_bit_lookup_duration_msec) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSBitLookupDurationMsec")));
-    } else {
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSBitLookupDurationMsec"), this->bit_lookup_duration_msec_, int)
-    }
-
-    if (got_global_transport_config) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSGlobalTransportConfig")));
-    } else {
-      GET_CONFIG_TSTRING_VALUE(cf, sect, ACE_TEXT("DCPSGlobalTransportConfig"), this->global_transport_config_);
-      if (this->global_transport_config_ == ACE_TEXT("$file")) {
-        // When the special string of "$file" is used, substitute the file name
-        this->global_transport_config_ = filename;
-      }
-    }
-
-    if (got_bit_flag) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSBit")));
-    } else {
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSBit"), this->bit_enabled_, int)
-    }
-
-    GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSLogBits"), log_bits, bool);
-
-#if defined(OPENDDS_SECURITY)
-    if (got_security_flag) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSSecurity")));
-    } else {
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSSecurity"), this->security_enabled_, int)
-    }
-
-    if (got_security_debug) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSSecurityDebug or DCPSSecurityDebugLevel")));
-    } else {
-      const ACE_TCHAR* debug_name = ACE_TEXT("DCPSSecurityDebug");
-      const ACE_TCHAR* debug_level_name = ACE_TEXT("DCPSSecurityDebugLevel");
-      bool got_value = false;
-      ACE_TString debug_level_value;
-      if (cf.get_string_value(sect, debug_level_name, debug_level_value) == -1) {
-        ACE_TString debug_value;
-        if (cf.get_string_value(sect, debug_name, debug_value) != -1) {
-          if (debug_value != ACE_TEXT("")) {
-            got_value = true;
-            security_debug.parse_flags(debug_value.c_str());
-          }
-        }
-      } else if (debug_level_value != ACE_TEXT("")) {
-        got_value = true;
-        security_debug.set_debug_level(ACE_OS::atoi(debug_level_value.c_str()));
-      }
-      if (!got_value && OpenDDS::DCPS::Transport_debug_level > 0) {
-        ACE_DEBUG((LM_NOTICE,
-          ACE_TEXT("(%P|%t) NOTICE: DCPSSecurityDebug and DCPSSecurityDebugLevel ")
-          ACE_TEXT("are not defined in config file or are blank - using code default.\n")));
-      }
-    }
-
-    if (got_security_fake_encryption) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSSecurityFakeEncryption")));
-    } else {
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSSecurityFakeEncryption"), security_debug.fake_encryption, int)
-    }
-#endif
-
-    if (got_transport_debug_level) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSTransportDebugLevel")));
-    } else {
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSTransportDebugLevel"), OpenDDS::DCPS::Transport_debug_level, int)
-    }
-
-#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
-    if (got_persistent_data_dir) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSPersistentDataDir")));
-    } else {
-      ACE_TString value;
-      GET_CONFIG_TSTRING_VALUE(cf, sect, ACE_TEXT("DCPSPersistentDataDir"), value)
-      this->persistent_data_dir_ = ACE_TEXT_ALWAYS_CHAR(value.c_str());
-    }
-#endif
-
-    if (got_pending_timeout) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSPendingTimeout")));
-    } else {
-      int timeout = 0;
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSPendingTimeout"), timeout, int)
-      pending_timeout_ = TimeDuration(timeout);
-    }
-
-    if (got_publisher_content_filter) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSPublisherContentFilter")));
-    } else {
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSPublisherContentFilter"),
-        this->publisher_content_filter_, bool)
-    }
-
-    if (got_default_discovery) {
-      ACE_Configuration::VALUETYPE type;
-      if (cf.find_value(sect, ACE_TEXT("DCPSDefaultDiscovery"), type) != -1) {
-        ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSDefaultDiscovery")));
-      }
-    } else {
-      GET_CONFIG_STRING_VALUE(cf, sect, ACE_TEXT("DCPSDefaultDiscovery"),
-        this->defaultDiscovery_);
-    }
-
-    if (got_bidir_giop) {
-      ACE_Configuration::VALUETYPE type;
-      if (cf.find_value(sect, ACE_TEXT("DCPSBidirGIOP"), type) != -1) {
-        ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSBidirGIOP")));
-      }
-    } else {
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSBidirGIOP"), bidir_giop_, bool)
-    }
-
-    if (got_thread_status_interval) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSThreadStatusInterval")));
-    } else {
-      int interval = 0;
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSThreadStatusInterval"), interval, int);
-      thread_status_manager_.thread_status_interval(TimeDuration(interval));
-    }
-
-    ACE_Configuration::VALUETYPE type;
-    if (got_log_fname) {
-      if (cf.find_value(sect, ACE_TEXT("ORBLogFile"), type) != -1) {
-        ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("ORBLogFile")));
-      }
-    } else {
-      OPENDDS_STRING log_fname;
-      GET_CONFIG_STRING_VALUE(cf, sect, ACE_TEXT("ORBLogFile"), log_fname);
-      if (!log_fname.empty()) {
-        set_log_file_name(log_fname.c_str());
-      }
-    }
-
-    if (got_log_verbose) {
-      if (cf.find_value(sect, ACE_TEXT("ORBVerboseLogging"), type) != -1) {
-        ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("ORBVerboseLogging")));
-      }
-    } else {
-      unsigned long verbose_logging = 0;
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("ORBVerboseLogging"), verbose_logging, unsigned long);
-      set_log_verbose(verbose_logging);
-    }
-
-    if (got_default_address) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSDefaultAddress")));
-    } else {
-      ACE_TString default_address_str;
-      GET_CONFIG_TSTRING_VALUE(cf, sect, ACE_TEXT("DCPSDefaultAddress"), default_address_str);
-      ACE_INET_Addr addr;
-      if (!default_address_str.empty() &&
-          addr.set(u_short(0), default_address_str.c_str())) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("(%P|%t) ERROR: Service_Participant::load_common_configuration: ")
-                          ACE_TEXT("failed to parse default address %C\n"),
-                          default_address_str.c_str()),
-                         -1);
-      }
-      default_address_ = NetworkAddress(addr);
-    }
-
-    if (got_monitor) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSMonitor")));
-    } else {
-      GET_CONFIG_VALUE(cf, sect, ACE_TEXT("DCPSMonitor"), monitor_enabled_, bool)
-    }
-
-    if (got_type_object_encoding) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSTypeObjectEncoding")));
-    } else {
-      String str;
-      GET_CONFIG_STRING_VALUE(cf, sect, ACE_TEXT("DCPSTypeObjectEncoding"), str);
-      if (!str.empty()) {
-        type_object_encoding(str.c_str());
-      }
-    }
-
-    if (got_log_level) {
-      ACE_DEBUG((LM_NOTICE, message, ACE_TEXT("DCPSLogLevel")));
-    } else {
-      String str;
-      GET_CONFIG_STRING_VALUE(cf, sect, ACE_TEXT("DCPSLogLevel"), str);
-      if (!str.empty()) {
-        log_level.set_from_string(str.c_str());
-      }
-    }
-
-    // These are not handled on the command line.
-    GET_CONFIG_VALUE(cf, sect, ACE_TEXT("FederationRecoveryDuration"), this->federation_recovery_duration_, int)
-    GET_CONFIG_VALUE(cf, sect, ACE_TEXT("FederationInitialBackoffSeconds"), this->federation_initial_backoff_seconds_, int)
-    GET_CONFIG_VALUE(cf, sect, ACE_TEXT("FederationBackoffMultiplier"), this->federation_backoff_multiplier_, int)
-    GET_CONFIG_VALUE(cf, sect, ACE_TEXT("FederationLivelinessDuration"), this->federation_liveliness_, int)
-
-#if OPENDDS_POOL_ALLOCATOR
-    GET_CONFIG_VALUE(cf, sect, ACE_TEXT("pool_size"), pool_size_, size_t)
-    GET_CONFIG_VALUE(cf, sect, ACE_TEXT("pool_granularity"), pool_granularity_, size_t)
-#endif
-
-    //
-    // Establish the scheduler if specified.
-    //
-    GET_CONFIG_TSTRING_VALUE(cf, sect, ACE_TEXT("scheduler"), this->schedulerString_)
-
-    suseconds_t usec(0);
-
-    GET_CONFIG_VALUE(cf, sect, ACE_TEXT("scheduler_slice"), usec, suseconds_t)
-
-    if (usec > 0) {
-      schedulerQuantum_ = TimeDuration(0, usec);
-    }
   }
 
   return 0;
@@ -2207,8 +1994,10 @@ Service_Participant::load_domain_ranges(ACE_Configuration_Heap& cf)
           }
         }
       }
-      if (this->global_transport_config_ != ACE_TEXT("")) {
-        range_element.transport_config_name = ACE_TEXT_ALWAYS_CHAR(this->global_transport_config_.c_str());
+      const String global_transport_config = config_store_.get(OPENDDS_COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG,
+                                                               OPENDDS_COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG_default);
+      if (!global_transport_config.empty()) {
+        range_element.transport_config_name = global_transport_config;
       }
       domain_ranges_.push_back(range_element);
     }
@@ -2252,7 +2041,7 @@ int Service_Participant::configure_domain_range_instance(DDS::DomainId_t domainI
         }
       }
 
-      ACE_TString cfg_name;
+      String cfg_name;
       if (get_transport_base_config_name(domainId, cfg_name)) {
         if (TransportRegistry::instance()->config_has_transport_template(cfg_name)) {
           // create transport instance add default transport config
@@ -2345,14 +2134,16 @@ Service_Participant::belongs_to_domain_range(DDS::DomainId_t domainId) const
 }
 
 bool
-Service_Participant::get_transport_base_config_name(DDS::DomainId_t domainId, ACE_TString& name) const
+Service_Participant::get_transport_base_config_name(DDS::DomainId_t domainId, String& name) const
 {
+  const String global_transport_config = config_store_.get(OPENDDS_COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG,
+                                                           OPENDDS_COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG_default);
   OPENDDS_MAP(DDS::DomainId_t, OPENDDS_STRING)::const_iterator it = domain_to_transport_name_map_.find(domainId);
   if ( it != domain_to_transport_name_map_.end()) {
-    name = ACE_TEXT_CHAR_TO_TCHAR(it->second.c_str());
+    name = it->second;
     return true;
-  } else if (global_transport_config_ != ACE_TEXT("")) {
-    name = global_transport_config_;
+  } else if (!global_transport_config.empty()) {
+    name = global_transport_config;
     return true;
   } else {
     return false;
@@ -2716,8 +2507,12 @@ Service_Participant::is_discovery_template(const OPENDDS_STRING& name)
 void
 Service_Participant::configure_pool()
 {
-  if (pool_size_) {
-    SafetyProfilePool::instance()->configure_pool(pool_size_, pool_granularity_);
+  const size_t pool_size = config_store_.get_uint32(OPENDDS_COMMON_POOL_SIZE,
+                                                    OPENDDS_COMMON_POOL_SIZE_default);
+  const size_t pool_granularity = config_store_.get_uint32(OPENDDS_COMMON_POOL_GRANULARITY,
+                                                          OPENDDS_COMMON_POOL_GRANULARITY_default);
+  if (pool_size) {
+    SafetyProfilePool::instance()->configure_pool(pool_size, pool_granularity);
     SafetyProfilePool::instance()->install();
   }
 }
@@ -2750,8 +2545,10 @@ Service_Participant::get_data_durability_cache(
 
       try {
         if (!this->persistent_data_cache_) {
-          this->persistent_data_cache_.reset(new DataDurabilityCache(kind,
-                                                                     this->persistent_data_dir_));
+          const String persistent_data_dir =
+            config_store_.get(OPENDDS_COMMON_DCPS_PERSISTENT_DATA_DIR,
+                              OPENDDS_COMMON_DCPS_PERSISTENT_DATA_DIR_default);
+          this->persistent_data_cache_.reset(new DataDurabilityCache(kind, persistent_data_dir));
         }
 
       } catch (const std::exception& ex) {
@@ -2868,7 +2665,7 @@ DDS::Topic_ptr Service_Participant::create_typeless_topic(
 
 void Service_Participant::default_configuration_file(const ACE_TCHAR* path)
 {
-  default_configuration_file_ = path;
+  config_store_.set_string(OPENDDS_DEFAULT_CONFIGURATION_FILE, ACE_TEXT_ALWAYS_CHAR(path));
 }
 
 ThreadStatusManager& Service_Participant::get_thread_status_manager()
@@ -2891,25 +2688,27 @@ NetworkConfigModifier* Service_Participant::network_config_modifier()
 DDS::Duration_t
 Service_Participant::bit_autopurge_nowriter_samples_delay() const
 {
-  return bit_autopurge_nowriter_samples_delay_;
+  return config_store_.get_duration(OPENDDS_COMMON_BIT_AUTOPURGE_NOWRITER_SAMPLES_DELAY,
+                                    OPENDDS_COMMON_BIT_AUTOPURGE_NOWRITER_SAMPLES_DELAY_default);
 }
 
 void
-Service_Participant::bit_autopurge_nowriter_samples_delay(const DDS::Duration_t& duration)
+Service_Participant::bit_autopurge_nowriter_samples_delay(const DDS::Duration_t& delay)
 {
-  bit_autopurge_nowriter_samples_delay_ = duration;
+  config_store_.set_duration(OPENDDS_COMMON_BIT_AUTOPURGE_NOWRITER_SAMPLES_DELAY, delay);
 }
 
 DDS::Duration_t
 Service_Participant::bit_autopurge_disposed_samples_delay() const
 {
-  return bit_autopurge_disposed_samples_delay_;
+  return config_store_.get_duration(OPENDDS_COMMON_BIT_AUTOPURGE_DISPOSED_SAMPLES_DELAY,
+                                    OPENDDS_COMMON_BIT_AUTOPURGE_DISPOSED_SAMPLES_DELAY_default);
 }
 
 void
-Service_Participant::bit_autopurge_disposed_samples_delay(const DDS::Duration_t& duration)
+Service_Participant::bit_autopurge_disposed_samples_delay(const DDS::Duration_t& delay)
 {
-  bit_autopurge_disposed_samples_delay_ = duration;
+  config_store_.set_duration(OPENDDS_COMMON_BIT_AUTOPURGE_DISPOSED_SAMPLES_DELAY, delay);
 }
 
 XTypes::TypeInformation
@@ -2950,9 +2749,12 @@ Service_Participant::get_type_object(DDS::DomainParticipant_ptr participant,
   return XTypes::TypeObject();
 }
 
-void
-Service_Participant::type_object_encoding(const char* encoding)
+Service_Participant::TypeObjectEncoding
+Service_Participant::type_object_encoding() const
 {
+  String encoding_str = "Normal";
+  config_store_.get(OPENDDS_COMMON_DCPS_TYPE_OBJECT_ENCODING, encoding_str);
+
   struct NameValue {
     const char* name;
     TypeObjectEncoding value;
@@ -2963,13 +2765,96 @@ Service_Participant::type_object_encoding(const char* encoding)
     {"ReadOldFormat", Encoding_ReadOldFormat},
   };
   for (size_t i = 0; i < sizeof entries / sizeof entries[0]; ++i) {
-    if (0 == std::strcmp(entries[i].name, encoding)) {
-      type_object_encoding(entries[i].value);
-      return;
+    if (0 == std::strcmp(entries[i].name, encoding_str.c_str())) {
+      return entries[i].value;
     }
   }
   ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Service_Participant::type_object_encoding: "
-             "invalid encoding %C\n", encoding));
+             "invalid encoding %C\n", encoding_str.c_str()));
+
+  return Encoding_Normal;
+}
+
+void Service_Participant::type_object_encoding(TypeObjectEncoding encoding)
+{
+  switch (encoding) {
+  case Encoding_Normal:
+    config_store_.set_string(OPENDDS_COMMON_DCPS_TYPE_OBJECT_ENCODING, "Normal");
+    break;
+  case Encoding_WriteOldFormat:
+    config_store_.set_string(OPENDDS_COMMON_DCPS_TYPE_OBJECT_ENCODING, "WriteOldFormat");
+    break;
+  case Encoding_ReadOldFormat:
+    config_store_.set_string(OPENDDS_COMMON_DCPS_TYPE_OBJECT_ENCODING, "ReadOldFormat");
+    break;
+  }
+}
+
+void
+Service_Participant::type_object_encoding(const char* encoding)
+{
+  config_store_.set_string(OPENDDS_COMMON_DCPS_TYPE_OBJECT_ENCODING, encoding);
+}
+
+unsigned int
+Service_Participant::printer_value_writer_indent() const
+{
+  return config_store_.get_uint32(OPENDDS_COMMON_PRINTER_VALUE_WRITER_INDENT,
+                                  OPENDDS_COMMON_PRINTER_VALUE_WRITER_INDENT_default);
+}
+
+void
+Service_Participant::printer_value_writer_indent(unsigned int value)
+{
+  config_store_.set_uint32(OPENDDS_COMMON_PRINTER_VALUE_WRITER_INDENT, value);
+}
+
+void
+Service_Participant::ConfigReaderListener::on_data_available(InternalDataReader_rch reader)
+{
+  InternalDataReader<ConfigPair>::SampleSequence samples;
+  InternalSampleInfoSequence infos;
+  reader->read(samples, infos, DDS::LENGTH_UNLIMITED,
+               DDS::NOT_READ_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE);
+  for (size_t idx = 0; idx != samples.size(); ++idx) {
+    const ConfigPair& p = samples[idx];
+    const DDS::SampleInfo& info = infos[idx];
+    if (info.valid_data) {
+      if (p.key() == OPENDDS_COMMON_ORB_LOG_FILE) {
+        set_log_file_name(p.value().c_str());
+      } else if (p.key() == OPENDDS_COMMON_ORB_VERBOSE_LOGGING) {
+        set_log_verbose(ACE_OS::atoi(p.value().c_str()));
+      } else if (p.key() == OPENDDS_COMMON_DCPS_DEBUG_LEVEL) {
+        set_DCPS_debug_level(ACE_OS::atoi(p.value().c_str()));
+      } else if (p.key() == OPENDDS_COMMON_DCPS_INFO_REPO) {
+        const OPENDDS_VECTOR(String) pieces = split(p.value(), '^');
+        const String ior = pieces[0];
+        const String repo = pieces.size() > 1 ? pieces[1] : Discovery::DEFAULT_REPO;
+        const bool attach_participant = pieces.size() > 2 ? (pieces[2] == "true") : true;
+        service_participant_.set_repo_ior(ior.c_str(), repo.c_str(), attach_participant, false);
+      } else if (p.key() == OPENDDS_COMMON_DCPSRTI_SERIALIZATION) {
+        if (ACE_OS::atoi(p.value().c_str()) == 0 && log_level >= LogLevel::Warning) {
+          ACE_ERROR((LM_WARNING,
+                     ACE_TEXT("(%P|%t) WARNING: ConfigReaderListener::on_data_available: ")
+                     ACE_TEXT("Argument ignored: DCPSRTISerialization is required to be enabled\n")));
+        }
+      } else if (p.key() == OPENDDS_COMMON_DCPS_TRANSPORT_DEBUG_LEVEL) {
+        OpenDDS::DCPS::Transport_debug_level = ACE_OS::atoi(p.value().c_str());
+      } else if (p.key() == OPENDDS_COMMON_DCPS_THREAD_STATUS_INTERVAL) {
+        service_participant_.thread_status_manager_.thread_status_interval(TimeDuration(ACE_OS::atoi(p.value().c_str())));
+#ifdef OPENDDS_SECURITY
+      } else if (p.key() == OPENDDS_COMMON_DCPS_SECURITY_DEBUG_LEVEL) {
+        security_debug.set_debug_level(ACE_OS::atoi(p.value().c_str()));
+      } else if (p.key() == OPENDDS_COMMON_DCPS_SECURITY_DEBUG) {
+        security_debug.parse_flags(p.value().c_str());
+      } else if (p.key() == OPENDDS_COMMON_DCPS_SECURITY_FAKE_ENCRYPTION) {
+        security_debug.fake_encryption = ACE_OS::atoi(p.value().c_str());
+#endif
+      } else if (p.key() == OPENDDS_COMMON_DCPS_LOG_LEVEL) {
+        log_level.set_from_string(p.value().c_str());
+      }
+    }
+  }
 }
 
 } // namespace DCPS

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -21,6 +21,7 @@
 #include "Replayer.h"
 #include "TimeSource.h"
 #include "AtomicBool.h"
+#include "ConfigStoreImpl.h"
 
 #include <dds/DdsDcpsInfrastructureC.h>
 #include <dds/DdsDcpsDomainC.h>
@@ -41,6 +42,142 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
 namespace DCPS {
+
+const char OPENDDS_COMMON_BIT_AUTOPURGE_DISPOSED_SAMPLES_DELAY[] =
+  "OPENDDS_COMMON_BIT_AUTOPURGE_DISPOSED_SAMPLES_DELAY";
+const DDS::Duration_t OPENDDS_COMMON_BIT_AUTOPURGE_DISPOSED_SAMPLES_DELAY_default =
+  { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+
+const char OPENDDS_COMMON_BIT_AUTOPURGE_NOWRITER_SAMPLES_DELAY[] =
+  "OPENDDS_COMMON_BIT_AUTOPURGE_NOWRITER_SAMPLES_DELAY";
+const DDS::Duration_t OPENDDS_COMMON_BIT_AUTOPURGE_NOWRITER_SAMPLES_DELAY_default =
+  { DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC };
+
+const char OPENDDS_COMMON_DCPSRTI_SERIALIZATION[] = "OPENDDS_COMMON_DCPSRTI_SERIALIZATION";
+
+const char OPENDDS_COMMON_DCPS_BIDIR_GIOP[] = "OPENDDS_COMMON_DCPS_BIDIR_GIOP";
+const bool OPENDDS_COMMON_DCPS_BIDIR_GIOP_default = true;
+
+const char OPENDDS_COMMON_DCPS_BIT[] = "OPENDDS_COMMON_DCPS_BIT";
+#ifdef DDS_HAS_MINIMUM_BIT
+const bool OPENDDS_COMMON_DCPS_BIT_default = false;
+#else
+const bool OPENDDS_COMMON_DCPS_BIT_default = true;
+#endif
+
+const char OPENDDS_COMMON_DCPS_BIT_LOOKUP_DURATION_MSEC[] = "OPENDDS_COMMON_DCPS_BIT_LOOKUP_DURATION_MSEC";
+const int OPENDDS_COMMON_DCPS_BIT_LOOKUP_DURATION_MSEC_default = 2000;
+
+const char OPENDDS_COMMON_DCPS_BIT_TRANSPORT_IP_ADDRESS[] = "OPENDDS_COMMON_DCPS_BIT_TRANSPORT_IP_ADDRESS";
+const String OPENDDS_COMMON_DCPS_BIT_TRANSPORT_IP_ADDRESS_default = "";
+
+const char OPENDDS_COMMON_DCPS_BIT_TRANSPORT_PORT[] = "OPENDDS_COMMON_DCPS_BIT_TRANSPORT_PORT";
+const int OPENDDS_COMMON_DCPS_BIT_TRANSPORT_PORT_default = 0;
+
+const char OPENDDS_COMMON_DCPS_CHUNKS[] = "OPENDDS_COMMON_DCPS_CHUNKS";
+const size_t OPENDDS_COMMON_DCPS_CHUNKS_default = 20;
+
+const char OPENDDS_COMMON_DCPS_CHUNK_ASSOCIATION_MULTIPLIER[] = "OPENDDS_COMMON_DCPS_CHUNK_ASSOCIATION_MULTIPLIER";
+const char OPENDDS_COMMON_DCPS_CHUNK_ASSOCIATION_MUTLTIPLIER[] = "OPENDDS_COMMON_DCPS_CHUNK_ASSOCIATION_MUTLTIPLIER";
+const size_t OPENDDS_COMMON_DCPS_CHUNK_ASSOCIATION_MULTIPLIER_default = 10;
+
+const char OPENDDS_COMMON_DCPS_CONFIG_FILE[] = "OPENDDS_COMMON_DCPS_CONFIG_FILE";
+const String OPENDDS_COMMON_DCPS_CONFIG_FILE_default = "";
+
+const char OPENDDS_COMMON_DCPS_DEBUG_LEVEL[] = "OPENDDS_COMMON_DCPS_DEBUG_LEVEL";
+
+const char OPENDDS_COMMON_DCPS_DEFAULT_ADDRESS[] = "OPENDDS_COMMON_DCPS_DEFAULT_ADDRESS";
+const NetworkAddress OPENDDS_COMMON_DCPS_DEFAULT_ADDRESS_default = NetworkAddress();
+
+const char OPENDDS_COMMON_DCPS_DEFAULT_DISCOVERY[] = "OPENDDS_COMMON_DCPS_DEFAULT_DISCOVERY";
+#ifdef DDS_DEFAULT_DISCOVERY_METHOD
+const Discovery::RepoKey OPENDDS_COMMON_DCPS_DEFAULT_DISCOVERY_default = DDS_DEFAULT_DISCOVERY_METHOD;
+#else
+# ifdef OPENDDS_SAFETY_PROFILE
+const Discovery::RepoKey OPENDDS_COMMON_DCPS_DEFAULT_DISCOVERY_default = Discovery::DEFAULT_RTPS;
+# else
+const Discovery::RepoKey OPENDDS_COMMON_DCPS_DEFAULT_DISCOVERY_default = Discovery::DEFAULT_REPO;
+# endif
+#endif
+
+const char OPENDDS_COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG[] = "OPENDDS_COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG";
+const String OPENDDS_COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG_default = "";
+
+const char OPENDDS_COMMON_DCPS_INFO_REPO[] = "OPENDDS_COMMON_DCPS_INFO_REPO";
+
+const char OPENDDS_COMMON_DCPS_LIVELINESS_FACTOR[] = "OPENDDS_COMMON_DCPS_LIVELINESS_FACTOR";
+const int OPENDDS_COMMON_DCPS_LIVELINESS_FACTOR_default = 80;
+
+const char OPENDDS_COMMON_DCPS_LOG_LEVEL[] = "OPENDDS_COMMON_DCPS_LOG_LEVEL";
+
+const char OPENDDS_COMMON_DCPS_MONITOR[] = "OPENDDS_COMMON_DCPS_MONITOR";
+const bool OPENDDS_COMMON_DCPS_MONITOR_default = false;
+
+const char OPENDDS_COMMON_DCPS_PENDING_TIMEOUT[] = "OPENDDS_COMMON_DCPS_PENDING_TIMEOUT";
+// Can't use TimeDuration::zero_value since initialization order is undefined.
+const TimeDuration OPENDDS_COMMON_DCPS_PENDING_TIMEOUT_default(0, 0);
+
+#ifndef OPENDDS_NO_PERSISTENCE_PROFILE
+const char OPENDDS_COMMON_DCPS_PERSISTENT_DATA_DIR[] = "OPENDDS_COMMON_DCPS_PERSISTENT_DATA_DIR";
+const String OPENDDS_COMMON_DCPS_PERSISTENT_DATA_DIR_default = "OpenDDS-durable-data-dir";
+#endif
+
+const char OPENDDS_COMMON_DCPS_PUBLISHER_CONTENT_FILTER[] = "OPENDDS_COMMON_DCPS_PUBLISHER_CONTENT_FILTER";
+const bool OPENDDS_COMMON_DCPS_PUBLISHER_CONTENT_FILTER_default = true;
+
+const char OPENDDS_COMMON_DCPS_THREAD_STATUS_INTERVAL[] = "OPENDDS_COMMON_DCPS_THREAD_STATUS_INTERVAL";
+
+const char OPENDDS_COMMON_DCPS_TRANSPORT_DEBUG_LEVEL[] = "OPENDDS_COMMON_DCPS_TRANSPORT_DEBUG_LEVEL";
+
+const char OPENDDS_COMMON_DCPS_TYPE_OBJECT_ENCODING[] = "OPENDDS_COMMON_DCPS_TYPE_OBJECT_ENCODING";
+const String OPENDDS_COMMON_DCPS_TYPE_OBJECT_ENCODING_default = "Normal";
+
+const char OPENDDS_COMMON_FEDERATION_BACKOFF_MULTIPLIER[] = "OPENDDS_COMMON_FEDERATION_BACKOFF_MULTIPLIER";
+const int OPENDDS_COMMON_FEDERATION_BACKOFF_MULTIPLIER_default = 2;
+
+const char OPENDDS_COMMON_FEDERATION_INITIAL_BACKOFF_SECONDS[] = "OPENDDS_COMMON_FEDERATION_INITIAL_BACKOFF_SECONDS";
+const int OPENDDS_COMMON_FEDERATION_INITIAL_BACKOFF_SECONDS_default = 1;
+
+const char OPENDDS_COMMON_FEDERATION_LIVELINESS_DURATION[] = "OPENDDS_COMMON_FEDERATION_LIVELINESS_DURATION";
+const int OPENDDS_COMMON_FEDERATION_LIVELINESS_DURATION_default = 60;
+
+const char OPENDDS_COMMON_FEDERATION_RECOVERY_DURATION[] = "OPENDDS_COMMON_FEDERATION_RECOVERY_DURATION";
+const int OPENDDS_COMMON_FEDERATION_RECOVERY_DURATION_default = 900;
+
+const char OPENDDS_COMMON_ORB_LOG_FILE[] = "OPENDDS_COMMON_ORB_LOG_FILE";
+
+const char OPENDDS_COMMON_ORB_VERBOSE_LOGGING[] = "OPENDDS_COMMON_ORB_VERBOSE_LOGGING";
+
+const char OPENDDS_COMMON_PRINTER_VALUE_WRITER_INDENT[] = "OPENDDS_COMMON_PRINTER_VALUE_WRITER_INDENT";
+const unsigned int OPENDDS_COMMON_PRINTER_VALUE_WRITER_INDENT_default = 4;
+
+const char OPENDDS_COMMON_SCHEDULER[] = "OPENDDS_COMMON_SCHEDULER";
+const String OPENDDS_COMMON_SCHEDULER_default = "";
+
+const char OPENDDS_COMMON_SCHEDULER_SLICE[] = "OPENDDS_COMMON_SCHEDULER_SLICE";
+const int OPENDDS_COMMON_SCHEDULER_SLICE_default = 0;
+
+const char OPENDDS_DEFAULT_CONFIGURATION_FILE[] = "OPENDDS_DEFAULT_CONFIGURATION_FILE";
+const String OPENDDS_DEFAULT_CONFIGURATION_FILE_default = "";
+
+#ifdef OPENDDS_SECURITY
+const char OPENDDS_COMMON_DCPS_SECURITY[] = "OPENDDS_COMMON_DCPS_SECURITY";
+const bool OPENDDS_COMMON_DCPS_SECURITY_default = false;
+
+const char OPENDDS_COMMON_DCPS_SECURITY_DEBUG[] = "OPENDDS_COMMON_DCPS_SECURITY_DEBUG";
+
+const char OPENDDS_COMMON_DCPS_SECURITY_DEBUG_LEVEL[] = "OPENDDS_COMMON_DCPS_SECURITY_DEBUG_LEVEL";
+
+const char OPENDDS_COMMON_DCPS_SECURITY_FAKE_ENCRYPTION[] = "OPENDDS_COMMON_DCPS_SECURITY_FAKE_ENCRYPTION";
+#endif
+
+#if OPENDDS_POOL_ALLOCATOR
+const char OPENDDS_COMMON_POOL_GRANULARITY[] = "OPENDDS_COMMON_POOL_GRANULARITY";
+const size_t OPENDDS_COMMON_POOL_GRANULARITY_default = 8;
+
+const char OPENDDS_COMMON_POOL_SIZE[] = "OPENDDS_COMMON_POOL_SIZE";
+const size_t OPENDDS_COMMON_POOL_SIZE_default = 1024 * 1024 * 16;
+#endif
 
 #ifndef OPENDDS_NO_PERSISTENCE_PROFILE
 class DataDurabilityCache;
@@ -206,7 +343,8 @@ public:
 
   bool set_repo_ior(const char* ior,
                     Discovery::RepoKey key = Discovery::DEFAULT_REPO,
-                    bool attach_participant = true);
+                    bool attach_participant = true,
+                    bool write_config = true);
 
 #ifdef DDS_HAS_WCHAR
   /// Convenience overload for wchar_t
@@ -240,38 +378,38 @@ public:
 
   /// Accessors for FederationRecoveryDuration in seconds.
   //@{
-  int& federation_recovery_duration();
-  int  federation_recovery_duration() const;
+  void federation_recovery_duration(int);
+  int federation_recovery_duration() const;
   //@}
 
   /// Accessors for FederationInitialBackoffSeconds.
   //@{
-  int& federation_initial_backoff_seconds();
-  int  federation_initial_backoff_seconds() const;
+  void federation_initial_backoff_seconds(int);
+  int federation_initial_backoff_seconds() const;
   //@}
 
   /// Accessors for FederationBackoffMultiplier.
   //@{
-  int& federation_backoff_multiplier();
-  int  federation_backoff_multiplier() const;
+  void federation_backoff_multiplier(int);
+  int federation_backoff_multiplier() const;
   //@}
 
   /// Accessors for FederationLivelinessDuration.
   //@{
-  int& federation_liveliness();
-  int  federation_liveliness() const;
+  void federation_liveliness(int);
+  int federation_liveliness() const;
   //@}
 
   /// Accessors for scheduling policy value.
   //@{
-  long& scheduler();
-  long  scheduler() const;
+  void scheduler(long);
+  long scheduler() const;
   //@}
 
   /// Accessors for PublisherContentFilter.
   //@{
-  bool& publisher_content_filter();
-  bool  publisher_content_filter() const;
+  void publisher_content_filter(bool);
+  bool publisher_content_filter() const;
   //@}
 
   /// Accessors for pending data timeout.
@@ -317,24 +455,14 @@ public:
   //@}
 
 #if defined(OPENDDS_SECURITY)
-  bool get_security() {
-    return security_enabled_;
-  }
-
-  void set_security(bool b) {
-    security_enabled_ = b;
-  }
+  bool get_security() const;
+  void set_security(bool b);
 #endif
 
-  bool get_BIT() {
-    return bit_enabled_;
-  }
+  bool get_BIT() const;
+  void set_BIT(bool b);
 
-  void set_BIT(bool b) {
-    bit_enabled_ = b;
-  }
-
-  const NetworkAddress& default_address() const { return default_address_; }
+  NetworkAddress default_address() const;
 
 #ifndef OPENDDS_NO_PERSISTENCE_PROFILE
   /// Get the data durability cache corresponding to the given
@@ -413,7 +541,7 @@ public:
    */
   bool belongs_to_domain_range(DDS::DomainId_t domainId) const;
 
-  bool get_transport_base_config_name(DDS::DomainId_t domainId, ACE_TString& name) const;
+  bool get_transport_base_config_name(DDS::DomainId_t domainId, String& name) const;
 
 #ifdef OPENDDS_SAFETY_PROFILE
   /**
@@ -466,15 +594,8 @@ public:
     return network_interface_address_topic_;
   }
 
-  unsigned int printer_value_writer_indent() const
-  {
-    return printer_value_writer_indent_;
-  }
-
-  void printer_value_writer_indent(unsigned int value)
-  {
-    printer_value_writer_indent_ = value;
-  }
+  unsigned int printer_value_writer_indent() const;
+  void printer_value_writer_indent(unsigned int value);
 
 private:
 
@@ -497,17 +618,7 @@ private:
    * transport section configuration to the TransportRegistry
    * singleton.
    */
-  int load_configuration();
-
-  /**
-   * Load the common configuration to the Service_Participant
-   * singleton.
-   *
-   * @note The values from command line can overwrite the values
-   *       in configuration file.
-   */
-  int load_common_configuration(ACE_Configuration_Heap& cf,
-                                const ACE_TCHAR* filename);
+  int load_configuration(const String& config_fname);
 
   /**
    * Load the domain configuration to the Service_Participant
@@ -565,8 +676,6 @@ private:
   /// The DomainId to RepoKey mapping.
   DomainRepoMap domainRepoMap_;
 
-  Discovery::RepoKey defaultDiscovery_;
-
   /// The lock to serialize DomainParticipantFactory singleton
   /// creation and shutdown.
   mutable ACE_Thread_Mutex factory_lock_;
@@ -605,42 +714,6 @@ private:
   DDS::SubscriberQos                  initial_SubscriberQos_;
   DDS::DomainParticipantFactoryQos    initial_DomainParticipantFactoryQos_;
   DDS::TypeConsistencyEnforcementQosPolicy initial_TypeConsistencyEnforcementQosPolicy_;
-
-  /// The configurable value of the number chunks that the
-  /// @c DataWriter's cached allocator can allocate.
-  size_t                                 n_chunks_;
-
-  /// The configurable value of maximum number of expected
-  /// associations for publishers and subscribers.  This is used
-  /// to pre allocate enough memory and reduce heap allocations.
-  size_t                                 association_chunk_multiplier_;
-
-  /// The propagation delay factor.
-  int                                    liveliness_factor_;
-
-  /// The builtin topic transport address.
-  ACE_TString bit_transport_ip_;
-
-  /// The builtin topic transport port number.
-  int bit_transport_port_;
-
-  bool bit_enabled_;
-
-#if defined(OPENDDS_SECURITY)
-  bool security_enabled_;
-#endif
-
-  /// The timeout for lookup data from the builtin topic
-  /// @c DataReader.
-  int bit_lookup_duration_msec_;
-
-  /// The default network address to use.
-  NetworkAddress default_address_;
-
-  /// Specifies the name of the transport configuration that
-  /// is used when the entity tree does not specify one.  If
-  /// not set, the default transport configuration is used.
-  ACE_TString global_transport_config_;
 
   // domain range template support
   struct DomainRange
@@ -694,43 +767,11 @@ public:
   unique_ptr<Monitor> monitor_;
 
 private:
-  /// The FederationRecoveryDuration value in seconds.
-  int federation_recovery_duration_;
-
-  /// The FederationInitialBackoffSeconds value.
-  int federation_initial_backoff_seconds_;
-
-  /// This FederationBackoffMultiplier.
-  int federation_backoff_multiplier_;
-
-  /// This FederationLivelinessDuration.
-  int federation_liveliness_;
-
-  /// Scheduling policy value from configuration file.
-  ACE_TString schedulerString_;
-
-  /// Scheduler time slice from configuration file.
-  TimeDuration schedulerQuantum_;
-
-#if OPENDDS_POOL_ALLOCATOR
-  /// Pool size from configuration file.
-  size_t pool_size_;
-
-  /// Pool granularity from configuration file.
-  size_t pool_granularity_;
-#endif
-
-  /// Scheduling policy value used for setting thread priorities.
-  long scheduler_;
-
   /// Minimum priority value for the current scheduling policy.
   int priority_min_;
 
   /// Maximum priority value for the current scheduling policy.
   int priority_max_;
-
-  /// Allow the publishing side to do content filtering?
-  bool publisher_content_filter_;
 
 #ifndef OPENDDS_NO_PERSISTENCE_PROFILE
 
@@ -740,25 +781,12 @@ private:
   /// The @c PERSISTENT data durability cache.
   unique_ptr<DataDurabilityCache> persistent_data_cache_;
 
-  /// The @c PERSISTENT data durability directory.
-  ACE_CString persistent_data_dir_;
-
 #endif
-
-  /// Number of seconds to wait on pending samples to be sent
-  /// or dropped.
-  TimeDuration pending_timeout_;
-
-  /// Enable TAO's Bidirectional GIOP?
-  bool bidir_giop_;
 
   ThreadStatusManager thread_status_manager_;
 
   /// Thread mutex used to protect the static initialization of XTypes data structures
   ACE_Thread_Mutex xtypes_lock_;
-
-  /// Enable Monitor functionality
-  bool monitor_enabled_;
 
   /// Used to track state of service participant
   AtomicBool shut_down_;
@@ -770,23 +798,28 @@ private:
 
   static int zero_argc;
 
-  /**
-   * If set before TheParticipantFactoryWithArgs and -DCPSConfigFile is not
-   * passed, use this as the configuration file.
-   */
-  ACE_TString default_configuration_file_;
-
   NetworkConfigMonitor_rch network_config_monitor_;
   mutable ACE_Thread_Mutex network_config_monitor_lock_;
 
-  DDS::Duration_t bit_autopurge_nowriter_samples_delay_;
-  DDS::Duration_t bit_autopurge_disposed_samples_delay_;
-
-  TypeObjectEncoding type_object_encoding_;
-
   RcHandle<InternalTopic<NetworkInterfaceAddress> > network_interface_address_topic_;
 
-  unsigned int printer_value_writer_indent_;
+  mutable ConfigStoreImpl config_store_;
+  ConfigReader_rch config_reader_;
+  ConfigReaderListener_rch config_reader_listener_;
+
+  class ConfigReaderListener : public InternalDataReaderListener<ConfigPair> {
+  public:
+    ConfigReaderListener(Service_Participant& service_participant)
+      : service_participant_(service_participant)
+    {}
+
+    void on_data_available(InternalDataReader_rch reader);
+
+  private:
+    Service_Participant& service_participant_;
+  };
+
+  bool set_repo_ior_result_;
 };
 
 #define TheServiceParticipant OpenDDS::DCPS::Service_Participant::instance()

--- a/dds/DCPS/Service_Participant.inl
+++ b/dds/DCPS/Service_Participant.inl
@@ -251,96 +251,6 @@ Service_Participant::initial_TypeConsistencyEnforcementQosPolicy() const
 }
 
 ACE_INLINE
-int&
-Service_Participant::federation_recovery_duration()
-{
-  return federation_recovery_duration_;
-}
-
-ACE_INLINE
-int
-Service_Participant::federation_recovery_duration() const
-{
-  return federation_recovery_duration_;
-}
-
-ACE_INLINE
-int&
-Service_Participant::federation_initial_backoff_seconds()
-{
-  return federation_initial_backoff_seconds_;
-}
-
-ACE_INLINE
-int
-Service_Participant::federation_initial_backoff_seconds() const
-{
-  return federation_initial_backoff_seconds_;
-}
-
-ACE_INLINE
-int&
-Service_Participant::federation_backoff_multiplier()
-{
-  return federation_backoff_multiplier_;
-}
-
-ACE_INLINE
-int
-Service_Participant::federation_backoff_multiplier() const
-{
-  return federation_backoff_multiplier_;
-}
-
-ACE_INLINE
-int&
-Service_Participant::federation_liveliness()
-{
-  return federation_liveliness_;
-}
-
-ACE_INLINE
-int
-Service_Participant::federation_liveliness() const
-{
-  return federation_liveliness_;
-}
-
-ACE_INLINE
-long&
-Service_Participant::scheduler()
-{
-  return scheduler_;
-}
-
-ACE_INLINE
-long
-Service_Participant::scheduler() const
-{
-  return scheduler_;
-}
-
-ACE_INLINE
-TimeDuration
-Service_Participant::pending_timeout() const
-{
-  return pending_timeout_;
-}
-
-ACE_INLINE
-void Service_Participant::pending_timeout(const TimeDuration& value)
-{
-  pending_timeout_ = value;
-}
-
-ACE_INLINE
-MonotonicTimePoint Service_Participant::new_pending_timeout_deadline() const
-{
-  return pending_timeout_.is_zero() ?
-    MonotonicTimePoint() : MonotonicTimePoint::now() + pending_timeout_;
-}
-
-ACE_INLINE
 int
 Service_Participant::priority_min() const
 {
@@ -355,44 +265,10 @@ Service_Participant::priority_max() const
 }
 
 ACE_INLINE
-bool&
-Service_Participant::publisher_content_filter()
-{
-  return publisher_content_filter_;
-}
-
-ACE_INLINE
-bool
-Service_Participant::publisher_content_filter() const
-{
-  return publisher_content_filter_;
-}
-
-ACE_INLINE
 bool
 Service_Participant::is_shut_down() const
 {
   return shut_down_;
-}
-
-ACE_INLINE
-bool
-Service_Participant::use_bidir_giop() const
-{
-  return bidir_giop_;
-}
-
-ACE_INLINE
-Service_Participant::TypeObjectEncoding
-Service_Participant::type_object_encoding() const
-{
-  return type_object_encoding_;
-}
-
-ACE_INLINE
-void Service_Participant::type_object_encoding(TypeObjectEncoding encoding)
-{
-  type_object_encoding_ = encoding;
 }
 
 } // namespace DCPS

--- a/dds/DCPS/debug.cpp
+++ b/dds/DCPS/debug.cpp
@@ -131,9 +131,9 @@ void SecurityDebug::set_all_flags_to(bool value)
   chlookup = value;
 }
 
-void SecurityDebug::parse_flags(const ACE_TCHAR* flags)
+void SecurityDebug::parse_flags(const char* flags)
 {
-  String s(ACE_TEXT_ALWAYS_CHAR(flags));
+  String s(flags);
   const String delim(",");
   while (true) {
     const size_t pos = s.find(delim);

--- a/dds/DCPS/debug.h
+++ b/dds/DCPS/debug.h
@@ -101,7 +101,7 @@ public:
    * Unknown ones are ignored and "all" enables all the flags.
    * Ex: "bookkeeping,showkeys"
    */
-  void parse_flags(const ACE_TCHAR* flags);
+  void parse_flags(const char* flags);
 
   /**
    * Set debug level similarly to DCPSDebugLevel

--- a/dds/DCPS/transport/framework/TransportRegistry.cpp
+++ b/dds/DCPS/transport/framework/TransportRegistry.cpp
@@ -622,7 +622,7 @@ TransportRegistry::bind_config(const TransportConfig_rch& cfg,
 
     if (found)
     {
-      ACE_TString cfg_name = ACE_TEXT_CHAR_TO_TCHAR(cfg->name().c_str());
+      const String cfg_name = cfg->name();
       // create if not already created
       int ret = create_transport_template_instance(domain_id, cfg_name);
 
@@ -639,7 +639,7 @@ TransportRegistry::bind_config(const TransportConfig_rch& cfg,
         OPENDDS_STRING transport_config_name;
 
         if (cfg_name.c_str() != 0) {
-          transport_config_name = ACE_TEXT_ALWAYS_CHAR(cfg_name.c_str());
+          transport_config_name = cfg_name;
         } else {
           ACE_ERROR((LM_ERROR,
                      ACE_TEXT("(%P|%t) TransportRegistry::bind_config: ")
@@ -739,7 +739,7 @@ TransportRegistry::create_new_transport_instance_for_participant(DDS::DomainId_t
 {
   // check per_participant
   TransportTemplate templ;
-  if (get_transport_template_info(ACE_TEXT_CHAR_TO_TCHAR(transport_config_name.c_str()), templ)) {
+  if (get_transport_template_info(transport_config_name, templ)) {
     if (!templ.instantiate_per_participant) {
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("(%P|%t) ERROR: TransportRegistry::")
@@ -768,10 +768,10 @@ TransportRegistry::create_new_transport_instance_for_participant(DDS::DomainId_t
   ach.open_section(ach.root_section(), ACE_TEXT("the_transport_setup"), true, sect_key);
 
   if (TheServiceParticipant->belongs_to_domain_range(id) ||
-      config_has_transport_template(ACE_TEXT_CHAR_TO_TCHAR(transport_config_name.c_str()))) {
+      config_has_transport_template(transport_config_name)) {
     TransportTemplate tr_inst;
 
-    if (get_transport_template_info(ACE_TEXT_CHAR_TO_TCHAR(cfg->name().c_str()), tr_inst)) {
+    if (get_transport_template_info(cfg->name(), tr_inst)) {
       ValueMap customs;
 
       if (!process_customizations(id, tr_inst, customs)) {
@@ -867,7 +867,7 @@ TransportRegistry::get_config_instance_name(const DDS::DomainId_t id)
 }
 
 int
-TransportRegistry::create_transport_template_instance(DDS::DomainId_t domain, const ACE_TString& config_name)
+TransportRegistry::create_transport_template_instance(DDS::DomainId_t domain, const String& config_name)
 {
   OPENDDS_STRING transport_inst_name = get_transport_template_instance_name(domain);
   OPENDDS_STRING config_inst_name = get_config_instance_name(domain);
@@ -940,10 +940,10 @@ TransportRegistry::create_transport_template_instance(DDS::DomainId_t domain, co
 }
 
 bool
-TransportRegistry::config_has_transport_template(const ACE_TString& config_name) const
+TransportRegistry::config_has_transport_template(const String& config_name) const
 {
   for (OPENDDS_VECTOR(TransportTemplate)::const_iterator i = transport_templates_.begin(); i != transport_templates_.end(); ++i) {
-    if (!ACE_OS::strcmp(ACE_TEXT_ALWAYS_CHAR(config_name.c_str()), i->config_name.c_str())) {
+    if (config_name == i->config_name) {
       return true;
     }
   }
@@ -952,12 +952,12 @@ TransportRegistry::config_has_transport_template(const ACE_TString& config_name)
 }
 
 bool
-TransportRegistry::get_transport_template_info(const ACE_TString& config_name, TransportTemplate& inst)
+TransportRegistry::get_transport_template_info(const String& config_name, TransportTemplate& inst)
 {
   bool ret = false;
   if (has_transport_templates()) {
     for (OPENDDS_VECTOR(TransportTemplate)::const_iterator i = transport_templates_.begin(); i != transport_templates_.end(); ++i) {
-      if (!ACE_OS::strcmp(ACE_TEXT_ALWAYS_CHAR(config_name.c_str()), i->config_name.c_str())) {
+      if (config_name == i->config_name) {
         inst.transport_template_name = i->transport_template_name;
         inst.config_name = i->config_name;
         inst.instantiate_per_participant = i->instantiate_per_participant;

--- a/dds/DCPS/transport/framework/TransportRegistry.h
+++ b/dds/DCPS/transport/framework/TransportRegistry.h
@@ -120,9 +120,9 @@ public:
 
   bool released() const;
 
-  bool config_has_transport_template(const ACE_TString& config_name) const;
+  bool config_has_transport_template(const String& config_name) const;
 
-  int create_transport_template_instance(DDS::DomainId_t domain, const ACE_TString& config_name);
+  int create_transport_template_instance(DDS::DomainId_t domain, const String& config_name);
 
   OPENDDS_STRING get_transport_template_instance_name(DDS::DomainId_t id);
 
@@ -178,7 +178,7 @@ private:
 
   OPENDDS_VECTOR(TransportTemplate) transport_templates_;
 
-  bool get_transport_template_info(const ACE_TString& config_name, TransportTemplate& inst);
+  bool get_transport_template_info(const String& config_name, TransportTemplate& inst);
 
   bool process_customizations(const DDS::DomainId_t id, const TransportTemplate& tr_inst, ValueMap& customs);
 


### PR DESCRIPTION
Problem
-------

The `Service_Participant` does not use the `ConfigStore`.  See #4134.

Solution
--------

Convert the `Service_Participant` to use the `ConfigStore`.

* Methods that returned references to configuration values in `Service_Participant` have been removed.

* Various strings have changed type.

* Each configuration value has a canonical name starting with `OPENDDS`.  The rest of the name is taken from its position in the config file by considering the section name.  Camelcase is converted into all-caps with underscores.  The canonical name resembles an environment variable to enable eventual support for environment variables.  See `Service_Participant.h` for the current list of configuration values.

* Argument parsing has been consolidated.  Arguments starting with `-DCPS`, `-Federation`, or `-OPENDDS` are canonicalized and added to the `ConfigStore`.  `-DCPS` and `-Federation` options are prefix with `OPENDDS_COMMON_`.  The ability to passes options via `-OPENDDS` means that any configuration value can be changed via the command line once all modules have adopted the `ConfigStore`.

* The configuration file is loaded into the `ConfigStore`.  The section name and key are concatenated and canonicalized.

* Configuration that involved more than setting a value has been implemented via an Internal DDS Listener.  The appropriate values are written into the `ConfigStore` and then the listener is manually invoked for the changes.  It is possible to set the listener for the reader if it is necessary to react to changes after the initial configuration.