### PR TITLE
Corrections to the News

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@ OpenDDS 3.24.0 was released on Apr 11 2023.
 - Can now cross-compile on macOS (#4048)
 - Added hardening features to RtpsRelay (#4045)
   - These are configured with the new options `-MaxAddrSetSize` and `-RejectedAddressDuration`.
+- Added `OPENDDS_AUTO_LINK_DCPS` and `OPENDDS_USE_CORRECT_INCLUDE_SCOPE` global options to the CMake package (#4071)
 - Expanded support for using C++ keywords in IDL (#4073)
 - Improved support for anonymous types in unions branches (#4078)
 - IDL file and generated TypeSupport.idl can now be in different directories (#4077)

--- a/docs/news.d/_releases/v3.24.0.rst
+++ b/docs/news.d/_releases/v3.24.0.rst
@@ -33,6 +33,7 @@ Additions
   - These are configured with the new options ``-MaxAddrSetSize`` and ``-RejectedAddressDuration``.
 
 - Can now cross-compile on macOS (:ghpr:`4048`)
+- Added ``OPENDDS_AUTO_LINK_DCPS`` and ``OPENDDS_USE_CORRECT_INCLUDE_SCOPE`` global options to the CMake package (:ghpr:`4071`)
 - Expanded support for using C++ keywords in IDL (:ghpr:`4073`)
 - IDL file and generated TypeSupport.idl can now be in different directories (:ghpr:`4077`)
 - Improved support for anonymous types in unions branches (:ghpr:`4078`)

--- a/docs/news.d/sample_convert.rst
+++ b/docs/news.d/sample_convert.rst
@@ -1,4 +1,4 @@
-.. news-prs: 4122 4133 4135
+.. news-prs: 4122 4133 4135 4144
 .. news-start-section: Additions
 - Added ``encode_to_string``, ``encode_to_bytes``, ``decode_from_string``, and ``decode_from_bytes`` to ``TypeSupport``.
 


### PR DESCRIPTION
- Add https://github.com/OpenDDS/OpenDDS/pull/4144 to News
- Retroactively add new global options from https://github.com/OpenDDS/OpenDDS/pull/4071 to 3.24.0. I realized I missed them when going over the CMake documentation.