### PR TITLE
No Docker image for master

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
+      - master
       - latest-release
     tags:
       - DDS-*


### PR DESCRIPTION
Problem
-------

Docker images are only produced for releases.  Having a Docker image of master is useful for trying new features.

Solution
--------

Build Docker images for master branch.