### PR TITLE
Multiple SpdpSendAddrs line support in ini files

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
@@ -418,7 +418,7 @@ public:
   void spdp_send_addrs(const AddrVec& addrs)
   {
     ACE_GUARD(ACE_Thread_Mutex, g, lock_);
-    spdp_send_addrs_ = addrs;
+    spdp_send_addrs_.insert(spdp_send_addrs_.end(), addrs.begin(), addrs.end());
   }
 
   DCPS::TimeDuration max_auth_time() const


### PR DESCRIPTION
Add support for multiple rtps.ini file lines specifying SpdpSendAddrs. In large systems on networks where Multicast discovery is impossible, it would be nice to be able to split the  SpdpSendAddrs entries across multiple lines.