### PR TITLE
TransportClient uses uninitialized GUID

### DIFF
--- a/dds/DCPS/DataReaderCallbacks.h
+++ b/dds/DCPS/DataReaderCallbacks.h
@@ -40,8 +40,9 @@ public:
 
   virtual ~DataReaderCallbacks() {}
 
-  virtual void add_association(const GUID_t& yourId,
-                               const WriterAssociation& writer,
+  virtual void set_subscription_id(const GUID_t& guid) = 0;
+
+  virtual void add_association(const WriterAssociation& writer,
                                bool active) = 0;
 
   virtual void remove_associations(const WriterIdSeq& writers,

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -214,8 +214,11 @@ public:
 
   virtual DDS::InstanceHandle_t get_instance_handle();
 
-  virtual void add_association(const GUID_t& yourId,
-                               const WriterAssociation& writer,
+  virtual void set_subscription_id(const GUID_t& guid);
+
+  const GUID_t& subscription_id() const { return subscription_id_; }
+
+  virtual void add_association(const WriterAssociation& writer,
                                bool active);
 
   virtual void transport_assoc_done(int flags, const GUID_t& remote_id);
@@ -610,16 +613,6 @@ public:
 
   virtual DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint();
 
-  GUID_t get_guid() const
-  {
-    ACE_Guard<ACE_Thread_Mutex> guard(subscription_id_mutex_);
-    ThreadStatusManager& thread_status_manager = TheServiceParticipant->get_thread_status_manager();
-    while (!has_subscription_id_ && !get_deleted()) {
-      subscription_id_condition_.wait(thread_status_manager);
-    }
-    return subscription_id_;
-  }
-
   void return_handle(DDS::InstanceHandle_t handle);
 
   const ValueDispatcher* get_value_dispatcher() const
@@ -748,10 +741,6 @@ protected:
 
   /// Data has arrived into the cache, unblock waiting ReadConditions
   void notify_read_conditions();
-
-  bool has_subscription_id_;
-  mutable ACE_Thread_Mutex subscription_id_mutex_;
-  mutable ConditionVariable<ACE_Thread_Mutex> subscription_id_condition_;
 
   unique_ptr<ReceivedDataAllocator> rd_allocator_;
   DDS::DataReaderQos qos_;

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1270,7 +1270,7 @@ private:
         }
 
         DDS::Security::SecurityException ex;
-        const GUID_t local_participant = make_part_guid(get_guid());
+        const GUID_t local_participant = make_part_guid(subscription_id());
         const GUID_t remote_participant = make_part_guid(header.publication_id_);
         const DDS::Security::ParticipantCryptoHandle remote_participant_permissions_handle = security_config_->get_handle_registry(local_participant)->get_remote_participant_permissions_handle(remote_participant);
         // Construct a DynamicData around the deserialized sample.
@@ -1289,7 +1289,7 @@ private:
       } else if (is_dispose_msg) {
 
         DDS::Security::SecurityException ex;
-        const GUID_t local_participant = make_part_guid(get_guid());
+        const GUID_t local_participant = make_part_guid(subscription_id());
         const GUID_t remote_participant = make_part_guid(header.publication_id_);
         const DDS::Security::ParticipantCryptoHandle remote_participant_permissions_handle = security_config_->get_handle_registry(local_participant)->get_remote_participant_permissions_handle(remote_participant);
         // Construct a DynamicData around the deserialized sample.
@@ -1535,7 +1535,7 @@ DDS::ReturnCode_t read_instance_i(MessageSequenceType& received_data,
     }
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderImpl_T::read_instance_i: ")
                ACE_TEXT("will return no data reading sub %C because:\n  %C\n"),
-               LogGuid(get_guid()).c_str(), msg.c_str()));
+               LogGuid(subscription_id()).c_str(), msg.c_str()));
   }
 
   results.copy_to_user();

--- a/dds/DCPS/DataWriterCallbacks.h
+++ b/dds/DCPS/DataWriterCallbacks.h
@@ -39,8 +39,9 @@ public:
 
   virtual ~DataWriterCallbacks() {}
 
-  virtual void add_association(const GUID_t& yourId,
-                               const ReaderAssociation& reader,
+  virtual void set_publication_id(const GUID_t& guid) = 0;
+
+  virtual void add_association(const ReaderAssociation& reader,
                                bool active) = 0;
 
   virtual void remove_associations(const ReaderIdSeq& readers,

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -191,8 +191,9 @@ public:
 
   virtual DDS::ReturnCode_t enable();
 
-  virtual void add_association(const GUID_t& yourId,
-                               const ReaderAssociation& reader,
+  virtual void set_publication_id(const GUID_t& guid);
+
+  virtual void add_association(const ReaderAssociation& reader,
                                bool active);
 
   virtual void transport_assoc_done(int flags, const GUID_t& remote_id);
@@ -487,12 +488,6 @@ public:
 
   virtual WeakRcHandle<ICE::Endpoint> get_ice_endpoint();
 
-  GUID_t get_guid() const
-  {
-    ACE_Guard<ACE_Recursive_Thread_Mutex> guard(lock_);
-    return publication_id_;
-  }
-
   SequenceNumber get_max_sn() const
   {
     ACE_Guard<ACE_Thread_Mutex> guard(sn_lock_);
@@ -518,14 +513,6 @@ public:
     const DDS::Time_t& source_timestamp);
 
 protected:
-
-  void check_and_set_repo_id(const GUID_t& id)
-  {
-    ACE_Guard<ACE_Recursive_Thread_Mutex> guard(lock_);
-    if (GUID_UNKNOWN == publication_id_) {
-      publication_id_ = id;
-    }
-  }
 
   SequenceNumber get_next_sn()
   {

--- a/dds/DCPS/DcpsUpcalls.cpp
+++ b/dds/DCPS/DcpsUpcalls.cpp
@@ -40,7 +40,7 @@ int DcpsUpcalls::svc()
   if (!drr) {
     return 0;
   }
-  drr->add_association(reader_, wa_, active_);
+  drr->add_association(wa_, active_);
 
   {
     ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mtx_, -1);

--- a/dds/DCPS/Discovery.h
+++ b/dds/DCPS/Discovery.h
@@ -186,15 +186,15 @@ public:
   /// for the publication pointer, so it requires that
   /// the publication pointer remain valid until
   /// remove_publication is called.
-  virtual GUID_t add_publication(
-    DDS::DomainId_t domainId,
-    const GUID_t& participantId,
-    const GUID_t& topicId,
-    DataWriterCallbacks_rch publication,
-    const DDS::DataWriterQos& qos,
-    const TransportLocatorSeq& transInfo,
-    const DDS::PublisherQos& publisherQos,
-    const XTypes::TypeInformation& type_info) = 0;
+  /// Return true on success.
+  virtual bool add_publication(DDS::DomainId_t domainId,
+                               const GUID_t& participantId,
+                               const GUID_t& topicId,
+                               DataWriterCallbacks_rch publication,
+                               const DDS::DataWriterQos& qos,
+                               const TransportLocatorSeq& transInfo,
+                               const DDS::PublisherQos& publisherQos,
+                               const XTypes::TypeInformation& type_info) = 0;
 
   virtual bool remove_publication(
     DDS::DomainId_t domainId,
@@ -228,18 +228,18 @@ public:
   /// for the subscription pointer, so it requires that
   /// the subscription pointer remain valid until
   /// remove_subscription is called.
-  virtual GUID_t add_subscription(
-    DDS::DomainId_t domainId,
-    const GUID_t& participantId,
-    const GUID_t& topicId,
-    DataReaderCallbacks_rch subscription,
-    const DDS::DataReaderQos& qos,
-    const TransportLocatorSeq& transInfo,
-    const DDS::SubscriberQos& subscriberQos,
-    const char* filterClassName,
-    const char* filterExpression,
-    const DDS::StringSeq& exprParams,
-    const XTypes::TypeInformation& type_info) = 0;
+  /// Return true on success.
+  virtual bool add_subscription(DDS::DomainId_t domainId,
+                                const GUID_t& participantId,
+                                const GUID_t& topicId,
+                                DataReaderCallbacks_rch subscription,
+                                const DDS::DataReaderQos& qos,
+                                const TransportLocatorSeq& transInfo,
+                                const DDS::SubscriberQos& subscriberQos,
+                                const char* filterClassName,
+                                const char* filterExpression,
+                                const DDS::StringSeq& exprParams,
+                                const XTypes::TypeInformation& type_info) = 0;
 
   virtual bool remove_subscription(
     DDS::DomainId_t domainId,

--- a/dds/DCPS/InfoRepoDiscovery/DataReaderRemote.idl
+++ b/dds/DCPS/InfoRepoDiscovery/DataReaderRemote.idl
@@ -21,7 +21,6 @@ module OpenDDS {
 
       // will tell transport and call on_subscription_matched()
       oneway void add_association(
-        in GUID_t yourId,
         in WriterAssociation writer,
         in boolean active);
 

--- a/dds/DCPS/InfoRepoDiscovery/DataReaderRemoteImpl.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/DataReaderRemoteImpl.cpp
@@ -33,23 +33,13 @@ DataReaderRemoteImpl::detach_parent()
 }
 
 void
-DataReaderRemoteImpl::add_association(const GUID_t& yourId,
-                                      const WriterAssociation& writer,
+DataReaderRemoteImpl::add_association(const WriterAssociation& writer,
                                       bool active)
 {
-  if (DCPS_debug_level) {
-    LogGuid writer_log(yourId);
-    LogGuid reader_log(writer.writerId);
-    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderRemoteImpl::add_association - ")
-               ACE_TEXT("local %C remote %C\n"),
-               writer_log.c_str(),
-               reader_log.c_str()));
-  }
-
   // the local copy of parent_ is necessary to prevent race condition
   RcHandle<DataReaderCallbacks> parent = parent_.lock();
   if (parent) {
-    parent->add_association(yourId, writer, active);
+    parent->add_association(writer, active);
   }
 }
 

--- a/dds/DCPS/InfoRepoDiscovery/DataReaderRemoteImpl.h
+++ b/dds/DCPS/InfoRepoDiscovery/DataReaderRemoteImpl.h
@@ -39,8 +39,7 @@ public:
 
   virtual ~DataReaderRemoteImpl();
 
-  virtual void add_association(const GUID_t& yourId,
-                               const WriterAssociation& writer,
+  virtual void add_association(const WriterAssociation& writer,
                                bool active);
 
   virtual void remove_associations(const WriterIdSeq& writers,

--- a/dds/DCPS/InfoRepoDiscovery/DataWriterRemote.idl
+++ b/dds/DCPS/InfoRepoDiscovery/DataWriterRemote.idl
@@ -21,7 +21,6 @@ module OpenDDS {
 
       // will tell transport and call on_publication_matched()
       oneway void add_association(
-        in GUID_t yourId,
         in ReaderAssociation reader,
         in boolean active);
 

--- a/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.cpp
@@ -33,23 +33,13 @@ DataWriterRemoteImpl::detach_parent()
 }
 
 void
-DataWriterRemoteImpl::add_association(const GUID_t& yourId,
-                                      const ReaderAssociation& reader,
+DataWriterRemoteImpl::add_association(const ReaderAssociation& reader,
                                       bool active)
 {
-  if (DCPS_debug_level) {
-    LogGuid writer_log(yourId);
-    LogGuid reader_log(reader.readerId);
-    ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataWriterRemoteImpl::add_association - ")
-               ACE_TEXT("local %C remote %C\n"),
-               writer_log.c_str(),
-               reader_log.c_str()));
-  }
-
   // the local copy of parent_ is necessary to prevent race condition
   RcHandle<DataWriterCallbacks> parent = parent_.lock();
   if (parent.in()) {
-    parent->add_association(yourId, reader, active);
+    parent->add_association(reader, active);
   }
 }
 

--- a/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.h
+++ b/dds/DCPS/InfoRepoDiscovery/DataWriterRemoteImpl.h
@@ -35,8 +35,7 @@ public:
 
   virtual ~DataWriterRemoteImpl();
 
-  virtual void add_association(const GUID_t& yourId,
-                               const ReaderAssociation& readers,
+  virtual void add_association(const ReaderAssociation& readers,
                                bool active);
 
   virtual void remove_associations(const ReaderIdSeq& readers,

--- a/dds/DCPS/InfoRepoDiscovery/Info.idl
+++ b/dds/DCPS/InfoRepoDiscovery/Info.idl
@@ -78,19 +78,24 @@ module OpenDDS {
                 Invalid_Participant,
                 Invalid_Topic);
 
-
+      GUID_t reserve_publication_id(in ::DDS::DomainId_t domainId,
+                                    in GUID_t participantId,
+                                    in GUID_t topicId)
+        raises (Invalid_Domain,
+                Invalid_Participant,
+                Invalid_Topic);
 
       // publisher calls to create new publication
-      // returns the id of the added publication
-      // 0 is an invalid id
-      GUID_t add_publication (in ::DDS::DomainId_t domainId,
-                              in GUID_t participantId,
-                              in GUID_t topicId,
-                              in DataWriterRemote publication,
-                              in ::DDS::DataWriterQos qos,
-                              in TransportLocatorSeq transInfo,
-                              in ::DDS::PublisherQos publisherQos,
-                              in ::DDS::OctetSeq serializedTypeInfo)
+      // returns true on success
+      boolean add_publication (in ::DDS::DomainId_t domainId,
+                               in GUID_t participantId,
+                               in GUID_t topicId,
+                               in GUID_t pubId,
+                               in DataWriterRemote publication,
+                               in ::DDS::DataWriterQos qos,
+                               in TransportLocatorSeq transInfo,
+                               in ::DDS::PublisherQos publisherQos,
+                               in ::DDS::OctetSeq serializedTypeInfo)
         raises (Invalid_Domain,
                 Invalid_Participant,
                 Invalid_Topic);
@@ -104,22 +109,27 @@ module OpenDDS {
                 Invalid_Participant,
                 Invalid_Publication);
 
-
+      GUID_t reserve_subscription_id(in ::DDS::DomainId_t domainId,
+                                     in GUID_t participantId,
+                                     in GUID_t topicId)
+        raises (Invalid_Domain,
+                Invalid_Participant,
+                Invalid_Topic);
 
       // subscriber calls to create new subscription
-      // returns the id of the added subscription
-      // 0 is an invalid id
-      GUID_t add_subscription (in ::DDS::DomainId_t domainId,
-                               in GUID_t participantId,
-                               in GUID_t topicId,
-                               in DataReaderRemote subscription,
-                               in ::DDS::DataReaderQos qos,
-                               in TransportLocatorSeq transInfo,
-                               in ::DDS::SubscriberQos subscriberQos,
-                               in string filterClassName,
-                               in string filterExpression,
-                               in ::DDS::StringSeq exprParams,
-                               in ::DDS::OctetSeq serializedTypeInfo)
+      // returns true on success.
+      boolean add_subscription (in ::DDS::DomainId_t domainId,
+                                in GUID_t participantId,
+                                in GUID_t topicId,
+                                in GUID_t subId,
+                                in DataReaderRemote subscription,
+                                in ::DDS::DataReaderQos qos,
+                                in TransportLocatorSeq transInfo,
+                                in ::DDS::SubscriberQos subscriberQos,
+                                in string filterClassName,
+                                in string filterExpression,
+                                in ::DDS::StringSeq exprParams,
+                                in ::DDS::OctetSeq serializedTypeInfo)
         raises (Invalid_Domain,
                 Invalid_Participant,
                 Invalid_Topic);

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
@@ -595,7 +595,7 @@ InfoRepoDiscovery::update_topic_qos(const GUID_t& topicId, DDS::DomainId_t domai
 
 // Publication operations:
 
-GUID_t
+bool
 InfoRepoDiscovery::add_publication(DDS::DomainId_t domainId,
                                    const GUID_t& participantId,
                                    const GUID_t& topicId,
@@ -605,13 +605,13 @@ InfoRepoDiscovery::add_publication(DDS::DomainId_t domainId,
                                    const DDS::PublisherQos& publisherQos,
                                    const XTypes::TypeInformation& type_info)
 {
-  GUID_t pubId;
+
 
   try {
     DCPS::DataWriterRemoteImpl* writer_remote_impl = 0;
     ACE_NEW_RETURN(writer_remote_impl,
                    DataWriterRemoteImpl(*publication),
-                   DCPS::GUID_UNKNOWN);
+                   false);
 
     //this is taking ownership of the DataWriterRemoteImpl (server side) allocated above
     PortableServer::ServantBase_var writer_remote(writer_remote_impl);
@@ -623,19 +623,32 @@ InfoRepoDiscovery::add_publication(DDS::DomainId_t domainId,
     DDS::OctetSeq serializedTypeInfo;
     XTypes::serialize_type_info(type_info, serializedTypeInfo);
 
-    pubId = get_dcps_info()->add_publication(domainId, participantId, topicId,
-      dr_remote_obj, qos, transInfo, publisherQos, serializedTypeInfo);
+    const GUID_t pubId = get_dcps_info()->reserve_publication_id(domainId, participantId, topicId);
+    publication->set_publication_id(pubId);
 
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, this->lock_, DCPS::GUID_UNKNOWN);
+    if (!get_dcps_info()->add_publication(domainId,
+                                          participantId,
+                                          topicId,
+                                          pubId,
+                                          dr_remote_obj,
+                                          qos,
+                                          transInfo,
+                                          publisherQos,
+                                          serializedTypeInfo)) {
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("(%P|%t) ERROR: InfoRepoDiscovery::add_publication: ")
+                 ACE_TEXT("failed to add publication\n")));
+      return false;
+    }
+
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, this->lock_, false);
     // take ownership of the client allocated above
     dataWriterMap_[pubId] = dr_remote_obj;
-
+    return true;
   } catch (const CORBA::Exception& ex) {
     ex._tao_print_exception("ERROR: InfoRepoDiscovery::add_publication: ");
-    pubId = DCPS::GUID_UNKNOWN;
+    return false;
   }
-
-  return pubId;
 }
 
 bool
@@ -691,7 +704,7 @@ InfoRepoDiscovery::update_publication_qos(DDS::DomainId_t domainId,
 
 // Subscription operations:
 
-GUID_t
+bool
 InfoRepoDiscovery::add_subscription(DDS::DomainId_t domainId,
                                     const GUID_t& participantId,
                                     const GUID_t& topicId,
@@ -704,13 +717,11 @@ InfoRepoDiscovery::add_subscription(DDS::DomainId_t domainId,
                                     const DDS::StringSeq& params,
                                     const XTypes::TypeInformation& type_info)
 {
-  GUID_t subId;
-
   try {
     DCPS::DataReaderRemoteImpl* reader_remote_impl = 0;
     ACE_NEW_RETURN(reader_remote_impl,
                    DataReaderRemoteImpl(*subscription),
-                   DCPS::GUID_UNKNOWN);
+                   false);
 
     //this is taking ownership of the DataReaderRemoteImpl (server side) allocated above
     PortableServer::ServantBase_var reader_remote(reader_remote_impl);
@@ -722,20 +733,35 @@ InfoRepoDiscovery::add_subscription(DDS::DomainId_t domainId,
     DDS::OctetSeq serializedTypeInfo;
     XTypes::serialize_type_info(type_info, serializedTypeInfo);
 
-    subId = get_dcps_info()->add_subscription(domainId, participantId, topicId,
-                                              dr_remote_obj, qos, transInfo, subscriberQos,
-                                              filterClassName, filterExpr, params,
-                                              serializedTypeInfo);
+    const GUID_t subId = get_dcps_info()->reserve_subscription_id(domainId, participantId, topicId);
+    subscription->set_subscription_id(subId);
 
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, this->lock_, DCPS::GUID_UNKNOWN);
+    if (!get_dcps_info()->add_subscription(domainId,
+                                           participantId,
+                                           topicId,
+                                           subId,
+                                           dr_remote_obj,
+                                           qos,
+                                           transInfo,
+                                           subscriberQos,
+                                           filterClassName,
+                                           filterExpr,
+                                           params,
+                                           serializedTypeInfo)) {
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("(%P|%t) ERROR: InfoRepoDiscovery::add_subscription: ")
+                 ACE_TEXT("failed to add subscription\n")));
+      return false;
+    }
+
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, this->lock_, false);
     // take ownership of the client allocated above
     dataReaderMap_[subId] = dr_remote_obj;
-
+    return true;
   } catch (const CORBA::Exception& ex) {
     ex._tao_print_exception("ERROR: InfoRepoDiscovery::add_subscription: ");
-    subId = DCPS::GUID_UNKNOWN;
+    return false;
   }
-  return subId;
 }
 
 bool

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h
@@ -152,7 +152,7 @@ public:
 
   // Publication operations:
 
-  virtual OpenDDS::DCPS::GUID_t add_publication(
+  virtual bool add_publication(
     DDS::DomainId_t domainId,
     const OpenDDS::DCPS::GUID_t& participantId,
     const OpenDDS::DCPS::GUID_t& topicId,
@@ -182,7 +182,7 @@ public:
 
   // Subscription operations:
 
-  virtual OpenDDS::DCPS::GUID_t add_subscription(
+  virtual bool add_subscription(
     DDS::DomainId_t domainId,
     const OpenDDS::DCPS::GUID_t& participantId,
     const OpenDDS::DCPS::GUID_t& topicId,

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -1319,7 +1319,7 @@ bool RtpsDiscovery::update_topic_qos(const GUID_t& topicId, DDS::DomainId_t doma
   return false;
 }
 
-GUID_t RtpsDiscovery::add_publication(
+bool RtpsDiscovery::add_publication(
   DDS::DomainId_t domainId,
   const GUID_t& participantId,
   const GUID_t& topicId,
@@ -1329,8 +1329,12 @@ GUID_t RtpsDiscovery::add_publication(
   const DDS::PublisherQos& publisherQos,
   const XTypes::TypeInformation& type_info)
 {
-  return get_part(domainId, participantId)->add_publication(
-    topicId, publication, qos, transInfo, publisherQos, type_info);
+  return get_part(domainId, participantId)->add_publication(topicId,
+                                                            publication,
+                                                            qos,
+                                                            transInfo,
+                                                            publisherQos,
+                                                            type_info);
 }
 
 bool RtpsDiscovery::remove_publication(
@@ -1365,7 +1369,7 @@ void RtpsDiscovery::update_publication_locators(
   get_part(domainId, partId)->update_publication_locators(dwId, transInfo);
 }
 
-GUID_t RtpsDiscovery::add_subscription(
+bool RtpsDiscovery::add_subscription(
   DDS::DomainId_t domainId,
   const GUID_t& participantId,
   const GUID_t& topicId,
@@ -1378,9 +1382,15 @@ GUID_t RtpsDiscovery::add_subscription(
   const DDS::StringSeq& params,
   const XTypes::TypeInformation& type_info)
 {
-  return get_part(domainId, participantId)->add_subscription(
-    topicId, subscription, qos, transInfo, subscriberQos, filterClassName,
-    filterExpr, params, type_info);
+  return get_part(domainId, participantId)->add_subscription(topicId,
+                                                             subscription,
+                                                             qos,
+                                                             transInfo,
+                                                             subscriberQos,
+                                                             filterClassName,
+                                                             filterExpr,
+                                                             params,
+                                                             type_info);
 }
 
 bool RtpsDiscovery::remove_subscription(

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -249,7 +249,7 @@ public:
   bool update_topic_qos(const GUID_t& topicId, DDS::DomainId_t domainId,
     const GUID_t& participantId, const DDS::TopicQos& qos);
 
-  GUID_t add_publication(
+  bool add_publication(
     DDS::DomainId_t domainId,
     const GUID_t& participantId,
     const GUID_t& topicId,
@@ -278,7 +278,7 @@ public:
     const GUID_t& dwId,
     const DCPS::TransportLocatorSeq& transInfo);
 
-  GUID_t add_subscription(
+  bool add_subscription(
     DDS::DomainId_t domainId,
     const GUID_t& participantId,
     const GUID_t& topicId,

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -224,7 +224,7 @@ public:
 
   DCPS::TopicStatus remove_topic(const GUID_t& topicId);
 
-  GUID_t add_publication(
+  bool add_publication(
     const GUID_t& topicId,
     DCPS::DataWriterCallbacks_rch publication,
     const DDS::DataWriterQos& qos,
@@ -237,7 +237,7 @@ public:
   void update_publication_locators(const GUID_t& publicationId,
                                    const DCPS::TransportLocatorSeq& transInfo);
 
-  GUID_t add_subscription(
+  bool add_subscription(
     const GUID_t& topicId,
     DCPS::DataReaderCallbacks_rch subscription,
     const DDS::DataReaderQos& qos,
@@ -351,7 +351,9 @@ private:
       , participant_crypto_handle_(DDS::HANDLE_NIL)
       , endpoint_crypto_handle_(DDS::HANDLE_NIL)
 #endif
-    {}
+    {
+      TransportClient::set_guid(repo_id);
+    }
 
     virtual ~Endpoint();
 

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -258,7 +258,7 @@ public:
     return endpoint_manager().update_topic_qos(topicId, qos);
   }
 
-  GUID_t add_publication(
+  bool add_publication(
     const GUID_t& topicId,
     DCPS::DataWriterCallbacks_rch publication,
     const DDS::DataWriterQos& qos,
@@ -266,8 +266,7 @@ public:
     const DDS::PublisherQos& publisherQos,
     const XTypes::TypeInformation& type_info)
   {
-    return endpoint_manager().add_publication(topicId, publication, qos,
-                                              transInfo, publisherQos, type_info);
+    return endpoint_manager().add_publication(topicId, publication, qos, transInfo, publisherQos, type_info);
   }
 
   void remove_publication(const GUID_t& publicationId)
@@ -295,7 +294,7 @@ public:
     endpoint_manager().update_publication_locators(publicationId, transInfo);
   }
 
-  GUID_t add_subscription(
+  bool add_subscription(
     const GUID_t& topicId,
     DCPS::DataReaderCallbacks_rch subscription,
     const DDS::DataReaderQos& qos,
@@ -306,8 +305,15 @@ public:
     const DDS::StringSeq& params,
     const XTypes::TypeInformation& type_info)
   {
-    return endpoint_manager().add_subscription(topicId, subscription, qos, transInfo,
-      subscriberQos, filterClassName, filterExpr, params, type_info);
+    return endpoint_manager().add_subscription(topicId,
+                                               subscription,
+                                               qos,
+                                               transInfo,
+                                               subscriberQos,
+                                               filterClassName,
+                                               filterExpr,
+                                               params,
+                                               type_info);
   }
 
   void remove_subscription(const GUID_t& subscriptionId)

--- a/dds/DCPS/RecorderImpl.h
+++ b/dds/DCPS/RecorderImpl.h
@@ -72,7 +72,6 @@ public:
 
   // Implement TransportClient
   virtual bool check_transport_qos(const TransportInst& inst);
-  virtual GUID_t get_guid() const;
   DDS::DomainId_t domain_id() const { return this->domain_id_; }
   virtual CORBA::Long get_priority_value(const AssociationData& data) const;
 
@@ -84,8 +83,9 @@ public:
 
   // Implement DataReaderCallbacks
 
-  virtual void add_association(const GUID_t&            yourId,
-                               const WriterAssociation& writer,
+  virtual void set_subscription_id(const GUID_t& guid);
+
+  virtual void add_association(const WriterAssociation& writer,
                                bool                     active);
 
   virtual void remove_associations(const WriterIdSeq& writers,

--- a/dds/DCPS/ReplayerImpl.cpp
+++ b/dds/DCPS/ReplayerImpl.cpp
@@ -375,7 +375,7 @@ ReplayerImpl::enable()
   type_info.complete.typeid_with_size.typeobject_serialized_size = 0;
   type_info.complete.dependent_typeid_count = 0;
 
-  this->publication_id_ =
+  const bool success =
     disco->add_publication(this->domain_id_,
                            this->participant_servant_->get_id(),
                            this->topic_servant_->get_id(),
@@ -385,7 +385,7 @@ ReplayerImpl::enable()
                            this->publisher_qos_,
                            type_info);
 
-  if (this->publication_id_ == GUID_UNKNOWN) {
+  if (!success || this->publication_id_ == GUID_UNKNOWN) {
     ACE_ERROR((LM_ERROR,
                ACE_TEXT("(%P|%t) ERROR: ReplayerImpl::enable, ")
                ACE_TEXT("add_publication returned invalid id.\n")));
@@ -395,11 +395,17 @@ ReplayerImpl::enable()
   return DDS::RETCODE_OK;
 }
 
-
+void
+ReplayerImpl::set_publication_id(const GUID_t& guid)
+{
+  OPENDDS_ASSERT(publication_id_ == GUID_UNKNOWN);
+  OPENDDS_ASSERT(guid != GUID_UNKNOWN);
+  publication_id_ = guid;
+  TransportClient::set_guid(guid);
+}
 
 void
-ReplayerImpl::add_association(const GUID_t&            yourId,
-                              const ReaderAssociation& reader,
+ReplayerImpl::add_association(const ReaderAssociation& reader,
                               bool                     active)
 {
   DBG_ENTRY_LVL("ReplayerImpl", "add_association", 6);
@@ -409,7 +415,7 @@ ReplayerImpl::add_association(const GUID_t&            yourId,
                ACE_TEXT("(%P|%t) ReplayerImpl::add_association - ")
                ACE_TEXT("bit %d local %C remote %C\n"),
                is_bit_,
-               LogGuid(yourId).c_str(),
+               LogGuid(publication_id_).c_str(),
                LogGuid(reader.readerId).c_str()));
   }
 
@@ -421,10 +427,6 @@ ReplayerImpl::add_association(const GUID_t&            yourId,
   //
   //   return;
   // }
-
-  if (GUID_UNKNOWN == publication_id_) {
-    publication_id_ = yourId;
-  }
 
   {
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->lock_);
@@ -765,11 +767,6 @@ ReplayerImpl::check_transport_qos(const TransportInst&)
   // DataWriter does not impose any constraints on which transports
   // may be used based on QoS.
   return true;
-}
-
-GUID_t ReplayerImpl::get_guid() const
-{
-  return this->publication_id_;
 }
 
 CORBA::Long

--- a/dds/DCPS/ReplayerImpl.h
+++ b/dds/DCPS/ReplayerImpl.h
@@ -101,7 +101,6 @@ public:
 
   // Implement TransportClient
   virtual bool check_transport_qos(const TransportInst& inst);
-  virtual GUID_t get_guid() const;
   DDS::DomainId_t domain_id() const { return this->domain_id_; }
   virtual CORBA::Long get_priority_value(const AssociationData& data) const;
   SequenceNumber get_max_sn() const { return sequence_number_; }
@@ -128,8 +127,9 @@ public:
   virtual void retrieve_inline_qos_data(InlineQosData& qos_data) const;
 
   // implement DataWriterCallbacks
-  virtual void add_association(const GUID_t&            yourId,
-                               const ReaderAssociation& reader,
+  virtual void set_publication_id(const GUID_t& guid);
+
+  virtual void add_association(const ReaderAssociation& reader,
                                bool                     active);
 
   virtual void remove_associations(const ReaderIdSeq& readers,

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -332,7 +332,7 @@ StaticEndpointManager::add_publication_i(const GUID_t& writerid,
       {reader.trans_info, TransportLocator(), 0, readerid, reader.subscriber_qos, reader.qos, "", "", 0, 0, {0, 0}};
     DataWriterCallbacks_rch pl = pub.publication_.lock();
     if (pl) {
-      pl->add_association(writerid, ra, true);
+      pl->add_association(ra, true);
     }
   }
 
@@ -404,7 +404,7 @@ StaticEndpointManager::add_subscription_i(const GUID_t& readerid,
     };
     DataReaderCallbacks_rch sl = sub.subscription_.lock();
     if (sl) {
-      sl->add_association(readerid, wa, false);
+      sl->add_association(wa, false);
     }
   }
 
@@ -496,7 +496,7 @@ StaticEndpointManager::reader_exists(const GUID_t& readerid, const GUID_t& write
       const ReaderAssociation ra =
         {reader_pos->second.trans_info, TransportLocator(), 0, readerid, reader_pos->second.subscriber_qos, reader_pos->second.qos,
          "", "", DDS::StringSeq(), DDS::OctetSeq(), {0, 0}};
-      dwr->add_association(writerid, ra, true);
+      dwr->add_association(ra, true);
     }
   }
 }
@@ -531,7 +531,7 @@ StaticEndpointManager::writer_exists(const GUID_t& writerid, const GUID_t& reade
     if (drr) {
       const WriterAssociation wa =
         {writer_pos->second.trans_info, TransportLocator(), 0, writerid, writer_pos->second.publisher_qos, writer_pos->second.qos, DDS::OctetSeq(), {0,0}};
-      drr->add_association(readerid, wa, false);
+      drr->add_association(wa, false);
     }
   }
 }
@@ -757,18 +757,18 @@ TopicStatus StaticEndpointManager::remove_topic(const GUID_t& topicId)
   return REMOVED;
 }
 
-GUID_t StaticEndpointManager::add_publication(
-  const GUID_t& topicId,
-  DataWriterCallbacks_rch publication,
-  const DDS::DataWriterQos& qos,
-  const TransportLocatorSeq& transInfo,
-  const DDS::PublisherQos& publisherQos,
-  const XTypes::TypeInformation& type_info)
+bool StaticEndpointManager::add_publication(const GUID_t& topicId,
+                                            DataWriterCallbacks_rch publication,
+                                            const DDS::DataWriterQos& qos,
+                                            const TransportLocatorSeq& transInfo,
+                                            const DDS::PublisherQos& publisherQos,
+                                            const XTypes::TypeInformation& type_info)
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, GUID_t());
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, false);
 
   GUID_t rid = participant_id_;
   assign_publication_key(rid, topicId, qos);
+  publication->set_publication_id(rid);
   LocalPublication& pb = local_publications_[rid];
   pb.topic_id_ = topicId;
   pb.publication_ = publication;
@@ -782,11 +782,11 @@ GUID_t StaticEndpointManager::add_publication(
   td.add_local_publication(rid);
 
   if (DDS::RETCODE_OK != add_publication_i(rid, pb)) {
-    return GUID_t();
+    return false;
   }
 
   if (DDS::RETCODE_OK != write_publication_data(rid, pb)) {
-    return GUID_t();
+    return false;
   }
 
   if (DCPS_debug_level > 3) {
@@ -795,7 +795,7 @@ GUID_t StaticEndpointManager::add_publication(
   }
   match_endpoints(rid, td);
 
-  return rid;
+  return true;
 }
 
 void StaticEndpointManager::remove_publication(const GUID_t& publicationId)
@@ -836,21 +836,21 @@ void StaticEndpointManager::update_publication_locators(
   }
 }
 
-GUID_t StaticEndpointManager::add_subscription(
-  const GUID_t& topicId,
-  DataReaderCallbacks_rch subscription,
-  const DDS::DataReaderQos& qos,
-  const TransportLocatorSeq& transInfo,
-  const DDS::SubscriberQos& subscriberQos,
-  const char* filterClassName,
-  const char* filterExpr,
-  const DDS::StringSeq& params,
-  const XTypes::TypeInformation& type_info)
+bool StaticEndpointManager::add_subscription(const GUID_t& topicId,
+                                             DataReaderCallbacks_rch subscription,
+                                             const DDS::DataReaderQos& qos,
+                                             const TransportLocatorSeq& transInfo,
+                                             const DDS::SubscriberQos& subscriberQos,
+                                             const char* filterClassName,
+                                             const char* filterExpr,
+                                             const DDS::StringSeq& params,
+                                             const XTypes::TypeInformation& type_info)
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, GUID_t());
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, false);
 
   GUID_t rid = participant_id_;
   assign_subscription_key(rid, topicId, qos);
+  subscription->set_subscription_id(rid);
   LocalSubscription& sb = local_subscriptions_[rid];
   sb.topic_id_ = topicId;
   sb.subscription_ = subscription;
@@ -867,11 +867,11 @@ GUID_t StaticEndpointManager::add_subscription(
   td.add_local_subscription(rid);
 
   if (DDS::RETCODE_OK != add_subscription_i(rid, sb)) {
-    return GUID_t();
+    return false;
   }
 
   if (DDS::RETCODE_OK != write_subscription_data(rid, sb)) {
-    return GUID_t();
+    return false;
   }
 
   if (DCPS_debug_level > 3) {
@@ -880,7 +880,7 @@ GUID_t StaticEndpointManager::add_subscription(
   }
   match_endpoints(rid, td);
 
-  return rid;
+  return true;
 }
 
 void StaticEndpointManager::remove_subscription(const GUID_t& subscriptionId)
@@ -1382,11 +1382,11 @@ void StaticEndpointManager::match_continue(const GUID_t& writer, const GUID_t& r
           if (drr_lock) {
             DcpsUpcalls thr(drr_lock, reader, wa, !writer_active, dwr_lock);
             thr.activate();
-            dwr_lock->add_association(writer, ra, writer_active);
+            dwr_lock->add_association(ra, writer_active);
             thr.writer_done();
           }
         } else {
-          dwr_lock->add_association(writer, ra, writer_active);
+          dwr_lock->add_association(ra, writer_active);
         }
       }
     } else if (call_reader) {
@@ -1397,7 +1397,7 @@ void StaticEndpointManager::match_continue(const GUID_t& writer, const GUID_t& r
       }
       DataReaderCallbacks_rch drr_lock = drr.lock();
       if (drr_lock) {
-        drr_lock->add_association(reader, wa, !writer_active);
+        drr_lock->add_association(wa, !writer_active);
       }
     }
 
@@ -2957,7 +2957,7 @@ bool StaticDiscovery::update_topic_qos(const GUID_t& topicId, DDS::DomainId_t do
   return participants_[domainId][participantId]->update_topic_qos(topicId, qos);
 }
 
-GUID_t StaticDiscovery::add_publication(
+bool StaticDiscovery::add_publication(
   DDS::DomainId_t domainId,
   const GUID_t& participantId,
   const GUID_t& topicId,
@@ -2967,8 +2967,7 @@ GUID_t StaticDiscovery::add_publication(
   const DDS::PublisherQos& publisherQos,
   const XTypes::TypeInformation& type_info)
 {
-  return get_part(domainId, participantId)->add_publication(
-    topicId, publication, qos, transInfo, publisherQos, type_info);
+  return get_part(domainId, participantId)->add_publication(topicId, publication, qos, transInfo, publisherQos, type_info);
 }
 
 bool StaticDiscovery::remove_publication(
@@ -3003,7 +3002,7 @@ void StaticDiscovery::update_publication_locators(
   get_part(domainId, partId)->update_publication_locators(dwId, transInfo);
 }
 
-GUID_t StaticDiscovery::add_subscription(
+bool StaticDiscovery::add_subscription(
   DDS::DomainId_t domainId,
   const GUID_t& participantId,
   const GUID_t& topicId,
@@ -3016,9 +3015,15 @@ GUID_t StaticDiscovery::add_subscription(
   const DDS::StringSeq& params,
   const XTypes::TypeInformation& type_info)
 {
-  return get_part(domainId, participantId)->add_subscription(
-    topicId, subscription, qos, transInfo, subscriberQos, filterClassName,
-    filterExpr, params, type_info);
+  return get_part(domainId, participantId)->add_subscription(topicId,
+                                                             subscription,
+                                                             qos,
+                                                             transInfo,
+                                                             subscriberQos,
+                                                             filterClassName,
+                                                             filterExpr,
+                                                             params,
+                                                             type_info);
 }
 
 bool StaticDiscovery::remove_subscription(

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -379,25 +379,25 @@ public:
   TopicStatus remove_topic(const GUID_t& topicId);
 
 
-  GUID_t add_publication(const GUID_t& topicId,
-                         DataWriterCallbacks_rch publication,
-                         const DDS::DataWriterQos& qos,
-                         const TransportLocatorSeq& transInfo,
-                         const DDS::PublisherQos& publisherQos,
-                         const XTypes::TypeInformation& type_info);
+  bool add_publication(const GUID_t& topicId,
+                       DataWriterCallbacks_rch publication,
+                       const DDS::DataWriterQos& qos,
+                       const TransportLocatorSeq& transInfo,
+                       const DDS::PublisherQos& publisherQos,
+                       const XTypes::TypeInformation& type_info);
   void remove_publication(const GUID_t& publicationId);
   void update_publication_locators(const GUID_t& publicationId,
                                    const TransportLocatorSeq& transInfo);
 
-  GUID_t add_subscription(const GUID_t& topicId,
-                          DataReaderCallbacks_rch subscription,
-                          const DDS::DataReaderQos& qos,
-                          const TransportLocatorSeq& transInfo,
-                          const DDS::SubscriberQos& subscriberQos,
-                          const char* filterClassName,
-                          const char* filterExpr,
-                          const DDS::StringSeq& params,
-                          const XTypes::TypeInformation& type_info);
+  bool add_subscription(const GUID_t& topicId,
+                        DataReaderCallbacks_rch subscription,
+                        const DDS::DataReaderQos& qos,
+                        const TransportLocatorSeq& transInfo,
+                        const DDS::SubscriberQos& subscriberQos,
+                        const char* filterClassName,
+                        const char* filterExpr,
+                        const DDS::StringSeq& params,
+                        const XTypes::TypeInformation& type_info);
   void remove_subscription(const GUID_t& subscriptionId);
   void update_subscription_locators(const GUID_t& subscriptionId,
                                     const TransportLocatorSeq& transInfo);
@@ -541,15 +541,14 @@ public:
   bool update_topic_qos(const GUID_t& topicId, DDS::DomainId_t domainId,
     const GUID_t& participantId, const DDS::TopicQos& qos);
 
-  GUID_t add_publication(
-    DDS::DomainId_t domainId,
-    const GUID_t& participantId,
-    const GUID_t& topicId,
-    DCPS::DataWriterCallbacks_rch publication,
-    const DDS::DataWriterQos& qos,
-    const DCPS::TransportLocatorSeq& transInfo,
-    const DDS::PublisherQos& publisherQos,
-    const XTypes::TypeInformation& type_info);
+  bool add_publication(DDS::DomainId_t domainId,
+                       const GUID_t& participantId,
+                       const GUID_t& topicId,
+                       DCPS::DataWriterCallbacks_rch publication,
+                       const DDS::DataWriterQos& qos,
+                       const DCPS::TransportLocatorSeq& transInfo,
+                       const DDS::PublisherQos& publisherQos,
+                       const XTypes::TypeInformation& type_info);
 
   bool remove_publication(DDS::DomainId_t domainId, const GUID_t& participantId,
     const GUID_t& publicationId);
@@ -570,18 +569,17 @@ public:
     const GUID_t& dwId,
     const DCPS::TransportLocatorSeq& transInfo);
 
-  GUID_t add_subscription(
-    DDS::DomainId_t domainId,
-    const GUID_t& participantId,
-    const GUID_t& topicId,
-    DCPS::DataReaderCallbacks_rch subscription,
-    const DDS::DataReaderQos& qos,
-    const DCPS::TransportLocatorSeq& transInfo,
-    const DDS::SubscriberQos& subscriberQos,
-    const char* filterClassName,
-    const char* filterExpr,
-    const DDS::StringSeq& params,
-    const XTypes::TypeInformation& type_info);
+  bool add_subscription(DDS::DomainId_t domainId,
+                        const GUID_t& participantId,
+                        const GUID_t& topicId,
+                        DCPS::DataReaderCallbacks_rch subscription,
+                        const DDS::DataReaderQos& qos,
+                        const DCPS::TransportLocatorSeq& transInfo,
+                        const DDS::SubscriberQos& subscriberQos,
+                        const char* filterClassName,
+                        const char* filterExpr,
+                        const DDS::StringSeq& params,
+                        const XTypes::TypeInformation& type_info);
 
   bool remove_subscription(DDS::DomainId_t domainId, const GUID_t& participantId,
     const GUID_t& subscriptionId);
@@ -672,7 +670,7 @@ public:
     return endpoint_manager().update_topic_qos(topicId, qos);
   }
 
-  GUID_t add_publication(
+  bool add_publication(
     const GUID_t& topicId,
     DataWriterCallbacks_rch publication,
     const DDS::DataWriterQos& qos,
@@ -680,8 +678,7 @@ public:
     const DDS::PublisherQos& publisherQos,
     const XTypes::TypeInformation& type_info)
   {
-    return endpoint_manager().add_publication(topicId, publication, qos,
-                                              transInfo, publisherQos, type_info);
+    return endpoint_manager().add_publication(topicId, publication, qos, transInfo, publisherQos, type_info);
   }
 
   void remove_publication(const GUID_t& publicationId)
@@ -709,19 +706,18 @@ public:
     endpoint_manager().update_publication_locators(publicationId, transInfo);
   }
 
-  GUID_t add_subscription(
-    const GUID_t& topicId,
-    DataReaderCallbacks_rch subscription,
-    const DDS::DataReaderQos& qos,
-    const TransportLocatorSeq& transInfo,
-    const DDS::SubscriberQos& subscriberQos,
-    const char* filterClassName,
-    const char* filterExpr,
-    const DDS::StringSeq& params,
-    const XTypes::TypeInformation& type_info)
+  bool add_subscription(const GUID_t& topicId,
+                        DataReaderCallbacks_rch subscription,
+                        const DDS::DataReaderQos& qos,
+                        const TransportLocatorSeq& transInfo,
+                        const DDS::SubscriberQos& subscriberQos,
+                        const char* filterClassName,
+                        const char* filterExpr,
+                        const DDS::StringSeq& params,
+                        const XTypes::TypeInformation& type_info)
   {
     return endpoint_manager().add_subscription(topicId, subscription, qos, transInfo,
-      subscriberQos, filterClassName, filterExpr, params, type_info);
+                                               subscriberQos, filterClassName, filterExpr, params, type_info);
   }
 
   void remove_subscription(const GUID_t& subscriptionId)
@@ -932,15 +928,14 @@ public:
   bool update_topic_qos(const GUID_t& topicId, DDS::DomainId_t domainId,
     const GUID_t& participantId, const DDS::TopicQos& qos);
 
-  GUID_t add_publication(
-    DDS::DomainId_t domainId,
-    const GUID_t& participantId,
-    const GUID_t& topicId,
-    DCPS::DataWriterCallbacks_rch publication,
-    const DDS::DataWriterQos& qos,
-    const DCPS::TransportLocatorSeq& transInfo,
-    const DDS::PublisherQos& publisherQos,
-    const XTypes::TypeInformation& type_info);
+  bool add_publication(DDS::DomainId_t domainId,
+                       const GUID_t& participantId,
+                       const GUID_t& topicId,
+                       DCPS::DataWriterCallbacks_rch publication,
+                       const DDS::DataWriterQos& qos,
+                       const DCPS::TransportLocatorSeq& transInfo,
+                       const DDS::PublisherQos& publisherQos,
+                       const XTypes::TypeInformation& type_info);
 
   bool remove_publication(DDS::DomainId_t domainId, const GUID_t& participantId,
     const GUID_t& publicationId);
@@ -961,18 +956,17 @@ public:
     const GUID_t& dwId,
     const DCPS::TransportLocatorSeq& transInfo);
 
-  GUID_t add_subscription(
-    DDS::DomainId_t domainId,
-    const GUID_t& participantId,
-    const GUID_t& topicId,
-    DCPS::DataReaderCallbacks_rch subscription,
-    const DDS::DataReaderQos& qos,
-    const DCPS::TransportLocatorSeq& transInfo,
-    const DDS::SubscriberQos& subscriberQos,
-    const char* filterClassName,
-    const char* filterExpr,
-    const DDS::StringSeq& params,
-    const XTypes::TypeInformation& type_info);
+  bool add_subscription(DDS::DomainId_t domainId,
+                        const GUID_t& participantId,
+                        const GUID_t& topicId,
+                        DCPS::DataReaderCallbacks_rch subscription,
+                        const DDS::DataReaderQos& qos,
+                        const DCPS::TransportLocatorSeq& transInfo,
+                        const DDS::SubscriberQos& subscriberQos,
+                        const char* filterClassName,
+                        const char* filterExpr,
+                        const DDS::StringSeq& params,
+                        const XTypes::TypeInformation& type_info);
 
   bool remove_subscription(DDS::DomainId_t domainId, const GUID_t& participantId,
     const GUID_t& subscriptionId);

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -370,7 +370,7 @@ SubscriberImpl::delete_datareader(::DDS::DataReader_ptr a_datareader)
     this->monitor_->report();
   }
 
-  const GUID_t subscription_id = dr_servant->get_guid();
+  const GUID_t subscription_id = dr_servant->subscription_id();
   Discovery_rch disco = TheServiceParticipant->get_discovery(this->domain_id_);
   if (!disco->remove_subscription(this->domain_id_,
                                   this->dp_id_,

--- a/dds/DCPS/security/AccessControlBuiltInImpl.cpp
+++ b/dds/DCPS/security/AccessControlBuiltInImpl.cpp
@@ -1502,6 +1502,7 @@ bool AccessControlBuiltInImpl::search_permissions(
   if (grant.default_permission == Permissions::ALLOW) {
     return true;
   } else {
+    ACE_DEBUG((LM_DEBUG, "### badness\n"));
     return CommonUtilities::set_security_error(ex, -1, 0, "AccessControlBuiltInImpl: No matching rule for topic, default permission is DENY.");
   }
 }

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -21,6 +21,7 @@
 #include <dds/DCPS/DiscoveryListener.h>
 #include <dds/DCPS/RcEventHandler.h>
 #include <dds/DCPS/BuiltInTopicUtils.h>
+#include <dds/DCPS/GuidUtils.h>
 
 #include <ace/Time_Value.h>
 #include <ace/Event_Handler.h>
@@ -128,7 +129,6 @@ public:
   bool remove_all_msgs();
 
   virtual void add_link(const DataLink_rch& link, const GUID_t& peer);
-  virtual GUID_t get_guid() const = 0;
   virtual RcHandle<BitSubscriber> get_builtin_subscriber_proxy() const { return RcHandle<BitSubscriber>(); }
 
   void terminate_send_if_suspended();
@@ -136,10 +136,17 @@ public:
   bool associated_with(const GUID_t& remote) const;
   bool pending_association_with(const GUID_t& remote) const;
 
-  GUID_t repo_id() const
+  void set_guid(const GUID_t& guid)
   {
-    ACE_Guard<ACE_Thread_Mutex> guard(lock_);
-    return repo_id_;
+    OPENDDS_ASSERT(guid_ == GUID_UNKNOWN);
+    OPENDDS_ASSERT(guid != GUID_UNKNOWN);
+    guid_ = guid;
+  }
+
+  GUID_t get_guid() const
+  {
+    OPENDDS_ASSERT(guid_ != GUID_UNKNOWN);
+    return guid_;
   }
 
   void data_acked(const GUID_t& remote);
@@ -348,7 +355,7 @@ private:
 
   Reverse_Lock_t reverse_lock_;
 
-  GUID_t repo_id_;
+  GUID_t guid_;
 };
 
 typedef RcHandle<TransportClient> TransportClient_rch;

--- a/dds/InfoRepo/DCPSInfo_i.h
+++ b/dds/InfoRepo/DCPSInfo_i.h
@@ -114,15 +114,19 @@ public:
     const OpenDDS::DCPS::GUID_t& participantId,
     const OpenDDS::DCPS::GUID_t& topicId);
 
-  virtual OpenDDS::DCPS::GUID_t add_publication(
-    DDS::DomainId_t domainId,
-    const OpenDDS::DCPS::GUID_t& participantId,
-    const OpenDDS::DCPS::GUID_t& topicId,
-    OpenDDS::DCPS::DataWriterRemote_ptr publication,
-    const DDS::DataWriterQos & qos,
-    const OpenDDS::DCPS::TransportLocatorSeq & transInfo,
-    const DDS::PublisherQos & publisherQos,
-    const DDS::OctetSeq & serializedTypeInfo);
+  virtual OpenDDS::DCPS::GUID_t reserve_publication_id(DDS::DomainId_t domainId,
+                                                       const OpenDDS::DCPS::GUID_t& participantId,
+                                                       const OpenDDS::DCPS::GUID_t& topicId);
+
+  virtual bool add_publication(DDS::DomainId_t domainId,
+                               const OpenDDS::DCPS::GUID_t& participantId,
+                               const OpenDDS::DCPS::GUID_t& topicId,
+                               const OpenDDS::DCPS::GUID_t& pubId,
+                               OpenDDS::DCPS::DataWriterRemote_ptr publication,
+                               const DDS::DataWriterQos & qos,
+                               const OpenDDS::DCPS::TransportLocatorSeq & transInfo,
+                               const DDS::PublisherQos & publisherQos,
+                               const DDS::OctetSeq & serializedTypeInfo);
 
   /**
    * @brief Add a previously existing publication to the repository.
@@ -162,18 +166,22 @@ public:
     const OpenDDS::DCPS::GUID_t& participantId,
     const OpenDDS::DCPS::GUID_t& publicationId);
 
-  virtual OpenDDS::DCPS::GUID_t add_subscription(
-    DDS::DomainId_t domainId,
-    const OpenDDS::DCPS::GUID_t& participantId,
-    const OpenDDS::DCPS::GUID_t& topicId,
-    OpenDDS::DCPS::DataReaderRemote_ptr subscription,
-    const DDS::DataReaderQos & qos,
-    const OpenDDS::DCPS::TransportLocatorSeq & transInfo,
-    const DDS::SubscriberQos & subscriberQos,
-    const char* filterClassName,
-    const char* filterExpression,
-    const DDS::StringSeq& exprParams,
-    const DDS::OctetSeq & serializedTypeInfo);
+  virtual OpenDDS::DCPS::GUID_t reserve_subscription_id(DDS::DomainId_t domainId,
+                                                        const OpenDDS::DCPS::GUID_t& participantId,
+                                                        const OpenDDS::DCPS::GUID_t& topicId);
+
+  virtual bool add_subscription(DDS::DomainId_t domainId,
+                                const OpenDDS::DCPS::GUID_t& participantId,
+                                const OpenDDS::DCPS::GUID_t& topicId,
+                                const OpenDDS::DCPS::GUID_t& subId,
+                                OpenDDS::DCPS::DataReaderRemote_ptr subscription,
+                                const DDS::DataReaderQos & qos,
+                                const OpenDDS::DCPS::TransportLocatorSeq & transInfo,
+                                const DDS::SubscriberQos & subscriberQos,
+                                const char* filterClassName,
+                                const char* filterExpression,
+                                const DDS::StringSeq& exprParams,
+                                const DDS::OctetSeq & serializedTypeInfo);
 
   /**
    * @brief Add a previously existing subscription to the repository.

--- a/dds/InfoRepo/DCPS_IR_Publication.cpp
+++ b/dds/InfoRepo/DCPS_IR_Publication.cpp
@@ -85,7 +85,7 @@ int DCPS_IR_Publication::add_associated_subscription(DCPS_IR_Subscription* sub,
                      std::string(sub_converter).c_str()));
         }
 
-        writer_->add_association(id_, association, active);
+        writer_->add_association(association, active);
 
         if (OpenDDS::DCPS::DCPS_debug_level > 0) {
           ACE_DEBUG((LM_DEBUG,

--- a/dds/InfoRepo/DCPS_IR_Subscription.cpp
+++ b/dds/InfoRepo/DCPS_IR_Subscription.cpp
@@ -86,7 +86,7 @@ int DCPS_IR_Subscription::add_associated_publication(DCPS_IR_Publication* pub,
                      std::string(pub_converter).c_str()));
         }
 
-        reader_->add_association(id_, association, active);
+        reader_->add_association(association, active);
 
         if (OpenDDS::DCPS::DCPS_debug_level > 0) {
           ACE_DEBUG((LM_DEBUG,

--- a/tests/DCPS/DCPSInfoRepo/DCPSDataReaderI.cpp
+++ b/tests/DCPS/DCPSInfoRepo/DCPSDataReaderI.cpp
@@ -5,10 +5,10 @@
 #include "dds/DCPS/RepoIdConverter.h"
 
 TAO_DDS_DCPSDataReader_i::TAO_DDS_DCPSDataReader_i (void)
-  :
-  disco_(0),
-  domainId_(0),
-  participantId_(OpenDDS::DCPS::GUID_UNKNOWN)
+  : disco_(0)
+  , domainId_(0)
+  , participantId_(OpenDDS::DCPS::GUID_UNKNOWN)
+  , guid_(OpenDDS::DCPS::GUID_UNKNOWN)
 {
 }
 
@@ -17,11 +17,10 @@ TAO_DDS_DCPSDataReader_i::~TAO_DDS_DCPSDataReader_i (void)
 }
 
 void TAO_DDS_DCPSDataReader_i::add_association (
-    const ::OpenDDS::DCPS::GUID_t& yourId,
     const OpenDDS::DCPS::WriterAssociation& writer,
     bool /*active*/)
 {
-  OpenDDS::DCPS::RepoIdConverter converterY(yourId);
+  OpenDDS::DCPS::RepoIdConverter converterY(guid_);
   ACE_DEBUG((LM_DEBUG,
     ACE_TEXT("\nTAO_DDS_DCPSDataReader_i::add_associations () :\n")
     ACE_TEXT("\tReader %C Adding association to writer:\n"),

--- a/tests/DCPS/DCPSInfoRepo/DCPSDataReaderI.h
+++ b/tests/DCPS/DCPSInfoRepo/DCPSDataReaderI.h
@@ -31,8 +31,12 @@ public:
   virtual ::DDS::ReturnCode_t enable_specific ()
     { received_.received(DiscReceivedCalls::ENABLE_SPECIFIC); return ::DDS::RETCODE_OK;};
 
+  virtual void set_subscription_id(const OpenDDS::DCPS::GUID_t& guid)
+  {
+    guid_ = guid;
+  }
+
   virtual void add_association (
-      const ::OpenDDS::DCPS::GUID_t& yourId,
       const OpenDDS::DCPS::WriterAssociation& writer,
       bool active);
 
@@ -55,8 +59,11 @@ public:
 
   OpenDDS::DCPS::WeakRcHandle<OpenDDS::ICE::Endpoint> get_ice_endpoint() { return OpenDDS::DCPS::WeakRcHandle<OpenDDS::ICE::Endpoint>(); }
 
+  const ::OpenDDS::DCPS::GUID_t& guid() const { return guid_; }
+
 private:
   DiscReceivedCalls received_;
+  ::OpenDDS::DCPS::GUID_t guid_;
 };
 
 

--- a/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.cpp
+++ b/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.cpp
@@ -5,6 +5,7 @@
 #include <dds/DCPS/RepoIdConverter.h>
 
 TAO_DDS_DCPSDataWriter_i::TAO_DDS_DCPSDataWriter_i (void)
+  : guid_(OpenDDS::DCPS::GUID_UNKNOWN)
   {
   }
 
@@ -13,13 +14,12 @@ TAO_DDS_DCPSDataWriter_i::~TAO_DDS_DCPSDataWriter_i (void)
   }
 
 void TAO_DDS_DCPSDataWriter_i::add_association (
-    const ::OpenDDS::DCPS::GUID_t& yourId,
     const OpenDDS::DCPS::ReaderAssociation& reader,
     bool /*active*/
   )
   {
 
-    OpenDDS::DCPS::RepoIdConverter converterY(yourId);
+    OpenDDS::DCPS::RepoIdConverter converterY(guid_);
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("\nTAO_DDS_DCPSDataWriter_i::add_associations () :\n")
                ACE_TEXT("\tWriter %C Adding association to a reader:\n"),

--- a/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.h
+++ b/tests/DCPS/DCPSInfoRepo/DCPSDataWriterI.h
@@ -27,8 +27,12 @@ public:
   virtual ::DDS::ReturnCode_t enable_specific ()
       { received_.received(DiscReceivedCalls::ENABLE_SPECIFIC); return ::DDS::RETCODE_OK;};
 
+  virtual void set_publication_id(const OpenDDS::DCPS::GUID_t& guid)
+  {
+    guid_ = guid;
+  }
+
   virtual void add_association (
-      const ::OpenDDS::DCPS::GUID_t& yourId,
       const OpenDDS::DCPS::ReaderAssociation& reader,
       bool active);
 
@@ -49,8 +53,11 @@ public:
 
   OpenDDS::DCPS::WeakRcHandle<OpenDDS::ICE::Endpoint> get_ice_endpoint() { return OpenDDS::DCPS::WeakRcHandle<OpenDDS::ICE::Endpoint>(); }
 
+  const OpenDDS::DCPS::GUID_t& guid() const { return guid_; }
+
 private:
   DiscReceivedCalls received_;
+  OpenDDS::DCPS::GUID_t guid_;
 };
 
 

--- a/tests/DCPS/DCPSInfoRepo/pubsub.cpp
+++ b/tests/DCPS/DCPSInfoRepo/pubsub.cpp
@@ -91,7 +91,6 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
 
   OpenDDS::DCPS::GUID_t pubPartId = OpenDDS::DCPS::GUID_UNKNOWN;
   OpenDDS::DCPS::GUID_t pubTopicId = OpenDDS::DCPS::GUID_UNKNOWN;
-  OpenDDS::DCPS::GUID_t pubId = OpenDDS::DCPS::GUID_UNKNOWN;
   OpenDDS::DCPS::RcHandle<TAO_DDS_DCPSDataWriter_i> dwImpl(OpenDDS::DCPS::make_rch<TAO_DDS_DCPSDataWriter_i>());
 
   DDS::DomainParticipantFactory_var dpf = TheServiceParticipant->get_domain_participant_factory();
@@ -219,15 +218,15 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
 
   ::DDS::PublisherQos_var pQos = new ::DDS::PublisherQos;
   *pQos = TheServiceParticipant->initial_PublisherQos();
-  pubId = disc->add_publication(domain,
-                                pubPartId,
-                                pubTopicId,
-                                rchandle_from(dwImpl.in()),
-                                dwQos.in(),
-                                tii,
-                                pQos.in(),
-                                type_info);
-  if (OpenDDS::DCPS::GUID_UNKNOWN == pubId)
+  disc->add_publication(domain,
+                        pubPartId,
+                        pubTopicId,
+                        rchandle_from(dwImpl.in()),
+                        dwQos.in(),
+                        tii,
+                        pQos.in(),
+                        type_info);
+  if (OpenDDS::DCPS::GUID_UNKNOWN == dwImpl->guid())
     {
       failed = true;
       ACE_ERROR((LM_ERROR, ACE_TEXT("ERROR: add_publication failed!\n") ));
@@ -268,7 +267,6 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
 
   OpenDDS::DCPS::GUID_t subPartId = OpenDDS::DCPS::GUID_UNKNOWN;
   OpenDDS::DCPS::GUID_t subTopicId = OpenDDS::DCPS::GUID_UNKNOWN;
-  OpenDDS::DCPS::GUID_t subId = OpenDDS::DCPS::GUID_UNKNOWN;
   TAO_DDS_DCPSDataReader_i drImpl;
   if (use_rtps)
     drImpl.disco_ = disc.in();
@@ -337,16 +335,16 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
   type_info.minimal.dependent_typeid_count = 0;
   type_info.complete.dependent_typeid_count = 0;
 
-  subId = disc->add_subscription(domain,
-                                 subPartId,
-                                 subTopicId,
-                                 rchandle_from(&drImpl),
-                                 drQos.in(),
-                                 tii,
-                                 subQos.in(),
-                                 "", "", DDS::StringSeq(),
-                                 type_info);
-  if( OpenDDS::DCPS::GUID_UNKNOWN == subId)
+  disc->add_subscription(domain,
+                         subPartId,
+                         subTopicId,
+                         rchandle_from(&drImpl),
+                         drQos.in(),
+                         tii,
+                         subQos.in(),
+                         "", "", DDS::StringSeq(),
+                         type_info);
+  if( OpenDDS::DCPS::GUID_UNKNOWN == drImpl.guid())
     {
       failed = true;
       ACE_ERROR((LM_ERROR, ACE_TEXT("ERROR: add_subscription failed!\n") ));
@@ -371,7 +369,6 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
 
 
   // incompatible QOS
-  OpenDDS::DCPS::GUID_t pubIncQosId = OpenDDS::DCPS::GUID_UNKNOWN;
   TAO_DDS_DCPSDataWriter_i dwIncQosImpl;
 
   // Add publication
@@ -393,15 +390,15 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
   type_info.minimal.dependent_typeid_count = 0;
   type_info.complete.dependent_typeid_count = 0;
 
-  pubIncQosId = disc->add_publication(domain,
-                                pubPartId,
-                                pubTopicId,
-                                rchandle_from(&dwIncQosImpl),
-                                dwIncQosQos.in(),
-                                tii,
-                                pQos.in(),
-                                type_info);
-  if (OpenDDS::DCPS::GUID_UNKNOWN == pubIncQosId)
+  disc->add_publication(domain,
+                        pubPartId,
+                        pubTopicId,
+                        rchandle_from(&dwIncQosImpl),
+                        dwIncQosQos.in(),
+                        tii,
+                        pQos.in(),
+                        type_info);
+  if (OpenDDS::DCPS::GUID_UNKNOWN == dwIncQosImpl.guid())
     {
       failed = true;
       ACE_ERROR((LM_ERROR, ACE_TEXT("ERROR: add_publication failed!\n") ));
@@ -420,9 +417,9 @@ bool pubsub(OpenDDS::DCPS::Discovery_rch disc, CORBA::ORB_var orb)
       failed = true;
     }
 
-  disc->remove_publication(domain, pubPartId, pubIncQosId);
-  disc->remove_subscription(domain, subPartId, subId);
-  disc->remove_publication(domain, pubPartId, pubId);
+  disc->remove_publication(domain, pubPartId, dwIncQosImpl.guid());
+  disc->remove_subscription(domain, subPartId, drImpl.guid());
+  disc->remove_publication(domain, pubPartId, dwImpl->guid());
   disc->remove_topic(domain, pubPartId, pubTopicId);
   disc->remove_topic(domain, subPartId, subTopicId);
   disc->remove_domain_participant(domain, subPartId);

--- a/tests/DCPS/FindTopic/LocalDiscovery.cpp
+++ b/tests/DCPS/FindTopic/LocalDiscovery.cpp
@@ -165,11 +165,11 @@ bool LocalDiscovery::update_topic_qos(
   return true;
 }
 
-GUID_t LocalDiscovery::add_publication(
+bool LocalDiscovery::add_publication(
   DDS::DomainId_t,
   const GUID_t&,
   const GUID_t&,
-  DataWriterCallbacks_rch,
+  DataWriterCallbacks_rch writer,
   const DDS::DataWriterQos&,
   const TransportLocatorSeq&,
   const DDS::PublisherQos&,
@@ -178,7 +178,8 @@ GUID_t LocalDiscovery::add_publication(
   GUID_t guid = GUID_UNKNOWN;
   guid.guidPrefix[0] = 1;
   guid.entityId.entityKind = ENTITYKIND_USER_WRITER_WITH_KEY;
-  return guid;
+  writer->set_publication_id(guid);
+  return true;
 }
 
 bool LocalDiscovery::remove_publication(
@@ -207,7 +208,7 @@ bool LocalDiscovery::update_publication_qos(
   return true;
 }
 
-GUID_t LocalDiscovery::add_subscription(
+bool LocalDiscovery::add_subscription(
   DDS::DomainId_t,
   const GUID_t&,
   const GUID_t&,
@@ -220,7 +221,7 @@ GUID_t LocalDiscovery::add_subscription(
   const DDS::StringSeq&,
   const OpenDDS::XTypes::TypeInformation&)
 {
-  return GUID_UNKNOWN;
+  return true;
 }
 
 bool LocalDiscovery::remove_subscription(

--- a/tests/DCPS/FindTopic/LocalDiscovery.h
+++ b/tests/DCPS/FindTopic/LocalDiscovery.h
@@ -104,7 +104,7 @@ private:
     const GUID_t& participantId,
     const DDS::TopicQos& qos);
 
-  GUID_t add_publication(
+  bool add_publication(
     DDS::DomainId_t domainId,
     const GUID_t& participantId,
     const GUID_t& topicId,
@@ -131,7 +131,7 @@ private:
     const DDS::DataWriterQos& qos,
     const DDS::PublisherQos& publisherQos);
 
-  GUID_t add_subscription(
+  bool add_subscription(
     DDS::DomainId_t domainId,
     const GUID_t& participantId,
     const GUID_t& topicId,

--- a/tests/DCPS/WriteDataContainer/WriteDataContainerTest.cpp
+++ b/tests/DCPS/WriteDataContainer/WriteDataContainerTest.cpp
@@ -373,6 +373,8 @@ int run_test(int argc, ACE_TCHAR *argv[])
         dw_qos.resource_limits.max_samples = MAX_SAMPLES;
 
         OpenDDS::DCPS::unique_ptr<Test::SimpleDataWriterImpl> fast_dw(new Test::SimpleDataWriterImpl());
+        GuidBuilder builder;
+        fast_dw->set_publication_id(builder.create());
         fast_dw->set_qos(dw_qos);
         test->setup_serialization(fast_dw.get());
         test->substitute_dw_particpant(fast_dw.get(), tpi);
@@ -492,6 +494,8 @@ int run_test(int argc, ACE_TCHAR *argv[])
         dw_qos.resource_limits.max_samples = 2;
 
         OpenDDS::DCPS::unique_ptr<Test::SimpleDataWriterImpl> fast_dw(new Test::SimpleDataWriterImpl());
+        GuidBuilder builder;
+        fast_dw->set_publication_id(builder.create());
         fast_dw->set_qos(dw_qos);
         test->setup_serialization(fast_dw.get());
         test->substitute_dw_particpant(fast_dw.get(), tpi);
@@ -625,6 +629,8 @@ int run_test(int argc, ACE_TCHAR *argv[])
         dw_qos.reliability.max_blocking_time.nanosec = MAX_BLOCKING_TIME_NANO;
 
         OpenDDS::DCPS::unique_ptr<Test::SimpleDataWriterImpl> fast_dw(new Test::SimpleDataWriterImpl());
+        GuidBuilder builder;
+        fast_dw->set_publication_id(builder.create());
         fast_dw->set_qos(dw_qos);
         test->setup_serialization(fast_dw.get());
         test->substitute_dw_particpant(fast_dw.get(), tpi);
@@ -762,6 +768,8 @@ int run_test(int argc, ACE_TCHAR *argv[])
         dw_qos.resource_limits.max_samples_per_instance = MAX_SAMPLES_PER_INSTANCE;
 
         OpenDDS::DCPS::unique_ptr<Test::SimpleDataWriterImpl> fast_dw(new Test::SimpleDataWriterImpl());
+        GuidBuilder builder;
+        fast_dw->set_publication_id(builder.create());
         fast_dw->set_qos(dw_qos);
         test->setup_serialization(fast_dw.get());
         test->substitute_dw_particpant(fast_dw.get(), tpi);

--- a/tests/transport/best_effort_reader/SimpleDataReader.cpp
+++ b/tests/transport/best_effort_reader/SimpleDataReader.cpp
@@ -22,6 +22,8 @@ using namespace OpenDDS::DCPS;
 SimpleDataReader::SimpleDataReader(const AppConfig& ac, const int readerIndex, AssociationData& ad)
   : config(ac), index(readerIndex), done_(false)
 {
+  TransportClient::set_guid(AppConfig::readerId[index]);
+
   enable_transport((index == 2), false); //(reliable, durable)
 
   for (int i = index; i < 3; ++i) {

--- a/tests/transport/rtps/publisher.cpp
+++ b/tests/transport/rtps/publisher.cpp
@@ -94,6 +94,7 @@ public:
     , callbacks_expected_(0)
     , inline_qos_mode_(DEFAULT_QOS)
   {
+    TransportClient::set_guid(pub_id_);
   }
 
   virtual ~SimpleDataWriter() {}

--- a/tests/transport/rtps/subscriber.cpp
+++ b/tests/transport/rtps/subscriber.cpp
@@ -46,7 +46,9 @@ public:
     , pub_id_(GUID_UNKNOWN)
     , seq_(SequenceNumber::ZERO())
     , control_msg_count_(0)
-  {}
+  {
+    TransportClient::set_guid(sub_id_);
+  }
 
   virtual ~SimpleDataReader() {}
 

--- a/tests/transport/rtps_directed_write/subscriber.cpp
+++ b/tests/transport/rtps_directed_write/subscriber.cpp
@@ -37,6 +37,8 @@ public:
   SimpleDataReader(const AppConfig& ac, const int readerIndex, AssociationData& publication)
     : config(ac), index(readerIndex), done_(false), seq_()
   {
+    TransportClient::set_guid(config.getSubRdrId(index));
+
     enable_transport(config.readersReliable(), false); //(reliable, durable)
 
     if (index == 1) {

--- a/tests/transport/rtps_reliability/rtps_reliability.cpp
+++ b/tests/transport/rtps_reliability/rtps_reliability.cpp
@@ -46,7 +46,10 @@ const Encoding encoding(Encoding::KIND_XCDR1, OpenDDS::DCPS::ENDIAN_LITTLE);
 const Encoding& blob_encoding = get_locators_encoding();
 
 struct SimpleTC: TransportClient {
-  explicit SimpleTC(const GUID_t& local) : local_id_(local), mutex_(), cond_(mutex_) {}
+  explicit SimpleTC(const GUID_t& local) : local_id_(local), mutex_(), cond_(mutex_)
+  {
+    TransportClient::set_guid(local_id_);
+  }
 
   void transport_assoc_done(int flags, const GUID_t& remote) {
     if (!(flags & ASSOC_OK)) {

--- a/tests/transport/simple/PubDriver.cpp
+++ b/tests/transport/simple/PubDriver.cpp
@@ -23,7 +23,6 @@
 PubDriver::PubDriver()
   : pub_id_(OpenDDS::DCPS::GuidBuilder::create())
   , sub_id_(OpenDDS::DCPS::GuidBuilder::create())
-  , writer_(pub_id_)
   , num_msgs_(1)
   , msg_size_(0)
   , shmem_(false)
@@ -364,6 +363,8 @@ PubDriver::parse_pub_arg(const ACE_TString& arg)
   builder.participantId(1);
   builder.entityKey(ACE_OS::atoi(pub_id_str.c_str()));
   builder.entityKind(OpenDDS::DCPS::ENTITYKIND_USER_WRITER_WITH_KEY);
+
+  writer_.set_guid(pub_id_);
 
   this->pub_addr_ = ACE_INET_Addr(this->pub_addr_str_.c_str());
 

--- a/tests/transport/simple/SimpleDataReader.cpp
+++ b/tests/transport/simple/SimpleDataReader.cpp
@@ -12,9 +12,8 @@
 
 #include "TestException.h"
 
-SimpleDataReader::SimpleDataReader(const OpenDDS::DCPS::GUID_t& sub_id)
-  : sub_id_(sub_id)
-  , num_messages_expected_(0)
+SimpleDataReader::SimpleDataReader()
+  : num_messages_expected_(0)
   , num_messages_received_(0)
 {
   DBG_ENTRY("SimpleDataReader","SimpleDataReader");

--- a/tests/transport/simple/SimpleDataReader.h
+++ b/tests/transport/simple/SimpleDataReader.h
@@ -14,7 +14,7 @@ class SimpleDataReader
 {
   public:
 
-    explicit SimpleDataReader(const OpenDDS::DCPS::GUID_t& sub_id);
+    SimpleDataReader();
     virtual ~SimpleDataReader();
 
     void init(const OpenDDS::DCPS::AssociationData& publication, int num_msgs);
@@ -31,8 +31,6 @@ class SimpleDataReader
     // Implementing TransportClient
     bool check_transport_qos(const OpenDDS::DCPS::TransportInst&)
       { return true; }
-    OpenDDS::DCPS::GUID_t get_guid() const
-      { return sub_id_; }
     DDS::DomainId_t domain_id() const
       { return 0; }
     CORBA::Long get_priority_value(const OpenDDS::DCPS::AssociationData&) const
@@ -55,7 +53,6 @@ class SimpleDataReader
   private:
 
     mutable ACE_Thread_Mutex mutex_;
-    const OpenDDS::DCPS::GUID_t& sub_id_;
     int num_messages_expected_;
     int num_messages_received_;
     ACE_Time_Value begin_recvd_;

--- a/tests/transport/simple/SimpleDataWriter.cpp
+++ b/tests/transport/simple/SimpleDataWriter.cpp
@@ -18,9 +18,8 @@
 
 #include <sstream>
 
-SimpleDataWriter::SimpleDataWriter(const OpenDDS::DCPS::GUID_t& pub_id)
-  : pub_id_(pub_id)
-  , num_messages_sent_(0)
+SimpleDataWriter::SimpleDataWriter()
+  : num_messages_sent_(0)
   , num_messages_delivered_(0)
   , associated_(false)
 {
@@ -141,8 +140,7 @@ SimpleDataWriter::delivered_test_message()
 }
 
 
-DDS_TEST::DDS_TEST(const OpenDDS::DCPS::GUID_t& pub_id)
-  : SimpleDataWriter(pub_id)
+DDS_TEST::DDS_TEST()
 {
 }
 
@@ -177,7 +175,7 @@ DDS_TEST::run(int num_messages, int msg_size)
 
   // The +1 makes the null terminator ('\0') get placed into the block.
   header.message_id_ = 1;
-  header.publication_id_ = this->pub_id_;
+  header.publication_id_ = this->get_guid();
 
   OpenDDS::DCPS::DataSampleElement* prev_element = 0;
 
@@ -220,8 +218,8 @@ DDS_TEST::run(int num_messages, int msg_size)
     OpenDDS::DCPS::DataSampleElement* element;
 
     ACE_NEW_MALLOC_RETURN(element,
-      static_cast<OpenDDS::DCPS::DataSampleElement*>(allocator.malloc(sizeof (OpenDDS::DCPS::DataSampleElement))),
-      OpenDDS::DCPS::DataSampleElement(this->pub_id_, this, OpenDDS::DCPS::PublicationInstance_rch()), 1);
+                          static_cast<OpenDDS::DCPS::DataSampleElement*>(allocator.malloc(sizeof (OpenDDS::DCPS::DataSampleElement))),
+                          OpenDDS::DCPS::DataSampleElement(this->get_guid(), this, OpenDDS::DCPS::PublicationInstance_rch()), 1);
 
     // The Sample Element will hold on to the chain of blocks (header + data).
     element->sample_.reset(header_block.release());

--- a/tests/transport/simple/SimpleDataWriter.h
+++ b/tests/transport/simple/SimpleDataWriter.h
@@ -17,7 +17,7 @@ class SimpleDataWriter
 {
   public:
 
-    explicit SimpleDataWriter(const OpenDDS::DCPS::GUID_t& pub_id);
+    SimpleDataWriter();
     virtual ~SimpleDataWriter();
 
     void init(const OpenDDS::DCPS::AssociationData& subscription);
@@ -51,8 +51,6 @@ class SimpleDataWriter
     // Implementing TransportClient
     bool check_transport_qos(const OpenDDS::DCPS::TransportInst&)
       { return true; }
-    OpenDDS::DCPS::GUID_t get_guid() const
-      { return pub_id_; }
     DDS::DomainId_t domain_id() const
       { return 0; }
     CORBA::Long get_priority_value(const OpenDDS::DCPS::AssociationData&) const
@@ -73,7 +71,6 @@ class SimpleDataWriter
   protected:
 
     mutable ACE_Thread_Mutex mutex_;
-    const OpenDDS::DCPS::GUID_t& pub_id_;
     int num_messages_sent_;
     int num_messages_delivered_;
     bool associated_;
@@ -82,7 +79,7 @@ class SimpleDataWriter
 class DDS_TEST : public SimpleDataWriter
 {
 public:
-    explicit DDS_TEST(const OpenDDS::DCPS::GUID_t& pub_id);
+    explicit DDS_TEST();
     virtual int run(int num_msgs, int msg_size);
 
     static void cleanup(OpenDDS::DCPS::DataSampleElementAllocator& alloc,

--- a/tests/transport/simple/SubDriver.cpp
+++ b/tests/transport/simple/SubDriver.cpp
@@ -26,7 +26,6 @@
 SubDriver::SubDriver()
   : pub_id_(OpenDDS::DCPS::GuidBuilder::create())
   , sub_id_(OpenDDS::DCPS::GuidBuilder::create())
-  , reader_(sub_id_)
   , num_msgs_(1)
   , shmem_(false)
 {
@@ -422,6 +421,8 @@ SubDriver::parse_sub_arg(const ACE_TString& arg)
   builder.participantId(1);
   builder.entityKey(ACE_OS::atoi(sub_id_str.c_str()));
   builder.entityKind(OpenDDS::DCPS::ENTITYKIND_USER_READER_WITH_KEY);
+
+  reader_.set_guid(sub_id_);
 
   // Use the remainder as the "stringified" ACE_INET_Addr.
   this->sub_addr_ = ACE_INET_Addr(this->sub_addr_str_.c_str());

--- a/tests/unit-tests/dds/DCPS/RTPS/AssociationRecord.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/AssociationRecord.cpp
@@ -17,23 +17,19 @@ using namespace OpenDDS::RTPS;
 class MockTransportClient : public OpenDDS::DCPS::TransportClient {
 public:
   MockTransportClient()
-    : local_id_(GUID_UNKNOWN)
   {
-    GuidBuilder builder(local_id_);
+    GUID_t local_id;
+    GuidBuilder builder(local_id);
     builder.guidPrefix0(0);
     builder.guidPrefix1(1);
     builder.guidPrefix2(2);
     builder.entityId(3);
     builder.entityKey(4);
+    TransportClient::set_guid(local_id);
   }
 
   virtual ~MockTransportClient()
   {}
-
-  virtual GUID_t get_guid() const
-  {
-    return local_id_;
-  }
 
   virtual bool check_transport_qos(const TransportInst&)
   {
@@ -49,9 +45,6 @@ public:
   {
     return 0;
   }
-
-private:
-  GUID_t local_id_;
 };
 
 TEST(dds_DCPS_RTPS_AssociationRecord, BuiltinAssociationRecord_ctor)
@@ -138,8 +131,11 @@ TEST(dds_DCPS_RTPS_AssociationRecord, BuiltinAssociationRecord_local_tokens_sent
 
 class MockDataWriterCallbacks : public DataWriterCallbacks {
 public:
-  virtual void add_association(const GUID_t&,
-                               const ReaderAssociation&,
+
+  virtual void set_publication_id(const GUID_t&)
+  {}
+
+  virtual void add_association(const ReaderAssociation&,
                                bool)
   {}
 
@@ -194,8 +190,10 @@ TEST(dds_DCPS_RTPS_AssociationRecord, WriterAssociationRecord_ctor)
 
 class MockDataReaderCallbacks : public DataReaderCallbacks {
 public:
-  virtual void add_association(const GUID_t&,
-                               const WriterAssociation&,
+  virtual void set_subscription_id(const GUID_t&)
+  {}
+
+  virtual void add_association(const WriterAssociation&,
                                bool)
   {}
 


### PR DESCRIPTION
Problem
-------

The TransportClient class does not initialize its guid until an association.  However, the client can and is used before an association.  One example is a DataWriter that sends liveliness messages.  The fix introduced by #4120 caused various functions to short-circuit when the guid was not set.  However, this introduced a deadlock in the example where the DataWriter was waiting for the liveliness message to be delivered.

Solution
--------

Three alternatives were considered.

First, extending the solution in #4120 lacked confidence as it was impossible to explore all of the corner cases.

Second, the guid was passed in the constructor of the TransportClient. This solution failed as the current design in concert with spec-defined behavior 1) allows DataWriters and DataReaders to be created before enabling them and 2) determines the guid during the call to enable via a call into discovery.  While this solution was the best in terms of maintainability, it would require extensive refactoring.

Third, modifying discovery to set the guid as soon as it is known and before any associations are processed.  This solution was close to the second one in terms of the class invariant of an initialized guid while fitting within the current design.

Discovery implementations now how the responsibility of calling `set_publication_id` and `set_subscription_id` when a publication or subscription is added.  DataReaderImpl was modifying to not use the TransportClient when the transport is disableb as it is for built-in topics.