### PR TITLE
Some language mappings don't support equality comparison

### DIFF
--- a/dds/idl/be_global.cpp
+++ b/dds/idl/be_global.cpp
@@ -54,6 +54,7 @@ BE_GlobalData::BE_GlobalData()
   , generate_value_reader_writer_(true)
   , generate_xtypes_complete_(false)
   , face_ts_(false)
+  , generate_equality_(false)
   , filename_only_includes_(false)
   , sequence_suffix_("Seq")
   , language_mapping_(LANGMAP_NONE)
@@ -376,6 +377,8 @@ BE_GlobalData::parse_args(long& i, char** av)
       face_ts(true);
     } else if (0 == ACE_OS::strcasecmp(av[i], "-Gxtypes-complete")) {
       xtypes_complete(true);
+    } else if (0 == ACE_OS::strcasecmp(av[i], "-Gequality")) {
+      generate_equality(true);
     } else {
       invalid_option(av[i]);
     }

--- a/dds/idl/be_global.h
+++ b/dds/idl/be_global.h
@@ -253,6 +253,9 @@ public:
 
   bool special_serialization(AST_Decl* node, std::string& template_name) const;
 
+  void generate_equality(bool flag) { generate_equality_ = flag; }
+  bool generate_equality() const { return generate_equality_; }
+
 private:
   /// Name of the IDL file we are processing.
   const char* filename_;
@@ -260,7 +263,7 @@ private:
   bool java_, suppress_idl_, suppress_typecode_, suppress_xtypes_,
     no_default_gen_, generate_itl_,
     generate_value_reader_writer_,
-    generate_xtypes_complete_, face_ts_;
+    generate_xtypes_complete_, face_ts_, generate_equality_;
 
   bool filename_only_includes_;
 

--- a/dds/idl/be_util.cpp
+++ b/dds/idl/be_util.cpp
@@ -114,6 +114,7 @@ be_util::usage()
     " -Grapidjson            generate TypeSupport for converting data samples to\n"
     "                        RapidJSON JavaScript objects\n"
     " -Gxtypes-complete      generate XTypes complete TypeObject and TypeIdentifier\n"
+    " -Gequality             generate == and != for structs and unions\n"
     " --filename-only-includes                strip leading directories from generated\n"
     "                                         #include lines\n"
     " --[no-]default-nested                   topic types must be declared\n"

--- a/dds/idl/ts_generator.cpp
+++ b/dds/idl/ts_generator.cpp
@@ -22,6 +22,8 @@
 #include <map>
 #include <iostream>
 
+using namespace AstTypeClassification;
+
 namespace {
   std::string read_template(const char* prefix)
   {
@@ -491,14 +493,137 @@ bool ts_generator::generate_ts(AST_Decl* node, UTL_ScopedName* name)
 }
 
 bool ts_generator::gen_struct(AST_Structure* node, UTL_ScopedName* name,
-  const std::vector<AST_Field*>&, AST_Type::SIZE_TYPE, const char*)
+  const std::vector<AST_Field*>& fields, AST_Type::SIZE_TYPE, const char*)
 {
+  if (be_global->generate_equality() && be_global->language_mapping() == BE_GlobalData::LANGMAP_NONE) {
+    // == and != are generated as class members in other language mappings.
+
+    const char* const nm = name->last_component()->get_string();
+
+    be_global->header_ << be_global->versioning_begin() << "\n";
+    {
+      ScopedNamespaceGuard hGuard(name, be_global->header_);
+
+      be_global->header_
+        << be_global->export_macro() << " bool operator==(const " << nm << "&, const " << nm << "&);\n"
+        << be_global->export_macro() << " bool operator!=(const " << nm << "&, const " << nm << "&);\n";
+    }
+    be_global->header_ << be_global->versioning_end() << "\n";
+
+    be_global->impl_ << be_global->versioning_begin() << "\n";
+    {
+      ScopedNamespaceGuard cppGuard(name, be_global->impl_);
+
+      be_global->impl_ << "bool operator==(const " << nm << "& lhs, const " << nm << "& rhs)\n"
+                       << "{\n";
+      for (size_t i = 0; i < fields.size(); ++i) {
+        const std::string field_name = fields[i]->local_name()->get_string();
+        AST_Type* field_type = resolveActualType(fields[i]->field_type());
+        const Classification cls = classify(field_type);
+        if (cls & CL_ARRAY) {
+          std::string indent("  ");
+          NestedForLoops nfl("int", "i",
+            dynamic_cast<AST_Array*>(field_type), indent, true);
+          be_global->impl_ <<
+            indent << "if (lhs." << field_name << nfl.index_ << " != rhs."
+            << field_name << nfl.index_ << ") {\n" <<
+            indent << "  return false;\n" <<
+            indent << "}\n";
+        } else if (cls & CL_SEQUENCE) {
+          be_global->impl_ <<
+            "  if (!OpenDDS::DCPS::sequence_equal(lhs." << field_name << ", rhs." << field_name << ")) return false;\n";
+        } else {
+          be_global->impl_ <<
+            "  if (lhs." << field_name << " != rhs." << field_name << ") {\n"
+            "    return false;\n"
+            "  }\n";
+        }
+      }
+      be_global->impl_ << "  return true;\n"
+                       << "}\n";
+      be_global->impl_ << "bool operator!=(const " << nm << "& lhs, const " << nm << "& rhs) { return !(lhs == rhs); }\n";
+    }
+    be_global->impl_ << be_global->versioning_end() << "\n";
+  }
+
   return generate_ts(node, name);
 }
 
+namespace {
+  std::string generateEqual(const std::string&, AST_Decl*, const std::string& name, AST_Type* field_type,
+                            const std::string&, bool, Intro&,
+                            const std::string&)
+  {
+    std::stringstream ss;
+
+    AST_Type* actual_field_type = resolveActualType(field_type);
+    const Classification cls = classify(actual_field_type);
+    if (cls & (CL_PRIMITIVE | CL_ENUM)) {
+      ss <<
+        "    return lhs." << name << "() == rhs." << name << "();\n";
+    } else if (cls & CL_STRING) {
+      ss <<
+        "    return std::strcmp (lhs." << name << "(), rhs." << name << "()) == 0 ;\n";
+    } else if (cls & CL_ARRAY) {
+      std::string indent("  ");
+      NestedForLoops nfl("int", "i",
+                         dynamic_cast<AST_Array*>(field_type), indent, true);
+      ss <<
+        indent << "if (lhs." << name << nfl.index_ << " != rhs."
+               << name << nfl.index_ << ") {\n" <<
+        indent << "  return false;\n" <<
+        indent << "}\n";
+      ss <<
+        "    return true;\n";
+    } else if (cls & CL_SEQUENCE) {
+      ss <<
+        "    return OpenDDS::DCPS::sequence_equal(lhs." << name << "(), rhs." << name << "());\n";
+    } else if (cls & (CL_STRUCTURE | CL_UNION | CL_FIXED)) {
+      ss <<
+        "    return lhs." << name << "() == rhs." << name << "();\n";
+    } else {
+      idl_global->err()->misc_warning("Unsupported type for union element", field_type);
+    }
+
+    return ss.str();
+  }
+}
+
 bool ts_generator::gen_union(AST_Union* node, UTL_ScopedName* name,
-  const std::vector<AST_UnionBranch*>&, AST_Type*, const char*)
+  const std::vector<AST_UnionBranch*>& branches, AST_Type* discriminator, const char*)
 {
+  if (be_global->generate_equality() && be_global->language_mapping() == BE_GlobalData::LANGMAP_NONE) {
+    // == and != are generated as class members in other language mappings.
+
+    const char* const nm = name->last_component()->get_string();
+
+    be_global->header_ << be_global->versioning_begin() << "\n";
+    {
+      ScopedNamespaceGuard hGuard(name, be_global->header_);
+
+      be_global->header_
+        << be_global->export_macro() << " bool operator==(const " << nm << "&, const " << nm << "&);\n"
+        << be_global->export_macro() << " bool operator!=(const " << nm << "&, const " << nm << "&);\n";
+    }
+    be_global->header_ << be_global->versioning_end() << "\n";
+
+    be_global->impl_ << be_global->versioning_begin() << "\n";
+    {
+      ScopedNamespaceGuard cppGuard(name, be_global->impl_);
+
+      be_global->impl_ << "bool operator==(const " << nm << "& lhs, const " << nm << "& rhs)\n"
+                       << "{\n"
+                       << "  if (lhs._d() != rhs._d()) return false;\n";
+      if (generateSwitchForUnion(node, "lhs._d()", generateEqual, branches, discriminator, "", "", "", false, false)) {
+        be_global->impl_ <<
+          "  return false;\n";
+      }
+      be_global->impl_ << "}\n";
+      be_global->impl_ << "bool operator!=(const " << nm << "& lhs, const " << nm << "& rhs) { return !(lhs == rhs); }\n";
+    }
+    be_global->impl_ << be_global->versioning_end() << "\n";
+  }
+
   return generate_ts(node, name);
 }
 

--- a/docs/devguide/opendds_idl.rst
+++ b/docs/devguide/opendds_idl.rst
@@ -164,6 +164,13 @@ The following table summarizes the options supported by ``opendds_idl``.
 
      - Only minimal TypeObjects are generated
 
+   * - ``-Gequality``
+
+     - Generate ``==`` and ``!=`` for structs and unions.
+       The members of the struct or union must have a type that could appear in a DDS topic and be supported by opendds_idl.
+
+     - Not generated
+
    * - ``-Lface``
 
      - Generates IDL-to-C++ mapping for FACE

--- a/docs/news.d/equality_operators.rst
+++ b/docs/news.d/equality_operators.rst
@@ -1,0 +1,10 @@
+.. news-prs: 4154
+
+.. news-start-section: Additions
+- Add ``-Gequality`` option to opendds_idl to generate ``==`` and ``!=`` for structs and unions.
+
+  - The members of the struct or union must have a type that could appear in a DDS topic and be supported by opendds_idl.
+
+  - The motivation for this change was to make the generated code more useful as many users go on to define these operators.
+
+.. news-end-section

--- a/tests/DCPS/Compiler/C++11/idl_test_nested_types_lib/cxx11_idl_test_nested_types_lib.mpc
+++ b/tests/DCPS/Compiler/C++11/idl_test_nested_types_lib/cxx11_idl_test_nested_types_lib.mpc
@@ -1,7 +1,7 @@
 project: dcps_test_idl_only_lib, opendds_cxx11 {
   idlflags      += -Wb,export_macro=NestedTypesTest_Export -Wb,export_include=NestedTypesTest_export.h \
                     -I../../idl_test_nested_types_lib
-  dcps_ts_flags += -Wb,export_macro=NestedTypesTest_Export -Wb,export_include=NestedTypesTest_export.h
+  dcps_ts_flags += -Wb,export_macro=NestedTypesTest_Export -Wb,export_include=NestedTypesTest_export.h -Gequality
   dynamicflags  += NESTEDTYPESTEST_BUILD_DLL
 
   TypeSupport_Files {

--- a/tests/DCPS/Compiler/idl_test_nested_types_lib/idl_test_nested_types_lib.mpc
+++ b/tests/DCPS/Compiler/idl_test_nested_types_lib/idl_test_nested_types_lib.mpc
@@ -1,7 +1,7 @@
 project: dcps_test_idl_only_lib {
   idlflags      += -Wb,stub_export_include=NestedTypesTest_export.h \
                    -Wb,stub_export_macro=NestedTypesTest_Export -SS
-  dcps_ts_flags += -Wb,export_macro=NestedTypesTest_Export
+  dcps_ts_flags += -Wb,export_macro=NestedTypesTest_Export -Gequality
   dynamicflags  += NESTEDTYPESTEST_BUILD_DLL
 
   TypeSupport_Files {


### PR DESCRIPTION
Problem
-------

The type support for C++11 does not include equality operators (`==` and `!=`).  The operators make the IDL defined types easier to use with generic programming techniques.

Solution
--------

Implement support for `==` and `!=`.