### PR TITLE
Update `docs/build.py` for Windows and Remove `./`

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -63,7 +63,6 @@ class DocEnv:
             rmtree(self.build_path)
 
     def setup(self, force_new=False):
-        sanity_path = self.bin_path / 'sphinx-build'
         install_deps = False
         if force_new or not self.venv_path.is_dir():
             log('Creating venv...')
@@ -72,16 +71,10 @@ class DocEnv:
         elif reqs_path.stat().st_mtime >= self.venv_path.stat().st_mtime:
             log('Requirements file was changed, updating dependencies.')
             install_deps = True
-        elif not sanity_path.is_file():
-            log('sphinx-build not found, need to install dependencies?')
-            install_deps = True
 
         if install_deps:
             log('Install Dependencies...')
             self.run('python', '-m', 'pip', 'install', '-r', str(reqs_path))
-            if not sanity_path.is_file():
-                log('sphinx-build not found after installing dependencies', error=True)
-                sys.exit(1)
             self.venv_path.touch()
             self.rm_build()
 

--- a/docs/internal/docs.rst
+++ b/docs/internal/docs.rst
@@ -18,7 +18,7 @@ Multiple kinds can be passed, and they are documented in the following sections.
 Requirements
 ============
 
-The script requires Python 3.6 or later and an internet connection if the script needs to download dependencies or check the validity of external links.
+The script requires `Python 3.6 or later <https://www.python.org/downloads/>`__ and an internet connection if the script needs to download dependencies or check the validity of external links.
 
 You might receive a message like this when running for the first time::
 
@@ -34,25 +34,25 @@ If you do, then follow the directions it gives, remove the ``docs/.venv`` direct
 HTML
 ====
 
-HTML documentation can be built and viewed using ``./docs/build.py -o html``.
-If it was built successfully, then the front page will be at ``./docs/_build/html/index.html``.
+HTML documentation can be built and viewed using ``docs/build.py -o html``.
+If it was built successfully, then the front page will be at ``docs/_build/html/index.html``.
 
-A single page variant is also available using ``./docs/build.py -o singlehtml``
-If it was built successfully, then the page will be at ``./docs/_build/singlehtml/index.html``.
+A single page variant is also available using ``docs/build.py -o singlehtml``
+If it was built successfully, then the page will be at ``docs/_build/singlehtml/index.html``.
 
 PDF
 ===
 
 .. note:: This has additional dependencies on LaTeX that are documented `here <https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.latex.LaTeXBuilder>`__.
 
-PDF documentation can be built and viewed using ``./docs/build.py -o pdf``.
-If it was built successfully, then the PDF file will be at ``./docs/_build/latex/opendds.pdf``.
+PDF documentation can be built and viewed using ``docs/build.py -o pdf``.
+If it was built successfully, then the PDF file will be at ``docs/_build/latex/opendds.pdf``.
 
 Dash
 ====
 
 Documentation can be built for `Dash <https://kapeli.com/dash>`_, `Zeal <https://zealdocs.org/>`_, and other Dash-compatible applications using `doc2dash <https://github.com/hynek/doc2dash>`_.
-The command for this is ``./docs/build.py dash``.
+The command for this is ``docs/build.py dash``.
 This will create a ``docs/_build/OpenDDS.docset`` directory that must be manually moved to where other docsets are stored.
 
 Strict Checks
@@ -478,7 +478,7 @@ These will result in:
   - Unoptimized all code that's not related to pigeons (:ghpr:`2222`) [Rank 0]
 
 The ranks are included in previews of the news as an aid to deciding what the rank of new news content should be.
-The preview can be viewed in :doc:`/news` or alternatively by running ``./docs/news.py preview``.
+The preview can be viewed in :doc:`/news` or alternatively by running ``docs/news.py preview``.
 The ranks are not included in the final news for a release.
 
 One final thing to note is that top-level sections, like "Additions", have a fixed rank that can't be changed so they always appear in the same order.
@@ -487,7 +487,7 @@ Generating the News
 ===================
 
 Before a release, a preview of the whole news for the next release will always be available in :doc:`/news`.
-It's also possible to see the source of that preview by running ``./docs/news.py preview`` or ``./docs/news.py preview-all``.
+It's also possible to see the source of that preview by running ``docs/news.py preview`` or ``docs/news.py preview-all``.
 During a release the fragments are permanently committed to :ghfile:`docs/news.d/_releases` and :ghfile:`NEWS.md` and the fragment files in :ghfile:`docs/news.d` are removed.
 
 .. seealso:: :doc:`release`

--- a/docs/internal/release.rst
+++ b/docs/internal/release.rst
@@ -231,7 +231,7 @@ Here is an example of what to run for a version 1.0.0 release command assuming t
 
 .. code-block:: bash
 
-    perl tools/scripts/gitrelease.pl ../1.0.0-release-workspace 1.0.0 --remedy
+    tools/scripts/gitrelease.pl ../1.0.0-release-workspace 1.0.0 --remedy
 
 Micro Releases
 --------------
@@ -255,7 +255,7 @@ Here is an example of what to run for a version 1.0.1 release assuming that the 
 .. code-block:: bash
 
     git checkout branch-DDS-1.0
-    perl tools/scripts/gitrelease.pl ../1.0.1-release-workspace 1.0.1 --micro --branch=branch-DDS-1.0 --remedy
+    tools/scripts/gitrelease.pl ../1.0.1-release-workspace 1.0.1 --micro --branch=branch-DDS-1.0 --remedy
 
 Doing Mock Releases with the Release Script
 -------------------------------------------

--- a/docs/internal/running_tests.rst
+++ b/docs/internal/running_tests.rst
@@ -31,7 +31,7 @@ For Unixes (Linux, macOS, BSDs, etc)
 
 Run this in :envvar:`DDS_ROOT`::
 
-  ./bin/auto_run_tests.pl
+  bin/auto_run_tests.pl
 
 For Windows
 -----------


### PR DESCRIPTION
`docs/build.py` almost works on Windows, but there is an extra check for the existence of `sphinx-build` that apparently doesn't work on Windows because the virutalenv directory structure is different. It isn't really necessary anyways.

Also removed unnecessary `./` before scripts.