### PR TITLE
DataWriterImpl can send liveliness before GUID is set

### DIFF
--- a/dds/DCPS/DataWriterImpl.cpp
+++ b/dds/DCPS/DataWriterImpl.cpp
@@ -73,15 +73,15 @@ DataWriterImpl::DataWriterImpl()
   , sequence_number_(SequenceNumber::SEQUENCENUMBER_UNKNOWN())
   , coherent_(false)
   , coherent_samples_(0)
-  , liveliness_lost_(false)
-  , reactor_(0)
-  , liveliness_check_interval_(TimeDuration::max_value)
   , last_deadline_missed_total_count_(0)
   , is_bit_(false)
   , min_suspended_transaction_id_(0)
   , max_suspended_transaction_id_(0)
-  , liveliness_asserted_(false)
-  , liveness_timer_(make_rch<LivenessTimer>(ref(*this)))
+  , liveliness_send_task_(make_rch<DWISporadicTask>(TheServiceParticipant->time_source(), TheServiceParticipant->interceptor(), rchandle_from(this), &DataWriterImpl::liveliness_send_task))
+  , liveliness_lost_task_(make_rch<DWISporadicTask>(TheServiceParticipant->time_source(), TheServiceParticipant->interceptor(), rchandle_from(this), &DataWriterImpl::liveliness_lost_task))
+  , liveliness_send_interval_(TimeDuration::max_value)
+  , liveliness_lost_interval_(TimeDuration::max_value)
+  , liveliness_lost_(false)
 {
   liveliness_lost_status_.total_count = 0;
   liveliness_lost_status_.total_count_change = 0;
@@ -110,6 +110,10 @@ DataWriterImpl::DataWriterImpl()
 DataWriterImpl::~DataWriterImpl()
 {
   DBG_ENTRY_LVL("DataWriterImpl", "~DataWriterImpl", 6);
+
+  liveliness_send_task_->cancel();
+  liveliness_lost_task_->cancel();
+
 #ifndef OPENDDS_SAFETY_PROFILE
   RcHandle<DomainParticipantImpl> participant = participant_servant_.lock();
   if (participant) {
@@ -168,8 +172,6 @@ DataWriterImpl::init(
   // Only store the publisher pointer, since it is our parent, we will
   // exist as long as it does.
   publisher_servant_ = *publisher_servant;
-
-  this->reactor_ = TheServiceParticipant->timer();
 }
 
 DDS::InstanceHandle_t
@@ -1195,6 +1197,7 @@ DataWriterImpl::get_publication_matched_status(
 DDS::ReturnCode_t
 DataWriterImpl::assert_liveliness()
 {
+  ACE_Guard<ACE_Recursive_Thread_Mutex> guard(lock_);
   switch (this->qos_.liveliness.kind) {
   case DDS::AUTOMATIC_LIVELINESS_QOS:
     // Do nothing.
@@ -1220,10 +1223,11 @@ DataWriterImpl::assert_liveliness()
 DDS::ReturnCode_t
 DataWriterImpl::assert_liveliness_by_participant()
 {
+  ACE_Guard<ACE_Recursive_Thread_Mutex> guard(lock_);
   // This operation is called by participant.
-  if (this->qos_.liveliness.kind == DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS) {
-    // Set a flag indicating that we should send a liveliness message on the timer if necessary.
-    liveliness_asserted_ = true;
+  if (this->qos_.liveliness.kind == DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS &&
+      !send_liveliness(MonotonicTimePoint::now())) {
+    return DDS::RETCODE_ERROR;
   }
 
   return DDS::RETCODE_OK;
@@ -1233,7 +1237,7 @@ TimeDuration
 DataWriterImpl::liveliness_check_interval(DDS::LivelinessQosPolicyKind kind)
 {
   if (this->qos_.liveliness.kind == kind) {
-    return liveliness_check_interval_;
+    return liveliness_send_interval_;
   } else {
     return TimeDuration::max_value;
   }
@@ -1438,19 +1442,10 @@ DataWriterImpl::enable()
   if (qos_.liveliness.lease_duration.sec != DDS::DURATION_INFINITE_SEC &&
       qos_.liveliness.lease_duration.nanosec != DDS::DURATION_INFINITE_NSEC) {
     // Must be at least 1 micro second.
-    liveliness_check_interval_ = std::max(
+    liveliness_send_interval_ = std::max(
       TimeDuration(qos_.liveliness.lease_duration) * (TheServiceParticipant->liveliness_factor() / 100.0),
       TimeDuration(0, 1));
-
-    if (reactor_->schedule_timer(liveness_timer_.in(),
-                                 0,
-                                 liveliness_check_interval_.value(),
-                                 liveliness_check_interval_.value()) == -1) {
-      ACE_ERROR((LM_ERROR,
-                 ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::enable: %p.\n"),
-                 ACE_TEXT("schedule_timer")));
-
-    }
+    liveliness_lost_interval_ = TimeDuration(qos_.liveliness.lease_duration);
   }
 
   if (!participant) {
@@ -1512,33 +1507,41 @@ DataWriterImpl::enable()
                            pub_qos,
                            type_info);
 
-  ACE_Guard<ACE_Recursive_Thread_Mutex> guard(lock_);
+  {
+    ACE_Guard<ACE_Recursive_Thread_Mutex> guard(lock_);
 
-  if (!success || publication_id_ == GUID_UNKNOWN) {
-    if (DCPS_debug_level >= 1) {
-      ACE_DEBUG((LM_WARNING, "(%P|%t) WARNING: DataWriterImpl::enable: "
-        "add_publication failed\n"));
+    if (!success || publication_id_ == GUID_UNKNOWN) {
+      if (DCPS_debug_level >= 1) {
+        ACE_DEBUG((LM_WARNING, "(%P|%t) WARNING: DataWriterImpl::enable: "
+                   "add_publication failed\n"));
+      }
+      data_container_->shutdown_ = true;
+      return DDS::RETCODE_ERROR;
     }
-    data_container_->shutdown_ = true;
-    return DDS::RETCODE_ERROR;
-  }
 
 #if defined(OPENDDS_SECURITY)
-  security_config_ = participant->get_security_config();
-  participant_permissions_handle_ = participant->permissions_handle();
-  dynamic_type_ = type_support_->get_type();
+    security_config_ = participant->get_security_config();
+    participant_permissions_handle_ = participant->permissions_handle();
+    dynamic_type_ = type_support_->get_type();
 #endif
 
-  if (DCPS_debug_level >= 2) {
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) DataWriterImpl::enable: "
-      "got GUID %C, publishing to topic name \"%C\" type \"%C\"\n",
-      LogGuid(publication_id_).c_str(),
-      topic_servant_->topic_name(), topic_servant_->type_name()));
+    if (DCPS_debug_level >= 2) {
+      ACE_DEBUG((LM_DEBUG, "(%P|%t) DataWriterImpl::enable: "
+                 "got GUID %C, publishing to topic name \"%C\" type \"%C\"\n",
+                 LogGuid(publication_id_).c_str(),
+                 topic_servant_->topic_name(), topic_servant_->type_name()));
+    }
+
+    this->data_container_->publication_id_ = this->publication_id_;
   }
 
-  this->data_container_->publication_id_ = this->publication_id_;
-
-  guard.release();
+  if (qos_.liveliness.lease_duration.sec != DDS::DURATION_INFINITE_SEC &&
+      qos_.liveliness.lease_duration.nanosec != DDS::DURATION_INFINITE_NSEC) {
+    if (qos_.liveliness.kind == DDS::AUTOMATIC_LIVELINESS_QOS) {
+      liveliness_send_task_->schedule(liveliness_send_interval_);
+    }
+    liveliness_lost_task_->schedule(liveliness_lost_interval_);
+  }
 
   const DDS::ReturnCode_t writer_enabled_result =
     publisher->writer_enabled(topic_name_.in(), this);
@@ -1926,6 +1929,7 @@ DataWriterImpl::write(Message_Block_Ptr data,
                      ret);
   }
   last_liveliness_activity_time_.set_to_now();
+  liveliness_lost_ = false;
 
   track_sequence_number(filter_out);
 
@@ -2474,86 +2478,60 @@ DataWriterImpl::listener_for(DDS::StatusKind kind)
   }
 }
 
-int
-DataWriterImpl::handle_timeout(const ACE_Time_Value& tv,
-                               const void* /* arg */)
+void
+DataWriterImpl::liveliness_send_task(const MonotonicTimePoint& now)
 {
   ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
 
-  const MonotonicTimePoint now(tv);
-  bool liveliness_lost = false;
+  ACE_Guard<ACE_Recursive_Thread_Mutex> guard(lock_);
+  OPENDDS_ASSERT(qos_.liveliness.kind == DDS::AUTOMATIC_LIVELINESS_QOS);
+
+  const TimeDuration elapsed = now - last_liveliness_activity_time_;
+
+  if (elapsed < liveliness_send_interval_) {
+    // Reschedule.
+    liveliness_send_task_->schedule(liveliness_send_interval_ - elapsed);
+    return;
+  }
+
+  send_liveliness(now);
+  liveliness_send_task_->schedule(liveliness_send_interval_);
+}
+
+void
+DataWriterImpl::liveliness_lost_task(const MonotonicTimePoint& now)
+{
+  ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
 
   ACE_Guard<ACE_Recursive_Thread_Mutex> guard(lock_);
 
-  TimeDuration elapsed = now - last_liveliness_activity_time_;
+  const TimeDuration elapsed = now - last_liveliness_activity_time_;
 
-  // Do we need to send a liveliness message?
-  if (elapsed >= liveliness_check_interval_) {
-    switch (this->qos_.liveliness.kind) {
-    case DDS::AUTOMATIC_LIVELINESS_QOS:
-      if (!send_liveliness(now)) {
-        liveliness_lost = true;
-      }
-      break;
-
-    case DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS:
-      if (liveliness_asserted_) {
-        if (!send_liveliness(now)) {
-          liveliness_lost = true;
-        }
-      }
-      break;
-
-    case DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS:
-      // Do nothing.
-      break;
-    }
-  }
-  else {
+  if (elapsed < liveliness_lost_interval_) {
     // Reschedule.
-    if (reactor_->cancel_timer(liveness_timer_.in()) == -1) {
-      ACE_ERROR((LM_ERROR,
-        ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::handle_timeout: %p.\n"),
-        ACE_TEXT("cancel_timer")));
-    }
-    if (reactor_->schedule_timer(liveness_timer_.in(), 0,
-      (liveliness_check_interval_ - elapsed).value(),
-      liveliness_check_interval_.value()) == -1)
-    {
-      ACE_ERROR((LM_ERROR,
-        ACE_TEXT("(%P|%t) ERROR: DataWriterImpl::handle_timeout: %p.\n"),
-        ACE_TEXT("schedule_timer")));
-    }
-    return 0;
+    liveliness_lost_task_->schedule(liveliness_lost_interval_ - elapsed);
+    return;
   }
 
-  liveliness_asserted_ = false;
-  elapsed = now - last_liveliness_activity_time_;
+  const bool notify = !liveliness_lost_;
+  liveliness_lost_task_->schedule(liveliness_lost_interval_);
+  liveliness_lost_ = true;
 
-  // Have we lost liveliness?
-  if (elapsed >= TimeDuration(qos_.liveliness.lease_duration)) {
-    liveliness_lost = true;
-  }
+  if (notify) {
+    ++liveliness_lost_status_.total_count;
+    ++liveliness_lost_status_.total_count_change;
 
-  if (!this->liveliness_lost_ && liveliness_lost) {
-    ++ this->liveliness_lost_status_.total_count;
-    ++ this->liveliness_lost_status_.total_count_change;
-
-    DDS::DataWriterListener_var listener =
-      listener_for(DDS::LIVELINESS_LOST_STATUS);
+    DDS::DataWriterListener_var listener = listener_for(DDS::LIVELINESS_LOST_STATUS);
 
     if (!CORBA::is_nil(listener.in())) {
       {
         ACE_Reverse_Lock<ACE_Recursive_Thread_Mutex> rev_lock(lock_);
         ACE_Guard<ACE_Reverse_Lock<ACE_Recursive_Thread_Mutex> > rev_guard(rev_lock);
-        listener->on_liveliness_lost(this, this->liveliness_lost_status_);
+        listener->on_liveliness_lost(this, liveliness_lost_status_);
       }
-      this->liveliness_lost_status_.total_count_change = 0;
+      liveliness_lost_status_.total_count_change = 0;
     }
   }
-
-  this->liveliness_lost_ = liveliness_lost;
-  return 0;
 }
 
 bool
@@ -2576,6 +2554,7 @@ DataWriterImpl::send_liveliness(const MonotonicTimePoint& now)
     }
   }
   last_liveliness_activity_time_ = now;
+  liveliness_lost_ = false;
   return true;
 }
 
@@ -2834,19 +2813,6 @@ DataWriterImpl::get_ice_endpoint()
 void DataWriterImpl::set_wait_pending_deadline(const MonotonicTimePoint& deadline)
 {
   wait_pending_deadline_ = deadline;
-}
-
-int LivenessTimer::handle_timeout(const ACE_Time_Value& tv, const void* arg)
-{
-  ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
-
-  DataWriterImpl_rch writer = this->writer_.lock();
-  if (writer) {
-    writer->handle_timeout(tv, arg);
-  } else {
-    this->reactor()->cancel_timer(this);
-  }
-  return 0;
 }
 
 void DataWriterImpl::transport_discovery_change()

--- a/dds/DCPS/DataWriterImpl.h
+++ b/dds/DCPS/DataWriterImpl.h
@@ -7,24 +7,25 @@
 #define OPENDDS_DCPS_DATAWRITERIMPL_H
 
 #include "Atomic.h"
-#include "Sample.h"
-#include "DataWriterCallbacks.h"
-#include "transport/framework/TransportSendListener.h"
-#include "transport/framework/TransportClient.h"
-#include "MessageTracker.h"
-#include "DataBlockLockPool.h"
-#include "PoolAllocator.h"
-#include "WriteDataContainer.h"
-#include "Definitions.h"
-#include "DataSampleHeader.h"
-#include "TopicImpl.h"
-#include "Time_Helper.h"
 #include "CoherentChangeControl.h"
+#include "DataBlockLockPool.h"
+#include "DataSampleHeader.h"
+#include "DataWriterCallbacks.h"
+#include "Definitions.h"
 #include "GuidUtils.h"
-#include "RcEventHandler.h"
-#include "unique_ptr.h"
+#include "MessageTracker.h"
 #include "Message_Block_Ptr.h"
+#include "PoolAllocator.h"
+#include "RcEventHandler.h"
+#include "Sample.h"
+#include "SporadicTask.h"
 #include "TimeTypes.h"
+#include "Time_Helper.h"
+#include "TopicImpl.h"
+#include "WriteDataContainer.h"
+#include "transport/framework/TransportClient.h"
+#include "transport/framework/TransportSendListener.h"
+#include "unique_ptr.h"
 #ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC
 #  include "FilterEvaluator.h"
 #endif
@@ -54,7 +55,6 @@ class Monitor;
 class DataSampleElement;
 class SendStateDataSampleList;
 struct AssociationData;
-class LivenessTimer;
 
 /**
  * @class DataWriterImpl
@@ -397,10 +397,6 @@ public:
    * factory/publisher.
    */
   DDS::DataWriterListener_ptr listener_for(DDS::StatusKind kind);
-
-  /// Handle the assert liveliness timeout.
-  virtual int handle_timeout(const ACE_Time_Value &tv,
-                             const void *arg);
 
   /// Called by the PublisherImpl to indicate that the Publisher is now
   /// resumed and any data collected while it was suspended should now be sent.
@@ -776,10 +772,6 @@ private:
   DDS::OfferedIncompatibleQosStatus offered_incompatible_qos_status_ ;
   DDS::PublicationMatchedStatus publication_match_status_ ;
 
-  /// True if the writer failed to actively signal its liveliness within
-  /// its offered liveliness period.
-  bool liveliness_lost_;
-
   /**
    * @todo The publication_lost_status_ and
    *       publication_reconnecting_status_ are left here for
@@ -800,13 +792,6 @@ private:
   unique_ptr<DataSampleHeaderAllocator> header_allocator_;
   unique_ptr<DataAllocator> data_allocator_;
 
-  /// The orb's reactor to be used to register the liveliness
-  /// timer.
-  ACE_Reactor_Timer_Interface* reactor_;
-  /// The time interval for sending liveliness message.
-  TimeDuration liveliness_check_interval_;
-  /// Timestamp of last write/dispose/assert_liveliness.
-  MonotonicTimePoint last_liveliness_activity_time_;
   /// Total number of offered deadlines missed during last offered
   /// deadline status check.
   CORBA::Long last_deadline_missed_total_count_;
@@ -835,12 +820,24 @@ private:
   DDS::ReturnCode_t send_end_historic_samples(const GUID_t& readerId);
   DDS::ReturnCode_t send_request_ack();
 
-  bool liveliness_asserted_;
-
   // Lock used to synchronize remove_associations calls from discovery
   // and unregister_instances during deletion of datawriter from application
   ACE_Thread_Mutex sync_unreg_rem_assocs_lock_;
-  RcHandle<LivenessTimer> liveness_timer_;
+
+  typedef PmfSporadicTask<DataWriterImpl> DWISporadicTask;
+
+  RcHandle<DWISporadicTask> liveliness_send_task_;
+  virtual void liveliness_send_task(const MonotonicTimePoint& now);
+  RcHandle<DWISporadicTask> liveliness_lost_task_;
+  virtual void liveliness_lost_task(const MonotonicTimePoint& now);
+  /// The time interval for sending liveliness message.
+  TimeDuration liveliness_send_interval_;
+  TimeDuration liveliness_lost_interval_;
+  /// True if the writer failed to actively signal its liveliness within
+  /// its offered liveliness period.
+  bool liveliness_lost_;
+  /// Timestamp of last write/dispose/assert_liveliness.
+  MonotonicTimePoint last_liveliness_activity_time_;
 
   MonotonicTimePoint wait_pending_deadline_;
 
@@ -861,22 +858,6 @@ protected:
 };
 
 typedef RcHandle<DataWriterImpl> DataWriterImpl_rch;
-
-
-class LivenessTimer : public virtual RcEventHandler
-{
-public:
-  LivenessTimer(DataWriterImpl& writer)
-    : writer_(writer)
-  {
-  }
-
-  /// Handle the assert liveliness timeout.
-  virtual int handle_timeout(const ACE_Time_Value& tv, const void* arg);
-
-private:
-  WeakRcHandle<DataWriterImpl> writer_;
-};
 
 } // namespace DCPS
 } // namespace OpenDDS

--- a/tests/DCPS/ManualAssertLiveliness/DataWriterListenerImpl.cpp
+++ b/tests/DCPS/ManualAssertLiveliness/DataWriterListenerImpl.cpp
@@ -3,20 +3,21 @@
 #include <dds/DdsDcpsPublicationC.h>
 #include <dds/DCPS/Service_Participant.h>
 
-DataWriterListenerImpl::DataWriterListenerImpl()
+DataWriterListenerImpl::DataWriterListenerImpl(const OpenDDS::DCPS::String& name)
   : num_liveliness_lost_callbacks_(0)
+  , name_(name)
 {}
 
 DataWriterListenerImpl::~DataWriterListenerImpl()
 {}
 
-void DataWriterListenerImpl::on_liveliness_lost(::DDS::DataWriter_ptr writer,
+void DataWriterListenerImpl::on_liveliness_lost(::DDS::DataWriter_ptr,
                                                 const ::DDS::LivelinessLostStatus& status)
 {
   ++num_liveliness_lost_callbacks_;
   ACE_DEBUG((LM_INFO,
-              ACE_TEXT("(%P|%t) DataWriterListenerImpl::on_liveliness_lost %@ %d\n"),
-              writer, (int) num_liveliness_lost_callbacks_.load()));
+             ACE_TEXT("(%P|%t) DataWriterListenerImpl::on_liveliness_lost %C %d\n"),
+             name_.c_str(), (int) num_liveliness_lost_callbacks_.load()));
   ACE_DEBUG((LM_INFO,
               ACE_TEXT("(%P|%t)    total_count=%d total_count_change=%d\n"),
               status.total_count, status.total_count_change));

--- a/tests/DCPS/ManualAssertLiveliness/DataWriterListenerImpl.h
+++ b/tests/DCPS/ManualAssertLiveliness/DataWriterListenerImpl.h
@@ -4,6 +4,7 @@
 #include "dds/DdsDcpsPublicationC.h"
 #include "dds/DCPS/Definitions.h"
 #include "dds/DCPS/LocalObject.h"
+#include "dds/DCPS/PoolAllocator.h"
 
 #include "ace/Atomic_Op.h"
 
@@ -15,7 +16,7 @@ class DataWriterListenerImpl
   : public virtual OpenDDS::DCPS::LocalObject<OpenDDS::DCPS::DataWriterListener>
 {
 public:
-  DataWriterListenerImpl (void);
+  DataWriterListenerImpl(const OpenDDS::DCPS::String& name);
 
   virtual ~DataWriterListenerImpl (void);
 
@@ -66,6 +67,7 @@ public:
 
 private:
   OpenDDS::DCPS::Atomic<unsigned long> num_liveliness_lost_callbacks_;
+  const OpenDDS::DCPS::String name_;
 };
 
 #endif /* DATAWRITER_LISTENER_IMPL  */

--- a/tests/DCPS/ManualAssertLiveliness/publisher.cpp
+++ b/tests/DCPS/ManualAssertLiveliness/publisher.cpp
@@ -178,13 +178,13 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
                                        DDS::SubscriberListener::_nil(),
                                        ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-  DataWriterListenerImpl* pub1_dwl1_servant = new DataWriterListenerImpl;
+  DataWriterListenerImpl* pub1_dwl1_servant = new DataWriterListenerImpl("Manual_By_Participant_Write");
   ::DDS::DataWriterListener_var pub1_dwl1 (pub1_dwl1_servant);
-  DataWriterListenerImpl* pub2_dwl2_servant = new DataWriterListenerImpl;
-  ::DDS::DataWriterListener_var pub2_dwl2 (pub2_dwl2_servant);
-  DataWriterListenerImpl* pub1_dwl2_servant = new DataWriterListenerImpl;
+  DataWriterListenerImpl* pub2_dwl1_servant = new DataWriterListenerImpl("Manual_By_Participant_Assert");
+  ::DDS::DataWriterListener_var pub2_dwl1 (pub2_dwl1_servant);
+  DataWriterListenerImpl* pub1_dwl2_servant = new DataWriterListenerImpl("Manual_By_Topic_Write");
   ::DDS::DataWriterListener_var pub1_dwl2 (pub1_dwl2_servant);
-  DataWriterListenerImpl* pub1_dwl3_servant = new DataWriterListenerImpl;
+  DataWriterListenerImpl* pub1_dwl3_servant = new DataWriterListenerImpl("Manual_By_Topic_Assert");
   ::DDS::DataWriterListener_var pub1_dwl3 (pub1_dwl3_servant);
 
   DataReaderListenerImpl* sub_drl_servant = new DataReaderListenerImpl(dcs);
@@ -193,15 +193,15 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
   // Create the datawriters
   ::DDS::DataWriterQos pub1_dw_qos;
   pub1_pub->get_default_datawriter_qos (pub1_dw_qos);
-  ::DDS::DataWriterQos pub2_dw2_qos;
-  pub2_pub->get_default_datawriter_qos (pub2_dw2_qos);
+  ::DDS::DataWriterQos pub2_dw1_qos;
+  pub2_pub->get_default_datawriter_qos (pub2_dw1_qos);
 
   pub1_dw_qos.liveliness.kind = ::DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
   pub1_dw_qos.liveliness.lease_duration.sec = PUB_LEASE_DURATION_SEC;
   pub1_dw_qos.liveliness.lease_duration.nanosec = 0;
-  pub2_dw2_qos.liveliness.kind = ::DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
-  pub2_dw2_qos.liveliness.lease_duration.sec = PUB_LEASE_DURATION_SEC;
-  pub2_dw2_qos.liveliness.lease_duration.nanosec = 0;
+  pub2_dw1_qos.liveliness.kind = ::DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS;
+  pub2_dw1_qos.liveliness.lease_duration.sec = PUB_LEASE_DURATION_SEC;
+  pub2_dw1_qos.liveliness.lease_duration.nanosec = 0;
 
   ::DDS::DataReaderQos sub_dr_qos;
   sub_sub->get_default_datareader_qos (sub_dr_qos);
@@ -218,8 +218,8 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
 
   DDS::DataWriter_var pub2_dw1 =
     pub2_pub->create_datawriter(pub2_topic.in (),
-                                pub2_dw2_qos,
-                                pub2_dwl2.in(),
+                                pub2_dw1_qos,
+                                pub2_dwl1.in(),
                                 ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
   pub1_dw_qos.liveliness.kind = ::DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS;
@@ -248,10 +248,10 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
   Utils::wait_match(pub1_dw3, 1);
 
   {
-    Write_Samples writer1(pub1_dw1, "Manual_By_Participant_Sample_Writer_1");
-    Assert_Participant_Liveliness writer2(pub2_dw1, "Manual_By_Participant_Assert_Writer_2");
-    Write_Samples writer3(pub1_dw2, "Manual_By_Topic_Sample_Writer_1");
-    Assert_Writer_Liveliness writer4(pub1_dw3, "Manual_By_Topic_Assert_Writer_2");
+    Write_Samples writer1(pub1_dw1, "Manual_By_Participant_Write");
+    Assert_Participant_Liveliness writer2(pub2_dw1, "Manual_By_Participant_Assert");
+    Write_Samples writer3(pub1_dw2, "Manual_By_Topic_Write");
+    Assert_Writer_Liveliness writer4(pub1_dw3, "Manual_By_Topic_Assert");
 
     writer1.start();
     writer2.start();
@@ -280,7 +280,7 @@ int ACE_TMAIN (int argc, ACE_TCHAR *argv[])
   }
 
   const unsigned long actual = pub1_dwl1_servant->num_liveliness_lost_callbacks() +
-    pub2_dwl2_servant->num_liveliness_lost_callbacks() +
+    pub2_dwl1_servant->num_liveliness_lost_callbacks() +
     pub1_dwl2_servant->num_liveliness_lost_callbacks() +
     pub1_dwl3_servant->num_liveliness_lost_callbacks();
 


### PR DESCRIPTION
Problem
-------

PR #4180 requires that the GUID be set before using the TransportClient.  DataWriterImpl can set a liveliness timer that expires before the GUID is set which leads to an assertion.

Solution
--------

Defer scheduling the liveliness timer until after the GUID is set.