### PR TITLE
Fix Smartquotes and Trailing Spaces in News

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,20 +53,20 @@ Read [the documenation for this release on Read the Docs](https://opendds.readth
 * Fixed issue deserializing bounded sequences with JSON ([PR #4150](https://github.com/OpenDDS/OpenDDS/pull/4150))
     * The deserialization will fail if the JSON input contains more elements than the bounded sequence can hold.
 
-* Updated the RtpsRelay’s tracking of client IP addresses so they are removed when no longer used. ([PR #4202](https://github.com/OpenDDS/OpenDDS/pull/4202))
+* Updated the RtpsRelay's tracking of client IP addresses so they are removed when no longer used. ([PR #4202](https://github.com/OpenDDS/OpenDDS/pull/4202))
 
     * The RtpsRelay configuration option -MaxAddrSetSize was renamed to -MaxIpsPerClient
 
 ### Documentation
 
-* Moved various markdown files into the Sphinx documentation so that they are now included along with the Developer’s Guide: ([PR #4139](https://github.com/OpenDDS/OpenDDS/pull/4139))
+* Moved various markdown files into the Sphinx documentation so that they are now included along with the Developer's Guide: ([PR #4139](https://github.com/OpenDDS/OpenDDS/pull/4139))
     * `INSTALL.md` is now [Building and Installing](https://opendds.readthedocs.io/en/dds-3.25/building/index.html).
     * `docs/dependencies.md` is now [Dependencies](https://opendds.readthedocs.io/en/dds-3.25/building/dependencies.html).
     * `docs/cmake.md` is now [Using OpenDDS in a CMake Project](https://opendds.readthedocs.io/en/dds-3.25/building/cmake.html).
     * `docs/android.md` is now [Android](https://opendds.readthedocs.io/en/dds-3.25/building/android.html).
     * `docs/ios.md` is now [iOS](https://opendds.readthedocs.io/en/dds-3.25/building/ios.html).
 
-* Restructured how the documentation is presented to cleanly separate the Developer’s Guide and internal documentation. ([PR #4139](https://github.com/OpenDDS/OpenDDS/pull/4139))
+* Restructured how the documentation is presented to cleanly separate the Developer's Guide and internal documentation. ([PR #4139](https://github.com/OpenDDS/OpenDDS/pull/4139))
 * Added a [proper main page](https://opendds.readthedocs.io/en/dds-3.25/index.html). ([PR #4139](https://github.com/OpenDDS/OpenDDS/pull/4139))
 * Added [Glossary](https://opendds.readthedocs.io/en/dds-3.25/glossary.html). ([PR #4139](https://github.com/OpenDDS/OpenDDS/pull/4139))
 * In addition to [`NEWS.md`](https://github.com/OpenDDS/OpenDDS/blob/DDS-3.25/NEWS.md), started adding release notes to [Release Notes](https://opendds.readthedocs.io/en/dds-3.25/news.html). ([PR #4125](https://github.com/OpenDDS/OpenDDS/pull/4125))

--- a/docs/build.py
+++ b/docs/build.py
@@ -132,7 +132,7 @@ class DocEnv:
         return None
 
     def do_markdown(self):
-        self.sphinx_build('markdown')
+        self.sphinx_build('markdown', '-Dsmartquotes_action=')
         return None
 
 

--- a/docs/internal/github_actions.rst
+++ b/docs/internal/github_actions.rst
@@ -1,6 +1,6 @@
-##############################
-GitHub Actions Summary and FAQ
-##############################
+##############
+GitHub Actions
+##############
 
 ********
 Overview
@@ -22,7 +22,7 @@ Operating System
 
 .. seealso::
 
-  `GitHub Runner Images <https://github.com/actions/runner-images>`
+  `GitHub Runner Images <https://github.com/actions/runner-images>`__
 
 Build Configuration
 ===================
@@ -178,11 +178,11 @@ Running this script requires the `YAML CPAN module <https://metacpan.org/pod/YAM
 As a safety measure, it has some picky rules about how steps are named and ordered.
 In simplified terms, these rules include:
 
-  * If used, the problem matcher must be appropriate for the platform the job is running on.
-  * The problem matcher must not be declared before steps that are named "setup gtest" or named like "build ACE/TAO".
-    This should reduce any warnings from Google Test or ACE/TAO.
-  * A problem matcher should be declared before steps that start with "build" or contain "make".
-    These steps should also contain ``cmake --build``, ``make``, or ``msbuild`` in their ``run`` string.
+* If used, the problem matcher must be appropriate for the platform the job is running on.
+* The problem matcher must not be declared before steps that are named "setup gtest" or named like "build ACE/TAO".
+  This should reduce any warnings from Google Test or ACE/TAO.
+* A problem matcher should be declared before steps that start with "build" or contain "make".
+  These steps should also contain ``cmake --build``, ``make``, or ``msbuild`` in their ``run`` string.
 
 Blocked Tests
 =============

--- a/docs/news.d/_releases/v3.25.0.rst
+++ b/docs/news.d/_releases/v3.25.0.rst
@@ -38,7 +38,7 @@ Additions
     - Added :cmake:func:`opendds_target_sources(USE_EXPORT)` to allow overriding the generated export header with an existing one. (:ghpr:`4160`)
 
   - Libraries and features can be passed to ``find_package(OpenDDS COMPONENTS)`` to change what is required. (:ghpr:`4160`, :ghpr:`4140`)
-  
+
     - See :ref:`cmake-components` for details.
 
 Security
@@ -83,6 +83,6 @@ Notes
 - CMake Config Package
 
   - ``OPENDDS_TARGET_SOURCES`` is now called ``opendds_target_sources``. (:ghpr:`4140`)
-  
+
     - CMake macros and functions names are case insensitive, so this should have no effect on CMake code.
 

--- a/docs/sphinx_extensions/newsd.py
+++ b/docs/sphinx_extensions/newsd.py
@@ -49,12 +49,14 @@ class PrintHelper:
         if combined.endswith('\n'):
             combined = combined[:-1]
         for line in combined.split('\n'):
+            line = line.rstrip()
             blank = not bool(line)
             if blank and self.printed_blank_line:
                 continue
-            if len(line) and not line.startswith(' ') and decorate:
-                line += decorate
-            line = indent + line
+            if len(line):
+                if not line.startswith(' ') and decorate:
+                    line += decorate
+                line = indent + line
             if self.avoid_rst:
                 ghfile_re.sub('')
             print(line, file=self.file, **kw)
@@ -219,8 +221,8 @@ def test_section():
     a.add_text(set([0]), ['- This is some text\n', '- This is a seperate item\n'])
     aa = a.get_section('Section AA')
     aa.add_text(set([3]), ['- This is some text\n  - This is some more\n'])
-    aa.add_text(set([1]), ['- This is some text\n  - This is some more\n'])
-    aa.add_text(set([5]), ['- This is some text\n  - This is some more\n'])
+    aa.add_text(set([1]), ['- This is some text  \n  - This is some more\n'])
+    aa.add_text(set([5]), ['- This is some text\n  - This is some more\n    \n'])
     aa.add_text(set([50]), ['- (Should be second in Section AA)\n'], 9)
     aaa = aa.get_section('Section AAA (Should be first in Section AA)', 10)
     aaa.add_text(set([4]), ['- This is some text\n  - This is some more\n'])


### PR DESCRIPTION
3.25.0 news had empty lines with tailing spaces in the RST news and broken encodings for single quotes in the GitHub release page. The trailing spaces was caused by some indent logic for indenting sections not checking if the line is empty before indenting. The broken single quotes were caused by Sphinx doing smartquotes and those non-ASCII quotes getting mangled by either the release script or maybe GitHub. This disables smartquotes in build.py, but if possible this should probably be something the Markdown builder sets since it doesn't make sense to do it in Markdown.

Also fixed some minor issues in the GHA document.