### PR TITLE
Support sending `DynamicDataAdapter` sample via dynamic writer

### DIFF
--- a/dds/DCPS/XTypes/DynamicDataAdapter.cpp
+++ b/dds/DCPS/XTypes/DynamicDataAdapter.cpp
@@ -196,12 +196,6 @@ DDS::ReturnCode_t DynamicDataAdapter::clear_value(DDS::MemberId)
   return unsupported_method("DynamicDataAdapater::clear_value");
 }
 
-DDS::DynamicData_ptr DynamicDataAdapter::clone()
-{
-  unsupported_method("DynamicDataAdapater::clone");
-  return 0;
-}
-
 DDS::ReturnCode_t DynamicDataAdapter::invalid_id(const char* method, DDS::MemberId id) const
 {
   if (DCPS::log_level >= DCPS::LogLevel::Notice) {

--- a/dds/DCPS/XTypes/DynamicDataAdapter.h
+++ b/dds/DCPS/XTypes/DynamicDataAdapter.h
@@ -12,8 +12,6 @@
 #    include "DynamicDataBase.h"
 #    include "Utils.h"
 
-#    include <dds/DCPS/Sample.h>
-
 #    include <vector>
 #  else
 #    include <dds/DdsDynamicDataC.h>

--- a/dds/DCPS/XTypes/DynamicDataAdapter.h
+++ b/dds/DCPS/XTypes/DynamicDataAdapter.h
@@ -704,35 +704,6 @@ public:
     return value_;
   }
 
-  bool serialized_size(const DCPS::Encoding& enc, size_t& size, DCPS::Sample::Extent ext) const
-  {
-    using namespace DCPS;
-    if (ext == DCPS::Sample::Full) {
-      serialized_size(enc, size, value_);
-    } else if (ext == DCPS::Sample::KeyOnly) {
-      KeyOnly<const T> key_only(value_);
-      serialized_size(enc, size, key_only);
-    } else {
-      NestedKeyOnly<const T> nested_key_only(value_);
-      serialized_size(enc, size, nested_key_only);
-    }
-    return true;
-  }
-
-  bool serialize(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const
-  {
-    using namespace DCPS;
-    if (ext == DCPS::Sample::Full) {
-      return ser << value_;
-    } else if (ext == DCPS::Sample::KeyOnly) {
-      KeyOnly<const T> key_only(value_);
-      return ser << key_only;
-    } else {
-      NestedKeyOnly<const T> nested_key_only(value_);
-      return ser << nested_key_only;
-    }
-  }
-
 protected:
   T& value_;
 };

--- a/dds/DCPS/XTypes/DynamicDataAdapter.h
+++ b/dds/DCPS/XTypes/DynamicDataAdapter.h
@@ -79,7 +79,7 @@ public:
   DDS::ReturnCode_t clear_all_values();
   DDS::ReturnCode_t clear_nonkey_values();
   DDS::ReturnCode_t clear_value(DDS::MemberId);
-  DDS::DynamicData_ptr clone();
+  DDS::DynamicData_ptr clone() = 0;
 
   DDS::ReturnCode_t get_int8_value(CORBA::Int8& value,
                                    DDS::MemberId id)

--- a/dds/DCPS/XTypes/DynamicDataAdapter.h
+++ b/dds/DCPS/XTypes/DynamicDataAdapter.h
@@ -12,6 +12,8 @@
 #    include "DynamicDataBase.h"
 #    include "Utils.h"
 
+#    include <dds/DCPS/Sample.h>
+
 #    include <vector>
 #  else
 #    include <dds/DdsDynamicDataC.h>
@@ -700,6 +702,35 @@ public:
   const T& wrapped() const
   {
     return value_;
+  }
+
+  bool serialized_size(const DCPS::Encoding& enc, size_t& size, DCPS::Sample::Extent ext) const
+  {
+    using namespace DCPS;
+    if (ext == DCPS::Sample::Full) {
+      serialized_size(enc, size, value_);
+    } else if (ext == DCPS::Sample::KeyOnly) {
+      KeyOnly<const T> key_only(value_);
+      serialized_size(enc, size, key_only);
+    } else {
+      NestedKeyOnly<const T> nested_key_only(value_);
+      serialized_size(enc, size, nested_key_only);
+    }
+    return true;
+  }
+
+  bool serialize(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const
+  {
+    using namespace DCPS;
+    if (ext == DCPS::Sample::Full) {
+      return ser << value_;
+    } else if (ext == DCPS::Sample::KeyOnly) {
+      KeyOnly<const T> key_only(value_);
+      return ser << key_only;
+    } else {
+      NestedKeyOnly<const T> nested_key_only(value_);
+      return ser << nested_key_only;
+    }
   }
 
 protected:

--- a/dds/DCPS/XTypes/DynamicDataBase.h
+++ b/dds/DCPS/XTypes/DynamicDataBase.h
@@ -49,6 +49,9 @@ public:
   virtual DDS::ReturnCode_t get_simple_value(DCPS::Value& value, DDS::MemberId id);
 #endif
 
+  virtual bool serialized_size(const DCPS::Encoding& enc, size_t& size, DCPS::Sample::Extent extent) const = 0;
+  virtual bool serialize(DCPS::Serializer& ser, DCPS::Sample::Extent extent) const = 0;
+
 protected:
   /// Verify that a given type is primitive or string or wstring.
   bool is_type_supported(TypeKind tk, const char* func_name);

--- a/dds/DCPS/XTypes/DynamicDataImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataImpl.cpp
@@ -333,9 +333,7 @@ DDS::ReturnCode_t DynamicDataImpl::clear_all_values()
 
 void DynamicDataImpl::clear_container()
 {
-  container_.single_map_.clear();
-  container_.sequence_map_.clear();
-  container_.complex_map_.clear();
+  container_.clear();
 }
 
 DDS::ReturnCode_t DynamicDataImpl::clear_nonkey_values()
@@ -4150,7 +4148,7 @@ bool DynamicDataImpl::serialized_size_string(const DCPS::Encoding& encoding, siz
   const bool is_empty = container_.single_map_.empty() && container_.complex_map_.empty();
   if (!is_empty) {
     CORBA::ULong largest_index;
-    if (!get_largest_index_basic(largest_index)) {
+    if (!container_.get_largest_index_basic(largest_index)) {
       return false;
     }
     primitive_serialized_size_ulong(encoding, size);
@@ -4206,7 +4204,7 @@ bool DynamicDataImpl::serialized_size_wstring(const DCPS::Encoding& encoding, si
   const bool is_empty = container_.single_map_.empty() && container_.complex_map_.empty();
   if (!is_empty) {
     CORBA::ULong largest_index;
-    if (!get_largest_index_basic(largest_index)) {
+    if (!container_.get_largest_index_basic(largest_index)) {
       return false;
     }
     primitive_serialized_size_ulong(encoding, size);
@@ -5997,7 +5995,7 @@ bool DynamicDataImpl::get_index_to_id_from_complex(IndexToIdMap& index_to_id,
   CORBA::ULong length = 0;
   if (!complex_map_.empty()) {
     CORBA::ULong largest_index;
-    if (!get_largest_complex_index(largest_index)) {
+    if (!container_.get_largest_complex_index(largest_index)) {
       return false;
     }
     length = largest_index + 1;
@@ -6030,7 +6028,7 @@ bool DynamicDataImpl::serialized_size_sequence(const DCPS::Encoding& encoding,
     CORBA::ULong length = 0;
     if (!is_empty) {
       CORBA::ULong largest_index;
-      if (!get_largest_index_basic(largest_index)) {
+      if (!container_.get_largest_index_basic(largest_index)) {
         return false;
       }
       length = largest_index + 1;
@@ -6071,7 +6069,7 @@ bool DynamicDataImpl::serialized_size_sequence(const DCPS::Encoding& encoding,
       CORBA::ULong length = 0;
       if (!is_empty) {
         CORBA::ULong largest_index;
-        if (!get_largest_index_basic_sequence(largest_index)) {
+        if (!container_.get_largest_index_basic_sequence(largest_index)) {
           return false;
         }
         length = largest_index + 1;
@@ -6114,7 +6112,7 @@ bool DynamicDataImpl::serialize_sequence(DCPS::Serializer& ser, DCPS::Sample::Ex
     CORBA::ULong length = 0;
     if (!is_empty) {
       CORBA::ULong largest_index;
-      if (!get_largest_index_basic(largest_index)) {
+      if (!container_.get_largest_index_basic(largest_index)) {
         return false;
       }
       length = largest_index + 1;
@@ -6145,7 +6143,7 @@ bool DynamicDataImpl::serialize_sequence(DCPS::Serializer& ser, DCPS::Sample::Ex
       CORBA::ULong length = 0;
       if (!is_empty) {
         CORBA::ULong largest_index;
-        if (!get_largest_index_basic_sequence(largest_index)) {
+        if (!container_.get_largest_index_basic_sequence(largest_index)) {
           return false;
         }
         length = largest_index + 1;
@@ -6164,7 +6162,7 @@ bool DynamicDataImpl::serialize_sequence(DCPS::Serializer& ser, DCPS::Sample::Ex
   CORBA::ULong length = 0;
   if (!container_.complex_map_.empty()) {
     CORBA::ULong largest_index;
-    if (!get_largest_complex_index(largest_index)) {
+    if (!container_.get_largest_complex_index(largest_index)) {
       return false;
     }
     length = largest_index + 1;

--- a/dds/DCPS/XTypes/DynamicDataImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataImpl.cpp
@@ -266,7 +266,7 @@ ACE_CDR::ULong DynamicDataImpl::get_item_count()
     }
     DDS::DynamicType_var disc_type = get_base_type(type_desc_->discriminator_type());
     CORBA::Long disc_val;
-    if (!container_.set_default_discriminator_value(disc_val, disc_type)) {
+    if (!set_default_discriminator_value(disc_val, disc_type)) {
       if (log_level >= LogLevel::Warning) {
         ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: DynamicDataImpl::get_item_count:"
                    " set_default_discriminator_value failed\n"));
@@ -378,19 +378,19 @@ DDS::ReturnCode_t DynamicDataImpl::clear_value(DDS::MemberId id)
     erase_member(id);
     for (CORBA::ULong i = id; i < size - 1; ++i) {
       const DDS::MemberId next_id = i + 1;
-      DataContainer::const_single_iterator single_it = container_.single_map_.find(next_id);
+      const_single_iterator single_it = container_.single_map_.find(next_id);
       if (single_it != container_.single_map_.end()) {
         container_.single_map_.insert(std::make_pair(i, single_it->second));
         container_.single_map_.erase(next_id);
         continue;
       }
-      DataContainer::const_sequence_iterator seq_it = container_.sequence_map_.find(next_id);
+      const_sequence_iterator seq_it = container_.sequence_map_.find(next_id);
       if (seq_it != container_.sequence_map_.end()) {
         container_.sequence_map_.insert(std::make_pair(i, seq_it->second));
         container_.sequence_map_.erase(next_id);
         continue;
       }
-      DataContainer::const_complex_iterator complex_it = container_.complex_map_.find(next_id);
+      const_complex_iterator complex_it = container_.complex_map_.find(next_id);
       if (complex_it != container_.complex_map_.end()) {
         container_.complex_map_.insert(std::make_pair(i, complex_it->second));
         container_.complex_map_.erase(next_id);
@@ -436,104 +436,104 @@ DDS::ReturnCode_t DynamicDataImpl::clear_value_i(DDS::MemberId id, const DDS::Dy
   switch (tk) {
   case TK_BOOLEAN: {
     ACE_OutputCDR::from_boolean val(false);
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_BYTE: {
     ACE_OutputCDR::from_octet val(0);
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_UINT8: {
     ACE_OutputCDR::from_uint8 val(0);
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_UINT16: {
     CORBA::UInt16 val(0);
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_UINT32: {
     CORBA::UInt32 val(0);
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_UINT64: {
     CORBA::UInt64 val(0);
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_INT8: {
     ACE_OutputCDR::from_int8 val(0);
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_INT16: {
     CORBA::Int16 val(0);
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_INT32: {
     CORBA::Int32 val(0);
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_INT64: {
     CORBA::Int64 val(0);
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_FLOAT32: {
     CORBA::Float val(0.0f);
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_FLOAT64: {
     CORBA::Double val(0.0);
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_FLOAT128: {
     CORBA::LongDouble val;
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_CHAR8: {
     ACE_OutputCDR::from_char val('\0');
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_STRING8: {
     const char* val = 0;
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
 #ifdef DDS_HAS_WCHAR
   case TK_CHAR16: {
     ACE_OutputCDR::from_wchar val(L'\0');
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
   case TK_STRING16: {
     const CORBA::WChar* val = 0;
-    container_.set_default_basic_value(val);
+    set_default_basic_value(val);
     insert_single(id, val);
     break;
   }
@@ -541,7 +541,7 @@ DDS::ReturnCode_t DynamicDataImpl::clear_value_i(DDS::MemberId id, const DDS::Dy
   case TK_ENUM: {
     // Set to first enumerator
     CORBA::Long value;
-    if (!container_.set_default_enum_value(member_type, value)) {
+    if (!set_default_enum_value(member_type, value)) {
       return DDS::RETCODE_ERROR;
     }
     TypeKind treat_as = tk;
@@ -566,19 +566,19 @@ DDS::ReturnCode_t DynamicDataImpl::clear_value_i(DDS::MemberId id, const DDS::Dy
     }
     if (treat_as == TK_UINT8) {
       ACE_OutputCDR::from_uint8 val(0);
-      container_.set_default_bitmask_value(val);
+      set_default_bitmask_value(val);
       insert_single(id, val);
     } else if (treat_as == TK_UINT16) {
       CORBA::UShort val;
-      container_.set_default_bitmask_value(val);
+      set_default_bitmask_value(val);
       insert_single(id, val);
     } else if (treat_as == TK_UINT32) {
       CORBA::ULong val;
-      container_.set_default_bitmask_value(val);
+      set_default_bitmask_value(val);
       insert_single(id, val);
     } else {
       CORBA::ULongLong val;
-      container_.set_default_bitmask_value(val);
+      set_default_bitmask_value(val);
       insert_single(id, val);
     }
     break;
@@ -1162,7 +1162,7 @@ template<> const DDS::WstringSeq& DynamicDataImpl::SequenceValue::get() const
 #undef SEQUENCE_VALUE_GETTERS
 
 bool DynamicDataImpl::read_discriminator(CORBA::Long& disc_val, const DDS::DynamicType_var& disc_type,
-                                         DataContainer::const_single_iterator it) const
+                                         const_single_iterator it) const
 {
   switch (disc_type->get_kind()) {
   case TK_BOOLEAN: {
@@ -1253,7 +1253,7 @@ bool DynamicDataImpl::read_discriminator(CORBA::Long& disc_val) const
   if (!is_valid_discriminator_type(type_->get_kind())) {
     return false;
   }
-  DataContainer::const_single_iterator it = container_.single_map_.find(MEMBER_ID_INVALID);
+  const_single_iterator it = container_.single_map_.find(MEMBER_ID_INVALID);
   if (it == container_.single_map_.end()) {
     return false;
   }
@@ -1266,7 +1266,7 @@ DDS::MemberId DynamicDataImpl::find_selected_member() const
 {
   // There can be at most 2 entries in total in all three maps,
   // one for the discriminator, one for a selected member.
-  for (DataContainer::const_single_iterator single_it = container_.single_map_.begin();
+  for (const_single_iterator single_it = container_.single_map_.begin();
        single_it != container_.single_map_.end(); ++single_it) {
     if (single_it->first != DISCRIMINATOR_ID) {
       return single_it->first;
@@ -1280,7 +1280,7 @@ DDS::MemberId DynamicDataImpl::find_selected_member() const
     return container_.sequence_map_.begin()->first;
   }
 
-  for (DataContainer::const_complex_iterator cmpl_it = container_.complex_map_.begin();
+  for (const_complex_iterator cmpl_it = container_.complex_map_.begin();
        cmpl_it != container_.complex_map_.end(); ++cmpl_it) {
     if (cmpl_it->first != DISCRIMINATOR_ID) {
       return cmpl_it->first;
@@ -1873,19 +1873,18 @@ DDS::ReturnCode_t DynamicDataImpl::set_wstring_value(DDS::MemberId id, const COR
 DDS::ReturnCode_t DynamicDataImpl::get_simple_value_boolean(DCPS::Value& value,
                                                             DDS::MemberId id) const
 {
-  DataContainer::const_single_iterator single_it = container_.single_map_.find(id);
+  const_single_iterator single_it = container_.single_map_.find(id);
   if (single_it != container_.single_map_.end()) {
     value = single_it->second.get<ACE_OutputCDR::from_boolean>().val_;
     return DDS::RETCODE_OK;
   }
-  DataContainer::const_complex_iterator complex_it = container_.complex_map_.find(id);
+  const_complex_iterator complex_it = container_.complex_map_.find(id);
   if (complex_it != container_.complex_map_.end()) {
     const DynamicDataImpl* inner_dd = dynamic_cast<DynamicDataImpl*>(complex_it->second.in());
     if (!inner_dd) {
       return DDS::RETCODE_ERROR;
     }
-    DataContainer::const_single_iterator inner_it =
-      inner_dd->container_.single_map_.find(MEMBER_ID_INVALID);
+    const_single_iterator inner_it = inner_dd->container_.single_map_.find(MEMBER_ID_INVALID);
     if (inner_it != inner_dd->container_.single_map_.end()) {
       value = inner_it->second.get<ACE_OutputCDR::from_boolean>().val_;
       return DDS::RETCODE_OK;
@@ -1897,19 +1896,18 @@ DDS::ReturnCode_t DynamicDataImpl::get_simple_value_boolean(DCPS::Value& value,
 DDS::ReturnCode_t DynamicDataImpl::get_simple_value_char(DCPS::Value& value,
                                                          DDS::MemberId id) const
 {
-  DataContainer::const_single_iterator single_it = container_.single_map_.find(id);
+  const_single_iterator single_it = container_.single_map_.find(id);
   if (single_it != container_.single_map_.end()) {
     value = single_it->second.get<ACE_OutputCDR::from_char>().val_;
     return DDS::RETCODE_OK;
   }
-  DataContainer::const_complex_iterator complex_it = container_.complex_map_.find(id);
+  const_complex_iterator complex_it = container_.complex_map_.find(id);
   if (complex_it != container_.complex_map_.end()) {
     const DynamicDataImpl* inner_dd = dynamic_cast<DynamicDataImpl*>(complex_it->second.in());
     if (!inner_dd) {
       return DDS::RETCODE_ERROR;
     }
-    DataContainer::const_single_iterator inner_it =
-      inner_dd->container_.single_map_.find(MEMBER_ID_INVALID);
+    const_single_iterator inner_it = inner_dd->container_.single_map_.find(MEMBER_ID_INVALID);
     if (inner_it != inner_dd->container_.single_map_.end()) {
       value = inner_it->second.get<ACE_OutputCDR::from_char>().val_;
       return DDS::RETCODE_OK;
@@ -1922,19 +1920,18 @@ template<typename ValueType>
 DDS::ReturnCode_t DynamicDataImpl::get_simple_value_primitive(DCPS::Value& value,
                                                               DDS::MemberId id) const
 {
-  DataContainer::const_single_iterator single_it = container_.single_map_.find(id);
+  const_single_iterator single_it = container_.single_map_.find(id);
   if (single_it != container_.single_map_.end()) {
     value = single_it->second.get<ValueType>();
     return DDS::RETCODE_OK;
   }
-  DataContainer::const_complex_iterator complex_it = container_.complex_map_.find(id);
+  const_complex_iterator complex_it = container_.complex_map_.find(id);
   if (complex_it != container_.complex_map_.end()) {
     const DynamicDataImpl* inner_dd = dynamic_cast<DynamicDataImpl*>(complex_it->second.in());
     if (!inner_dd) {
       return DDS::RETCODE_ERROR;
     }
-    DataContainer::const_single_iterator inner_it =
-      inner_dd->container_.single_map_.find(MEMBER_ID_INVALID);
+    const_single_iterator inner_it = inner_dd->container_.single_map_.find(MEMBER_ID_INVALID);
     if (inner_it != inner_dd->container_.single_map_.end()) {
       value = inner_it->second.get<ValueType>();
       return DDS::RETCODE_OK;
@@ -1946,13 +1943,13 @@ DDS::ReturnCode_t DynamicDataImpl::get_simple_value_primitive(DCPS::Value& value
 DDS::ReturnCode_t DynamicDataImpl::get_simple_value_string(DCPS::Value& value,
                                                            DDS::MemberId id) const
 {
-  DataContainer::const_single_iterator single_it = container_.single_map_.find(id);
+  const_single_iterator single_it = container_.single_map_.find(id);
   if (single_it != container_.single_map_.end()) {
     value = single_it->second.get<const char*>();
     return DDS::RETCODE_OK;
   }
 
-  DataContainer::const_complex_iterator complex_it = container_.complex_map_.find(id);
+  const_complex_iterator complex_it = container_.complex_map_.find(id);
   if (complex_it != container_.complex_map_.end()) {
     // The string member has its own DynamicData object.
     const DynamicDataImpl* str_dd = dynamic_cast<DynamicDataImpl*>(complex_it->second.in());
@@ -2558,7 +2555,7 @@ bool DynamicDataImpl::read_basic_value(char*& value) const
     const CORBA::ULong length = largest_index + 2;
     CORBA::String_var str_var = CORBA::string_alloc(length);
     ACE_OS::memset(str_var.inout(), 0, length);
-    if (!container_.reconstruct_string_value(str_var.inout())) {
+    if (!reconstruct_string_value(str_var.inout())) {
       return false;
     }
     CORBA::string_free(value);
@@ -2582,7 +2579,7 @@ bool DynamicDataImpl::read_basic_value(CORBA::WChar*& value) const
     const CORBA::ULong length = largest_index + 2;
     CORBA::WString_var wstr_var = CORBA::wstring_alloc(length);
     ACE_OS::memset(wstr_var.inout(), 0, length * sizeof(CORBA::WChar));
-    if (!container_.reconstruct_wstring_value(wstr_var.inout())) {
+    if (!reconstruct_wstring_value(wstr_var.inout())) {
       return false;
     }
     CORBA::wstring_free(value);
@@ -2598,7 +2595,7 @@ bool DynamicDataImpl::read_basic_value(CORBA::WChar*& value) const
 template<typename ValueType>
 bool DynamicDataImpl::read_basic_in_single_map(ValueType& value, DDS::MemberId id)
 {
-  DataContainer::const_single_iterator single_it = container_.single_map_.find(id);
+  const_single_iterator single_it = container_.single_map_.find(id);
   if (single_it != container_.single_map_.end()) {
     value = single_it->second.get<ValueType>();
     return true;
@@ -2609,7 +2606,7 @@ bool DynamicDataImpl::read_basic_in_single_map(ValueType& value, DDS::MemberId i
 template<>
 bool DynamicDataImpl::read_basic_in_single_map(char*& value, DDS::MemberId id)
 {
-  DataContainer::const_single_iterator single_it = container_.single_map_.find(id);
+  const_single_iterator single_it = container_.single_map_.find(id);
   if (single_it != container_.single_map_.end()) {
     CORBA::string_free(value);
     value = single_it->second.get_string();
@@ -2621,7 +2618,7 @@ bool DynamicDataImpl::read_basic_in_single_map(char*& value, DDS::MemberId id)
 template<>
 bool DynamicDataImpl::read_basic_in_single_map(CORBA::WChar*& value, DDS::MemberId id)
 {
-  DataContainer::const_single_iterator single_it = container_.single_map_.find(id);
+  const_single_iterator single_it = container_.single_map_.find(id);
   if (single_it != container_.single_map_.end()) {
     CORBA::wstring_free(value);
     value = single_it->second.get_wstring();
@@ -2633,7 +2630,7 @@ bool DynamicDataImpl::read_basic_in_single_map(CORBA::WChar*& value, DDS::Member
 template<typename ValueType>
 bool DynamicDataImpl::read_basic_in_complex_map(ValueType& value, DDS::MemberId id)
 {
-  DataContainer::const_complex_iterator complex_it = container_.complex_map_.find(id);
+  const_complex_iterator complex_it = container_.complex_map_.find(id);
   if (complex_it != container_.complex_map_.end()) {
     DynamicDataImpl* nested_dd = dynamic_cast<DynamicDataImpl*>(complex_it->second.in());
     return nested_dd && nested_dd->read_basic_value(value);
@@ -2666,11 +2663,11 @@ bool DynamicDataImpl::get_value_from_self(ValueType& value, DDS::MemberId id)
   if (!is_primitive(type_->get_kind()) || id != MEMBER_ID_INVALID) {
     return false;
   }
-  DataContainer::const_single_iterator it = container_.single_map_.find(MEMBER_ID_INVALID);
+  const_single_iterator it = container_.single_map_.find(MEMBER_ID_INVALID);
   if (it != container_.single_map_.end()) {
     value = it->second.get<ValueType>();
   } else {
-    container_.set_default_basic_value(value);
+    set_default_basic_value(value);
   }
   return true;
 }
@@ -2697,12 +2694,12 @@ bool DynamicDataImpl::get_value_from_enum(ValueType& value, DDS::MemberId id)
   if (rc != DDS::RETCODE_OK || treat_as_tk != ValueTypeKind || id != MEMBER_ID_INVALID) {
     return false;
   }
-  DataContainer::const_single_iterator it = container_.single_map_.find(MEMBER_ID_INVALID);
+  const_single_iterator it = container_.single_map_.find(MEMBER_ID_INVALID);
   if (it != container_.single_map_.end()) {
     value = it->second.get<ValueType>();
   } else {
     CORBA::Long enum_default_val;
-    if (!container_.set_default_enum_value(type_, enum_default_val)) {
+    if (!set_default_enum_value(type_, enum_default_val)) {
       return false;
     }
     cast_to_enum_value(value, enum_default_val);
@@ -2730,11 +2727,11 @@ bool DynamicDataImpl::get_value_from_bitmask(ValueType& value, DDS::MemberId id)
   if (rc != DDS::RETCODE_OK || treat_as_tk != ValueTypeKind || id != MEMBER_ID_INVALID) {
     return false;
   }
-  DataContainer::const_single_iterator it = container_.single_map_.find(MEMBER_ID_INVALID);
+  const_single_iterator it = container_.single_map_.find(MEMBER_ID_INVALID);
   if (it != container_.single_map_.end()) {
     value = it->second.get<ValueType>();
   } else {
-    container_.set_default_bitmask_value(value);
+    set_default_bitmask_value(value);
   }
   return true;
 }
@@ -2772,7 +2769,7 @@ bool DynamicDataImpl::get_value_from_struct(ValueType& value, DDS::MemberId id)
     }
     return false;
   }
-  container_.set_default_basic_value(value);
+  set_default_basic_value(value);
   return true;
 }
 
@@ -2795,7 +2792,7 @@ bool DynamicDataImpl::get_value_from_union(ValueType& value, DDS::MemberId id)
   if (id == DISCRIMINATOR_ID) {
     // Set the discriminator to default value.
     // If it selects a branch, set the branch to default value.
-    container_.set_default_basic_value(value);
+    set_default_basic_value(value);
     CORBA::Long disc_value;
     if (!cast_to_discriminator_value(disc_value, value)) {
       return false;
@@ -2819,8 +2816,8 @@ bool DynamicDataImpl::get_value_from_union(ValueType& value, DDS::MemberId id)
       }
     }
   } else {
-    DataContainer::const_single_iterator single_it = container_.single_map_.find(DISCRIMINATOR_ID);
-    DataContainer::const_complex_iterator complex_it = container_.complex_map_.find(DISCRIMINATOR_ID);
+    const_single_iterator single_it = container_.single_map_.find(DISCRIMINATOR_ID);
+    const_complex_iterator complex_it = container_.complex_map_.find(DISCRIMINATOR_ID);
     const bool has_disc = single_it != container_.single_map_.end() ||
       complex_it != container_.complex_map_.end();
     if (has_disc) {
@@ -2899,7 +2896,7 @@ bool DynamicDataImpl::get_value_from_collection(ValueType& value, DDS::MemberId 
   if (read_basic_member(value, id)) {
     return true;
   }
-  container_.set_default_basic_value(value);
+  set_default_basic_value(value);
 
   // Must insert this member in case it's index is larger than the current largest index,
   // so that all new members up to this member are serialized. Otherwise, we would be returning
@@ -3033,13 +3030,13 @@ DDS::ReturnCode_t DynamicDataImpl::get_char_common(CharT& value, DDS::MemberId i
       good = false;
       break;
     }
-    DataContainer::const_single_iterator it = container_.single_map_.find(id);
+    const_single_iterator it = container_.single_map_.find(id);
     if (it != container_.single_map_.end()) {
       FromCharT from_char = it->second.get<FromCharT>();
       value = from_char.val_;
     } else {
       FromCharT from_char('\0');
-      container_.set_default_basic_value(from_char);
+      set_default_basic_value(from_char);
       value = from_char.val_;
     }
     break;
@@ -3153,13 +3150,13 @@ DDS::ReturnCode_t DynamicDataImpl::get_boolean_value(CORBA::Boolean& value, DDS:
       good = false;
       break;
     }
-    DataContainer::const_single_iterator it = container_.single_map_.find(id);
+    const_single_iterator it = container_.single_map_.find(id);
     if (it != container_.single_map_.end()) {
       ACE_OutputCDR::from_boolean from_bool = it->second.get<ACE_OutputCDR::from_boolean>();
       value = from_bool.val_;
     } else {
       ACE_OutputCDR::from_boolean from_bool(false);
-      container_.set_default_basic_value(from_bool);
+      set_default_basic_value(from_bool);
       value = from_bool.val_;
     }
     break;
@@ -3245,8 +3242,7 @@ DDS::ReturnCode_t DynamicDataImpl::get_wstring_value(CORBA::WChar*& value, DDS::
 #endif
 }
 
-bool DynamicDataImpl::move_single_to_complex(const DataContainer::const_single_iterator& it,
-                                             DynamicDataImpl* data)
+bool DynamicDataImpl::move_single_to_complex(const const_single_iterator& it, DynamicDataImpl* data)
 {
   DDS::DynamicType_var member_type = data->type();
   const TypeKind member_tk = member_type->get_kind();
@@ -3259,7 +3255,7 @@ bool DynamicDataImpl::move_single_to_complex(const DataContainer::const_single_i
   return move_single_to_complex_i(it, data, treat_as);
 }
 
-bool DynamicDataImpl::move_single_to_complex_i(const DataContainer::const_single_iterator& it,
+bool DynamicDataImpl::move_single_to_complex_i(const const_single_iterator& it,
                                                DynamicDataImpl* data, const TypeKind treat_as)
 {
   switch (treat_as) {
@@ -3365,8 +3361,7 @@ bool DynamicDataImpl::move_single_to_complex_i(const DataContainer::const_single
 }
 
 template<typename SequenceType>
-void DynamicDataImpl::move_sequence_helper(const DataContainer::const_sequence_iterator& it,
-                                           DynamicDataImpl* data)
+void DynamicDataImpl::move_sequence_helper(const const_sequence_iterator& it, DynamicDataImpl* data)
 {
   const SequenceType& values = it->second.get<SequenceType>();
   for (CORBA::ULong i = 0; i < values.length(); ++i) {
@@ -3376,7 +3371,7 @@ void DynamicDataImpl::move_sequence_helper(const DataContainer::const_sequence_i
 
 // Get the inner C-string explicitly
 template<>
-void DynamicDataImpl::move_sequence_helper<DDS::StringSeq>(const DataContainer::const_sequence_iterator& it,
+void DynamicDataImpl::move_sequence_helper<DDS::StringSeq>(const const_sequence_iterator& it,
                                                            DynamicDataImpl* data)
 {
   const DDS::StringSeq& values = it->second.get<DDS::StringSeq>();
@@ -3387,7 +3382,7 @@ void DynamicDataImpl::move_sequence_helper<DDS::StringSeq>(const DataContainer::
 
 #ifdef DDS_HAS_WCHAR
 template<>
-void DynamicDataImpl::move_sequence_helper<DDS::WstringSeq>(const DataContainer::const_sequence_iterator& it,
+void DynamicDataImpl::move_sequence_helper<DDS::WstringSeq>(const const_sequence_iterator& it,
                                                             DynamicDataImpl* data)
 {
   const DDS::WstringSeq& values = it->second.get<DDS::WstringSeq>();
@@ -3398,7 +3393,7 @@ void DynamicDataImpl::move_sequence_helper<DDS::WstringSeq>(const DataContainer:
 #endif
 
 template<>
-void DynamicDataImpl::move_sequence_helper<DDS::Int8Seq>(const DataContainer::const_sequence_iterator& it,
+void DynamicDataImpl::move_sequence_helper<DDS::Int8Seq>(const const_sequence_iterator& it,
                                                          DynamicDataImpl* data)
 {
   const DDS::Int8Seq& values = it->second.get<DDS::Int8Seq>();
@@ -3408,7 +3403,7 @@ void DynamicDataImpl::move_sequence_helper<DDS::Int8Seq>(const DataContainer::co
 }
 
 template<>
-void DynamicDataImpl::move_sequence_helper<DDS::UInt8Seq>(const DataContainer::const_sequence_iterator& it,
+void DynamicDataImpl::move_sequence_helper<DDS::UInt8Seq>(const const_sequence_iterator& it,
                                                           DynamicDataImpl* data)
 {
   const DDS::UInt8Seq& values = it->second.get<DDS::UInt8Seq>();
@@ -3418,7 +3413,7 @@ void DynamicDataImpl::move_sequence_helper<DDS::UInt8Seq>(const DataContainer::c
 }
 
 template<>
-void DynamicDataImpl::move_sequence_helper<DDS::CharSeq>(const DataContainer::const_sequence_iterator& it,
+void DynamicDataImpl::move_sequence_helper<DDS::CharSeq>(const const_sequence_iterator& it,
                                                          DynamicDataImpl* data)
 {
   const DDS::CharSeq& values = it->second.get<DDS::CharSeq>();
@@ -3428,7 +3423,7 @@ void DynamicDataImpl::move_sequence_helper<DDS::CharSeq>(const DataContainer::co
 }
 
 template<>
-void DynamicDataImpl::move_sequence_helper<DDS::ByteSeq>(const DataContainer::const_sequence_iterator& it,
+void DynamicDataImpl::move_sequence_helper<DDS::ByteSeq>(const const_sequence_iterator& it,
                                                          DynamicDataImpl* data)
 {
   const DDS::ByteSeq& values = it->second.get<DDS::ByteSeq>();
@@ -3438,7 +3433,7 @@ void DynamicDataImpl::move_sequence_helper<DDS::ByteSeq>(const DataContainer::co
 }
 
 template<>
-void DynamicDataImpl::move_sequence_helper<DDS::BooleanSeq>(const DataContainer::const_sequence_iterator& it,
+void DynamicDataImpl::move_sequence_helper<DDS::BooleanSeq>(const const_sequence_iterator& it,
                                                             DynamicDataImpl* data)
 {
   const DDS::BooleanSeq& values = it->second.get<DDS::BooleanSeq>();
@@ -3449,7 +3444,7 @@ void DynamicDataImpl::move_sequence_helper<DDS::BooleanSeq>(const DataContainer:
 
 #ifdef DDS_HAS_WCHAR
 template<>
-void DynamicDataImpl::move_sequence_helper<DDS::WcharSeq>(const DataContainer::const_sequence_iterator& it,
+void DynamicDataImpl::move_sequence_helper<DDS::WcharSeq>(const const_sequence_iterator& it,
                                                           DynamicDataImpl* data)
 {
   const DDS::WcharSeq& values = it->second.get<DDS::WcharSeq>();
@@ -3459,7 +3454,7 @@ void DynamicDataImpl::move_sequence_helper<DDS::WcharSeq>(const DataContainer::c
 }
 #endif
 
-bool DynamicDataImpl::move_sequence_to_complex(const DataContainer::const_sequence_iterator& it,
+bool DynamicDataImpl::move_sequence_to_complex(const const_sequence_iterator& it,
                                                DynamicDataImpl* data)
 {
   DDS::DynamicType_var seq_type = data->type();
@@ -3551,7 +3546,7 @@ bool DynamicDataImpl::move_sequence_to_complex(const DataContainer::const_sequen
 bool DynamicDataImpl::get_complex_from_aggregated(DDS::DynamicData_var& value, DDS::MemberId id,
                                                   FoundStatus& found_status)
 {
-  DataContainer::const_complex_iterator complex_it = container_.complex_map_.find(id);
+  const_complex_iterator complex_it = container_.complex_map_.find(id);
   if (complex_it != container_.complex_map_.end()) {
     value = DDS::DynamicData::_duplicate(complex_it->second);
     found_status = FOUND_IN_COMPLEX_MAP;
@@ -3570,14 +3565,14 @@ bool DynamicDataImpl::get_complex_from_aggregated(DDS::DynamicData_var& value, D
   DynamicDataImpl* dd_impl = new DynamicDataImpl(member_type);
   DDS::DynamicData_var dd_var = dd_impl;
 
-  DataContainer::const_single_iterator single_it = container_.single_map_.find(id);
+  const_single_iterator single_it = container_.single_map_.find(id);
   if (single_it != container_.single_map_.end()) {
     if (!move_single_to_complex(single_it, dd_impl)) {
       return false;
     }
     found_status = FOUND_IN_NON_COMPLEX_MAP;
   } else {
-    DataContainer::const_sequence_iterator sequence_it = container_.sequence_map_.find(id);
+    const_sequence_iterator sequence_it = container_.sequence_map_.find(id);
     if (sequence_it != container_.sequence_map_.end()) {
       if (!move_sequence_to_complex(sequence_it, dd_impl)) {
         return false;
@@ -3673,7 +3668,7 @@ bool DynamicDataImpl::get_complex_from_union(DDS::DynamicData_ptr& value, DDS::M
   if (id == DISCRIMINATOR_ID) {
     DDS::DynamicType_var disc_type = get_base_type(type_desc_->discriminator_type());
     CORBA::Long disc_value;
-    if (!container_.set_default_discriminator_value(disc_value, disc_type)) {
+    if (!set_default_discriminator_value(disc_value, disc_type)) {
       return false;
     }
     bool found_selected_member = false;
@@ -3700,8 +3695,8 @@ bool DynamicDataImpl::get_complex_from_union(DDS::DynamicData_ptr& value, DDS::M
     CORBA::release(value);
     value = DDS::DynamicData::_duplicate(dd_var);
   } else {
-    DataContainer::const_single_iterator single_it = container_.single_map_.find(DISCRIMINATOR_ID);
-    DataContainer::const_complex_iterator complex_it = container_.complex_map_.find(DISCRIMINATOR_ID);
+    const_single_iterator single_it = container_.single_map_.find(DISCRIMINATOR_ID);
+    const_complex_iterator complex_it = container_.complex_map_.find(DISCRIMINATOR_ID);
     const bool has_disc = single_it != container_.single_map_.end() ||
       complex_it != container_.complex_map_.end();
     if (has_disc) {
@@ -3734,7 +3729,7 @@ bool DynamicDataImpl::get_complex_from_union(DDS::DynamicData_ptr& value, DDS::M
 
 bool DynamicDataImpl::get_complex_from_collection(DDS::DynamicData_ptr& value, DDS::MemberId id)
 {
-  DataContainer::const_complex_iterator complex_it = container_.complex_map_.find(id);
+  const_complex_iterator complex_it = container_.complex_map_.find(id);
   if (complex_it != container_.complex_map_.end()) {
     CORBA::release(value);
     value = DDS::DynamicData::_duplicate(complex_it->second);
@@ -3748,13 +3743,13 @@ bool DynamicDataImpl::get_complex_from_collection(DDS::DynamicData_ptr& value, D
   DynamicDataImpl* dd_impl = new DynamicDataImpl(type_desc_->element_type());
   DDS::DynamicData_var dd_var = dd_impl;
 
-  DataContainer::const_single_iterator single_it = container_.single_map_.find(id);
+  const_single_iterator single_it = container_.single_map_.find(id);
   if (single_it != container_.single_map_.end()) {
     if (!move_single_to_complex(single_it, dd_impl)) {
       return false;
     }
   } else {
-    DataContainer::const_sequence_iterator sequence_it = container_.sequence_map_.find(id);
+    const_sequence_iterator sequence_it = container_.sequence_map_.find(id);
     if (sequence_it != container_.sequence_map_.end()) {
       if (!move_sequence_to_complex(sequence_it, dd_impl)) {
         return false;
@@ -4115,14 +4110,14 @@ bool DynamicDataImpl::reconstruct_string_value(CORBA::Char* str) const
   const CORBA::ULong bound = type_desc_->bound()[0];
   for (const_single_iterator it = container_.single_map_.begin(); it != container_.single_map_.end(); ++it) {
     CORBA::ULong index;
-    if (!data_->get_index_from_id(it->first, index, bound)) {
+    if (!get_index_from_id(it->first, index, bound)) {
       return false;
     }
     str[index] = it->second.get<ACE_OutputCDR::from_char>().val_;
   }
   for (const_complex_iterator it = container_.complex_map_.begin(); it != container_.complex_map_.end(); ++it) {
     CORBA::ULong index;
-    if (!data_->get_index_from_id(it->first, index, bound)) {
+    if (!get_index_from_id(it->first, index, bound)) {
       return false;
     }
     // The DynamicData object for this character may not contain any data.
@@ -4164,7 +4159,7 @@ bool DynamicDataImpl::serialized_size_string(const DCPS::Encoding& encoding, siz
 bool DynamicDataImpl::serialize_string_value(DCPS::Serializer& ser) const
 {
   char* str = 0;
-  return data_->read_basic_value(str) && (ser << str);
+  return read_basic_value(str) && (ser << str);
 }
 
 #ifdef DDS_HAS_WCHAR
@@ -4173,14 +4168,14 @@ bool DynamicDataImpl::reconstruct_wstring_value(CORBA::WChar* wstr) const
   const CORBA::ULong bound = type_desc_->bound()[0];
   for (const_single_iterator it = container_.single_map_.begin(); it != container_.single_map_.end(); ++it) {
     CORBA::ULong index;
-    if (!data_->get_index_from_id(it->first, index, bound)) {
+    if (!get_index_from_id(it->first, index, bound)) {
       return false;
     }
     wstr[index] = it->second.get<ACE_OutputCDR::from_wchar>().val_;
   }
   for (const_complex_iterator it = container_.complex_map_.begin(); it != container_.complex_map_.end(); ++it) {
     CORBA::ULong index;
-    if (!data_->get_index_from_id(it->first, index, bound)) {
+    if (!get_index_from_id(it->first, index, bound)) {
       return false;
     }
     const DynamicDataImpl* elem_dd = dynamic_cast<const DynamicDataImpl*>(it->second.in());
@@ -4219,7 +4214,7 @@ bool DynamicDataImpl::serialized_size_wstring(const DCPS::Encoding& encoding, si
 bool DynamicDataImpl::serialize_wstring_value(DCPS::Serializer& ser) const
 {
   CORBA::WChar* wstr = 0;
-  return data_->read_basic_value(wstr) && (ser << wstr);
+  return read_basic_value(wstr) && (ser << wstr);
 }
 #endif
 
@@ -5519,21 +5514,21 @@ bool DynamicDataImpl::get_index_to_id_map(IndexToIdMap& index_to_id,
 {
   for (const_single_iterator it = container_.single_map_.begin(); it != container_.single_map_.end(); ++it) {
     CORBA::ULong index;
-    if (!data_->get_index_from_id(it->first, index, bound)) {
+    if (!get_index_from_id(it->first, index, bound)) {
       return false;
     }
     index_to_id[index] = it->first;
   }
   for (const_sequence_iterator it = container_.sequence_map_.begin(); it != container_.sequence_map_.end(); ++it) {
     CORBA::ULong index;
-    if (!data_->get_index_from_id(it->first, index, bound)) {
+    if (!get_index_from_id(it->first, index, bound)) {
       return false;
     }
     index_to_id[index] = it->first;
   }
   for (const_complex_iterator it = container_.complex_map_.begin(); it != container_.complex_map_.end(); ++it) {
     CORBA::ULong index;
-    if (!data_->get_index_from_id(it->first, index, bound)) {
+    if (!get_index_from_id(it->first, index, bound)) {
       return false;
     }
     index_to_id[index] = it->first;
@@ -5965,7 +5960,7 @@ bool DynamicDataImpl::serialize_complex_sequence(DCPS::Serializer& ser,
   IndexToIdMap index_to_id(size, MEMBER_ID_INVALID);
   for (const_complex_iterator it = container_.complex_map_.begin(); it != container_.complex_map_.end(); ++it) {
     CORBA::ULong index;
-    if (!data_->get_index_from_id(it->first, index, bound)) {
+    if (!get_index_from_id(it->first, index, bound)) {
       return false;
     }
     index_to_id[index] = it->first;
@@ -5993,7 +5988,7 @@ bool DynamicDataImpl::get_index_to_id_from_complex(IndexToIdMap& index_to_id,
                                                    CORBA::ULong bound) const
 {
   CORBA::ULong length = 0;
-  if (!complex_map_.empty()) {
+  if (!container_.complex_map_.empty()) {
     CORBA::ULong largest_index;
     if (!container_.get_largest_complex_index(largest_index)) {
       return false;
@@ -6003,7 +5998,7 @@ bool DynamicDataImpl::get_index_to_id_from_complex(IndexToIdMap& index_to_id,
   index_to_id.resize(length, MEMBER_ID_INVALID);
   for (const_complex_iterator it = container_.complex_map_.begin(); it != container_.complex_map_.end(); ++it) {
     CORBA::ULong index;
-    if (!data_->get_index_from_id(it->first, index, bound)) {
+    if (!get_index_from_id(it->first, index, bound)) {
       return false;
     }
     index_to_id[index] = it->first;
@@ -6789,7 +6784,7 @@ bool DynamicDataImpl::serialize_complex_array(
   IndexToIdMap index_to_id(length, MEMBER_ID_INVALID);
   for (const_complex_iterator it = container_.complex_map_.begin(); it != container_.complex_map_.end(); ++it) {
     CORBA::ULong index;
-    if (!data_->get_index_from_id(it->first, index, length)) {
+    if (!get_index_from_id(it->first, index, length)) {
       return false;
     }
     index_to_id[index] = it->first;
@@ -7254,7 +7249,7 @@ bool DynamicDataImpl::serialized_size_basic_struct_member_xcdr2(
     }
   }
 
-  if (single_it != single_map_.end()) {
+  if (single_it != container_.single_map_.end()) {
     return serialized_size_single_aggregated_member_xcdr2(encoding, size, single_it, member_type,
                                                           optional, extensibility, mutable_running_total);
   }
@@ -7805,7 +7800,7 @@ bool DynamicDataImpl::serialize_structure_xcdr2(DCPS::Serializer& ser, DCPS::Sam
   const DCPS::Encoding& encoding = ser.encoding();
   size_t total_size = 0;
   if (extensibility == DDS::APPENDABLE || extensibility == DDS::MUTABLE) {
-    if (!data_->serialized_size_i(encoding, total_size, ext) || !ser.write_delimiter(total_size)) {
+    if (!serialized_size_i(encoding, total_size, ext) || !ser.write_delimiter(total_size)) {
       return false;
     }
   }
@@ -7995,7 +7990,7 @@ bool DynamicDataImpl::get_discriminator_value(
   const DDS::DynamicType_var& disc_type) const
 {
   if (single_it != container_.single_map_.end()) {
-    data_->read_discriminator(value, disc_type, single_it);
+    read_discriminator(value, disc_type, single_it);
   } else { // Find in complex map
     const DynamicDataImpl* dd_impl = dynamic_cast<const DynamicDataImpl*>(complex_it->second.in());
     if (!dd_impl) {
@@ -8003,7 +7998,7 @@ bool DynamicDataImpl::get_discriminator_value(
     }
     const_single_iterator it = dd_impl->container_.single_map_.find(MEMBER_ID_INVALID);
     if (it != dd_impl->container_.single_map_.end()) {
-      data_->read_discriminator(value, disc_type, it);
+      read_discriminator(value, disc_type, it);
     } else {
       return set_default_discriminator_value(value, disc_type);
     }
@@ -8200,7 +8195,7 @@ bool DynamicDataImpl::serialized_size_union_xcdr2(const DCPS::Encoding& encoding
   const_complex_iterator complex_it = container_.complex_map_.find(DISCRIMINATOR_ID);
   const bool has_disc = single_it != container_.single_map_.end() ||
     complex_it != container_.complex_map_.end();
-  const DDS::MemberId selected_id = data_->find_selected_member();
+  const DDS::MemberId selected_id = find_selected_member();
 
   CORBA::Long disc_value;
   if (has_disc) {
@@ -8215,7 +8210,7 @@ bool DynamicDataImpl::serialized_size_union_xcdr2(const DCPS::Encoding& encoding
     bool found_selected_member = false;
     DDS::MemberDescriptor_var selected_md;
     const DDS::ReturnCode_t rc =
-      data_->get_selected_union_branch(disc_value, found_selected_member, selected_md);
+      get_selected_union_branch(disc_value, found_selected_member, selected_md);
     if (rc != DDS::RETCODE_OK) {
       if (log_level >= LogLevel::Notice) {
         ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DynamicDataImpl::serialized_size_union_xcdr2:"
@@ -8270,7 +8265,7 @@ bool DynamicDataImpl::serialize_union_xcdr2(DCPS::Serializer& ser, DCPS::Sample:
   const DCPS::Encoding& encoding = ser.encoding();
   size_t total_size = 0;
   if (extensibility == DDS::APPENDABLE || extensibility == DDS::MUTABLE) {
-    if (!data_->serialized_size_i(encoding, total_size, ext) || !ser.write_delimiter(total_size)) {
+    if (!serialized_size_i(encoding, total_size, ext) || !ser.write_delimiter(total_size)) {
       return false;
     }
   }
@@ -8279,7 +8274,7 @@ bool DynamicDataImpl::serialize_union_xcdr2(DCPS::Serializer& ser, DCPS::Sample:
   const_complex_iterator complex_it = container_.complex_map_.find(DISCRIMINATOR_ID);
   const bool has_disc = single_it != container_.single_map_.end() ||
     complex_it != container_.complex_map_.end();
-  const DDS::MemberId selected_id = data_->find_selected_member();
+  const DDS::MemberId selected_id = find_selected_member();
   DDS::DynamicType_var disc_type = get_base_type(type_desc_->discriminator_type());
   const TypeKind disc_tk = disc_type->get_kind();
 
@@ -8300,7 +8295,7 @@ bool DynamicDataImpl::serialize_union_xcdr2(DCPS::Serializer& ser, DCPS::Sample:
     bool found_selected_member = false;
     DDS::MemberDescriptor_var selected_md;
     const DDS::ReturnCode_t rc =
-      data_->get_selected_union_branch(disc_value, found_selected_member, selected_md);
+      get_selected_union_branch(disc_value, found_selected_member, selected_md);
     if (rc != DDS::RETCODE_OK) {
       if (log_level >= LogLevel::Notice) {
         ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DynamicDataImpl::serialize_union_xcdr2:"

--- a/dds/DCPS/XTypes/DynamicDataImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataImpl.cpp
@@ -3266,7 +3266,7 @@ bool DynamicDataImpl::move_single_to_complex(const const_single_iterator& it, Dy
 }
 
 bool DynamicDataImpl::move_single_to_complex_i(const const_single_iterator& it,
-                                               DynamicDataImpl* data, const TypeKind treat_as)
+                                               DynamicDataImpl* data, TypeKind treat_as)
 {
   switch (treat_as) {
   case TK_INT8: {

--- a/dds/DCPS/XTypes/DynamicDataImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataImpl.cpp
@@ -3266,7 +3266,7 @@ bool DynamicDataImpl::move_single_to_complex(const const_single_iterator& it, Dy
 }
 
 bool DynamicDataImpl::move_single_to_complex_i(const const_single_iterator& it,
-                                               DynamicDataImpl* data, TypeKind treat_as)
+                                               DynamicDataImpl* data, const TypeKind treat_as)
 {
   switch (treat_as) {
   case TK_INT8: {

--- a/dds/DCPS/XTypes/DynamicDataImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataImpl.cpp
@@ -2032,6 +2032,16 @@ DDS::ReturnCode_t DynamicDataImpl::get_simple_value(DCPS::Value& value, DDS::Mem
 }
 #endif
 
+bool DynamicDataImpl::serialized_size(const DCPS::Encoding& enc, size_t& size, DCPS::Sample::Extent ext) const
+{
+  return serialized_size_i(enc, size, ext);
+}
+
+bool DynamicDataImpl::serialize(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const
+{
+  return serialize_i(ser, ext);
+}
+
 bool DynamicDataImpl::set_complex_to_struct(DDS::MemberId id, DDS::DynamicData_var value)
 {
   DDS::DynamicTypeMember_var member;
@@ -5406,56 +5416,56 @@ bool DynamicDataImpl::serialized_size_sequence_value(
 {
   switch (sv.elem_kind_) {
   case TK_INT32:
-    serialized_size(encoding, size, sv.get<DDS::Int32Seq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::Int32Seq>());
     return true;
   case TK_UINT32:
-    serialized_size(encoding, size, sv.get<DDS::UInt32Seq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::UInt32Seq>());
     return true;
   case TK_INT8:
-    serialized_size(encoding, size, sv.get<DDS::Int8Seq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::Int8Seq>());
     return true;
   case TK_UINT8:
-    serialized_size(encoding, size, sv.get<DDS::UInt8Seq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::UInt8Seq>());
     return true;
   case TK_INT16:
-    serialized_size(encoding, size, sv.get<DDS::Int16Seq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::Int16Seq>());
     return true;
   case TK_UINT16:
-    serialized_size(encoding, size, sv.get<DDS::UInt16Seq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::UInt16Seq>());
     return true;
   case TK_INT64:
-    serialized_size(encoding, size, sv.get<DDS::Int64Seq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::Int64Seq>());
     return true;
   case TK_UINT64:
-    serialized_size(encoding, size, sv.get<DDS::UInt64Seq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::UInt64Seq>());
     return true;
   case TK_FLOAT32:
-    serialized_size(encoding, size, sv.get<DDS::Float32Seq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::Float32Seq>());
     return true;
   case TK_FLOAT64:
-    serialized_size(encoding, size, sv.get<DDS::Float64Seq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::Float64Seq>());
     return true;
   case TK_FLOAT128:
-    serialized_size(encoding, size, sv.get<DDS::Float128Seq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::Float128Seq>());
     return true;
   case TK_CHAR8:
-    serialized_size(encoding, size, sv.get<DDS::CharSeq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::CharSeq>());
     return true;
   case TK_BYTE:
-    serialized_size(encoding, size, sv.get<DDS::ByteSeq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::ByteSeq>());
     return true;
   case TK_BOOLEAN:
-    serialized_size(encoding, size, sv.get<DDS::BooleanSeq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::BooleanSeq>());
     return true;
   case TK_STRING8:
-    serialized_size(encoding, size, sv.get<DDS::StringSeq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::StringSeq>());
     return true;
 #ifdef DDS_HAS_WCHAR
   case TK_CHAR16:
-    serialized_size(encoding, size, sv.get<DDS::WcharSeq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::WcharSeq>());
     return true;
   case TK_STRING16:
-    serialized_size(encoding, size, sv.get<DDS::WstringSeq>());
+    DCPS::serialized_size(encoding, size, sv.get<DDS::WstringSeq>());
     return true;
 #endif
   default:
@@ -5563,7 +5573,7 @@ bool DynamicDataImpl::serialized_size_nested_basic_sequences(
       }
     } else { // Empty sequence
       protoseq.length(0);
-      serialized_size(encoding, size, protoseq);
+      DCPS::serialized_size(encoding, size, protoseq);
     }
   }
   return true;
@@ -7336,88 +7346,88 @@ bool DynamicDataImpl::serialized_size_basic_sequence(const DCPS::Encoding& encod
   switch (it->second.elem_kind_) {
   case TK_INT32: {
     const DDS::Int32Seq& seq = it->second.get<DDS::Int32Seq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_UINT32: {
     const DDS::UInt32Seq& seq = it->second.get<DDS::UInt32Seq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_INT8: {
     const DDS::Int8Seq& seq = it->second.get<DDS::Int8Seq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_UINT8: {
     const DDS::UInt8Seq& seq = it->second.get<DDS::UInt8Seq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_INT16: {
     const DDS::Int16Seq& seq = it->second.get<DDS::Int16Seq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_UINT16: {
     const DDS::UInt16Seq& seq = it->second.get<DDS::UInt16Seq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_INT64: {
     const DDS::Int64Seq& seq = it->second.get<DDS::Int64Seq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_UINT64: {
     const DDS::UInt64Seq& seq = it->second.get<DDS::UInt64Seq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_FLOAT32: {
     const DDS::Float32Seq& seq = it->second.get<DDS::Float32Seq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_FLOAT64: {
     const DDS::Float64Seq& seq = it->second.get<DDS::Float64Seq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_FLOAT128: {
     const DDS::Float128Seq& seq = it->second.get<DDS::Float128Seq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_CHAR8: {
     const DDS::CharSeq& seq = it->second.get<DDS::CharSeq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_BYTE: {
     const DDS::ByteSeq& seq = it->second.get<DDS::ByteSeq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_BOOLEAN: {
     const DDS::BooleanSeq& seq = it->second.get<DDS::BooleanSeq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_STRING8: {
     const DDS::StringSeq& seq = it->second.get<DDS::StringSeq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
 #ifdef DDS_HAS_WCHAR
   case TK_CHAR16: {
     const DDS::WcharSeq& seq = it->second.get<DDS::WcharSeq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
   case TK_STRING16: {
     const DDS::WstringSeq& seq = it->second.get<DDS::WstringSeq>();
-    serialized_size(encoding, size, seq);
+    DCPS::serialized_size(encoding, size, seq);
     return true;
   }
 #endif

--- a/dds/DCPS/XTypes/DynamicDataImpl.h
+++ b/dds/DCPS/XTypes/DynamicDataImpl.h
@@ -398,6 +398,62 @@ private:
   template<TypeKind ValueTypeKind, typename ValueType>
   DDS::ReturnCode_t get_single_value(ValueType& value, DDS::MemberId id);
 
+  void set_default_basic_value(CORBA::Long& value) const;
+  void set_default_basic_value(CORBA::ULong& value) const;
+  void set_default_basic_value(ACE_OutputCDR::from_int8& value) const;
+  void set_default_basic_value(ACE_OutputCDR::from_uint8& value) const;
+  void set_default_basic_value(CORBA::Short& value) const;
+  void set_default_basic_value(CORBA::UShort& value) const;
+  void set_default_basic_value(CORBA::LongLong& value) const;
+  void set_default_basic_value(CORBA::ULongLong& value) const;
+  void set_default_basic_value(CORBA::Float& value) const;
+  void set_default_basic_value(CORBA::Double& value) const;
+  void set_default_basic_value(CORBA::LongDouble& value) const;
+  void set_default_basic_value(ACE_OutputCDR::from_char& value) const;
+  void set_default_basic_value(ACE_OutputCDR::from_octet& value) const;
+  void set_default_basic_value(const char*& value) const;
+  void set_default_basic_value(char*& value) const;
+  void set_default_basic_value(ACE_OutputCDR::from_boolean& value) const;
+#ifdef DDS_HAS_WCHAR
+  void set_default_basic_value(ACE_OutputCDR::from_wchar& value) const;
+  void set_default_basic_value(const CORBA::WChar*& value) const;
+  void set_default_basic_value(CORBA::WChar*& value) const;
+#endif
+
+  bool set_default_enum_value(const DDS::DynamicType_var& dt, CORBA::Long& value) const;
+
+  template<typename ElementType, typename CollectionType>
+  bool set_default_enum_values(CollectionType& collection,
+                               const DDS::DynamicType_var& enum_type) const;
+
+  void set_default_bitmask_value(ACE_OutputCDR::from_uint8& value) const;
+  void set_default_bitmask_value(CORBA::UShort& value) const;
+  void set_default_bitmask_value(CORBA::ULong& value) const;
+  void set_default_bitmask_value(CORBA::ULongLong& value) const;
+
+  template<typename Type>
+  void set_default_bitmask_value(Type& value) const;
+
+  template<typename CollectionType>
+  void set_default_bitmask_values(CollectionType& col) const;
+
+  void set_default_primitive_values(DDS::Int8Seq& collection) const;
+  void set_default_primitive_values(DDS::UInt8Seq& collection) const;
+  void set_default_primitive_values(DDS::CharSeq& collection) const;
+  void set_default_primitive_values(DDS::ByteSeq& collection) const;
+  void set_default_primitive_values(DDS::BooleanSeq& collection) const;
+#ifdef DDS_HAS_WCHAR
+  void set_default_primitive_values(DDS::WcharSeq& collection) const;
+#endif
+
+  template<typename CollectionType>
+  void set_default_primitive_values(CollectionType& collection) const;
+
+  bool set_default_discriminator_value(CORBA::Long& value,
+                                       const DDS::DynamicType_var& disc_type) const;
+
+  typedef OPENDDS_VECTOR(CORBA::ULong) IndexToIdMap;
+
   // Contain data for an instance of a basic type.
   struct SingleValue {
     SingleValue(CORBA::Long int32);
@@ -517,16 +573,14 @@ private:
     SequenceValue& operator=(const SequenceValue& rhs);
   };
 
-  typedef OPENDDS_VECTOR(CORBA::ULong) IndexToIdMap;
+  typedef OPENDDS_MAP(DDS::MemberId, SingleValue)::const_iterator const_single_iterator;
+  typedef OPENDDS_MAP(DDS::MemberId, SequenceValue)::const_iterator const_sequence_iterator;
+  typedef OPENDDS_MAP(DDS::MemberId, DDS::DynamicData_var)::const_iterator const_complex_iterator;
 
   // Container for all data written to this DynamicData object.
   // At anytime, there can be at most 1 entry for any given MemberId in all maps.
   // That is, each member is stored in at most 1 map.
   struct DataContainer {
-    typedef OPENDDS_MAP(DDS::MemberId, SingleValue)::const_iterator const_single_iterator;
-    typedef OPENDDS_MAP(DDS::MemberId, SequenceValue)::const_iterator const_sequence_iterator;
-    typedef OPENDDS_MAP(DDS::MemberId, DDS::DynamicData_var)::const_iterator const_complex_iterator;
-
     DataContainer(const DDS::DynamicType_var& type, const DynamicDataImpl* data)
       : type_(type)
       , type_desc_(data->type_desc_)
@@ -559,406 +613,6 @@ private:
     // (each element of the collection is a sequence of a basic type).
     // Assuming at least 1 sequence is stored.
     bool get_largest_index_basic_sequence(CORBA::ULong& index) const;
-
-    bool serialize_single_value(DCPS::Serializer& ser, const SingleValue& sv) const;
-
-    template<typename PrimitiveType>
-    bool serialize_primitive_value(DCPS::Serializer& ser, PrimitiveType default_value) const;
-    bool serialized_size_enum(const DCPS::Encoding& encoding,
-                              size_t& size, const DDS::DynamicType_var& enum_type) const;
-    bool serialize_enum_default_value(DCPS::Serializer& ser,
-                                      const DDS::DynamicType_var& enum_type) const;
-    bool serialize_enum_value(DCPS::Serializer& ser) const;
-    bool serialized_size_bitmask(const DCPS::Encoding& encoding,
-                                 size_t& size, const DDS::DynamicType_var& bitmask_type) const;
-    bool serialize_bitmask_default_value(DCPS::Serializer& ser,
-                                         const DDS::DynamicType_var& bitmask_type) const;
-    bool serialize_bitmask_value(DCPS::Serializer& ser) const;
-    bool reconstruct_string_value(CORBA::Char* str) const;
-    bool serialized_size_string(const DCPS::Encoding& encoding, size_t& size) const;
-    bool serialize_string_value(DCPS::Serializer& ser) const;
-    bool reconstruct_wstring_value(CORBA::WChar* wstr) const;
-    bool serialized_size_wstring(const DCPS::Encoding& encoding, size_t& size) const;
-    bool serialize_wstring_value(DCPS::Serializer& ser) const;
-    void serialized_size_primitive_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                            TypeKind elem_tk, CORBA::ULong length) const;
-
-    void set_default_basic_value(CORBA::Long& value) const;
-    void set_default_basic_value(CORBA::ULong& value) const;
-    void set_default_basic_value(ACE_OutputCDR::from_int8& value) const;
-    void set_default_basic_value(ACE_OutputCDR::from_uint8& value) const;
-    void set_default_basic_value(CORBA::Short& value) const;
-    void set_default_basic_value(CORBA::UShort& value) const;
-    void set_default_basic_value(CORBA::LongLong& value) const;
-    void set_default_basic_value(CORBA::ULongLong& value) const;
-    void set_default_basic_value(CORBA::Float& value) const;
-    void set_default_basic_value(CORBA::Double& value) const;
-    void set_default_basic_value(CORBA::LongDouble& value) const;
-    void set_default_basic_value(ACE_OutputCDR::from_char& value) const;
-    void set_default_basic_value(ACE_OutputCDR::from_octet& value) const;
-    void set_default_basic_value(const char*& value) const;
-    void set_default_basic_value(char*& value) const;
-    void set_default_basic_value(ACE_OutputCDR::from_boolean& value) const;
-#ifdef DDS_HAS_WCHAR
-    void set_default_basic_value(ACE_OutputCDR::from_wchar& value) const;
-    void set_default_basic_value(const CORBA::WChar*& value) const;
-    void set_default_basic_value(CORBA::WChar*& value) const;
-#endif
-
-    bool set_default_enum_value(const DDS::DynamicType_var& dt, CORBA::Long& value) const;
-
-    void set_default_bitmask_value(ACE_OutputCDR::from_uint8& value) const;
-    void set_default_bitmask_value(CORBA::UShort& value) const;
-    void set_default_bitmask_value(CORBA::ULong& value) const;
-    void set_default_bitmask_value(CORBA::ULongLong& value) const;
-
-    template<typename Type>
-    void set_default_bitmask_value(Type& value) const;
-
-    void set_default_primitive_values(DDS::Int8Seq& collection) const;
-    void set_default_primitive_values(DDS::UInt8Seq& collection) const;
-    void set_default_primitive_values(DDS::CharSeq& collection) const;
-    void set_default_primitive_values(DDS::ByteSeq& collection) const;
-    void set_default_primitive_values(DDS::BooleanSeq& collection) const;
-#ifdef DDS_HAS_WCHAR
-    void set_default_primitive_values(DDS::WcharSeq& collection) const;
-#endif
-
-    template<typename CollectionType>
-    void set_default_primitive_values(CollectionType& collection) const;
-
-    template<typename ElementType, typename CollectionType>
-    bool set_primitive_values(CollectionType& collection, CORBA::ULong bound,
-                              const ElementType& elem_tag) const;
-
-    template<typename ElementType, typename CollectionType>
-    bool reconstruct_primitive_collection(CollectionType& collection,
-      CORBA::ULong size, CORBA::ULong bound, const ElementType& elem_tag) const;
-
-    bool serialize_primitive_sequence(DCPS::Serializer& ser, TypeKind elem_tk,
-                                      CORBA::ULong size, CORBA::ULong bound) const;
-
-    void serialized_size_string_common(const DCPS::Encoding& encoding, size_t& size,
-                                       const char* str) const;
-#ifdef DDS_HAS_WCHAR
-    void serialized_size_string_common(const DCPS::Encoding& encoding, size_t& size,
-                                       const CORBA::WChar* wstr) const;
-#endif
-    void serialized_size_string_common(const DCPS::Encoding& encoding, size_t& size,
-                                       const SingleValue& sv) const;
-
-    template<typename StringType>
-    bool serialized_size_generic_string_collection(const DCPS::Encoding& encoding, size_t& size,
-                                                   const IndexToIdMap& index_to_id) const;
-    template<typename StringType>
-    bool serialized_size_generic_string_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                                 const IndexToIdMap& index_to_id) const;
-    template<typename StringType>
-    bool serialize_generic_string_collection(DCPS::Serializer& ser,
-                                             const IndexToIdMap& index_to_id) const;
-    template<typename StringType>
-    bool serialize_generic_string_sequence(DCPS::Serializer& ser, CORBA::ULong length,
-                                           CORBA::ULong bound) const;
-
-    template<typename ElementType, typename CollectionType>
-    bool set_default_enum_values(CollectionType& collection,
-                                 const DDS::DynamicType_var& enum_type) const;
-
-    template<typename ElementType, typename WrapElementType, typename CollectionType>
-    bool reconstruct_enum_collection(CollectionType& collection, CORBA::ULong size,
-      CORBA::ULong bound, const DDS::DynamicType_var& enum_type, const WrapElementType& elem_tag) const;
-
-    void serialized_size_enum_sequence_as_int8s(const DCPS::Encoding& encoding, size_t& size,
-                                                CORBA::ULong length) const;
-    void serialized_size_enum_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                       const DDS::Int8Seq& seq) const;
-    bool serialize_enum_sequence_as_ints_i(DCPS::Serializer& ser, const DDS::Int8Seq& enumseq) const;
-    bool serialize_enum_sequence_as_int8s(DCPS::Serializer& ser, CORBA::ULong size,
-      CORBA::ULong bound, const DDS::DynamicType_var& enum_type) const;
-    void serialized_size_enum_sequence_as_int16s(const DCPS::Encoding& encoding, size_t& size,
-                                                 CORBA::ULong length) const;
-    void serialized_size_enum_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                       const DDS::Int16Seq& seq) const;
-    bool serialize_enum_sequence_as_ints_i(DCPS::Serializer& ser, const DDS::Int16Seq& enumseq) const;
-    bool serialize_enum_sequence_as_int16s(DCPS::Serializer& ser, CORBA::ULong size,
-      CORBA::ULong bound, const DDS::DynamicType_var& enum_type) const;
-    void serialized_size_enum_sequence_as_int32s(const DCPS::Encoding& encoding, size_t& size,
-                                                 CORBA::ULong length) const;
-    void serialized_size_enum_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                       const DDS::Int32Seq& seq) const;
-    bool serialize_enum_sequence_as_ints_i(DCPS::Serializer& ser, const DDS::Int32Seq& enumseq) const;
-    bool serialize_enum_sequence_as_int32s(DCPS::Serializer& ser, CORBA::ULong size,
-      CORBA::ULong bound, const DDS::DynamicType_var& enum_type) const;
-
-    void serialized_size_enum_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                       CORBA::ULong length, CORBA::ULong bitbound) const;
-    bool serialize_enum_sequence(DCPS::Serializer& ser, CORBA::ULong size, CORBA::ULong bitbound,
-                                 CORBA::ULong seqbound, const DDS::DynamicType_var& enum_type) const;
-
-    template<typename CollectionType>
-    void set_default_bitmask_values(CollectionType& col) const;
-
-    template<typename WrapElementType, typename CollectionType>
-    bool reconstruct_bitmask_collection(CollectionType& collection, CORBA::ULong size,
-                                        CORBA::ULong bound, const WrapElementType& elem_tag) const;
-    void serialized_size_bitmask_sequence_as_uint8s(const DCPS::Encoding& encoding,
-                                                    size_t& size, CORBA::ULong length) const;
-    void serialized_size_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                          const DDS::UInt8Seq& seq) const;
-    bool serialize_bitmask_sequence_as_uints_i(DCPS::Serializer& ser,
-                                               const DDS::UInt8Seq& bitmask_seq) const;
-    bool serialize_bitmask_sequence_as_uint8s(DCPS::Serializer& ser, CORBA::ULong size,
-                                              CORBA::ULong bound) const;
-    void serialized_size_bitmask_sequence_as_uint16s(const DCPS::Encoding& encoding, size_t& size,
-                                                     CORBA::ULong length) const;
-    void serialized_size_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                          const DDS::UInt16Seq& seq) const;
-    bool serialize_bitmask_sequence_as_uints_i(DCPS::Serializer& ser,
-                                               const DDS::UInt16Seq& bitmask_seq) const;
-    bool serialize_bitmask_sequence_as_uint16s(DCPS::Serializer& ser, CORBA::ULong size,
-                                               CORBA::ULong bound) const;
-    void serialized_size_bitmask_sequence_as_uint32s(const DCPS::Encoding& encoding, size_t& size,
-                                                     CORBA::ULong length) const;
-    void serialized_size_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                          const DDS::UInt32Seq& seq) const;
-    bool serialize_bitmask_sequence_as_uints_i(DCPS::Serializer& ser,
-                                               const DDS::UInt32Seq& bitmask_seq) const;
-    bool serialize_bitmask_sequence_as_uint32s(DCPS::Serializer& ser, CORBA::ULong size,
-                                               CORBA::ULong bound) const;
-    void serialized_size_bitmask_sequence_as_uint64s(const DCPS::Encoding& encoding, size_t& size,
-                                                     CORBA::ULong length) const;
-    void serialized_size_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                          const DDS::UInt64Seq& seq) const;
-    bool serialize_bitmask_sequence_as_uints_i(DCPS::Serializer& ser,
-                                               const DDS::UInt64Seq& bitmask_seq) const;
-    bool serialize_bitmask_sequence_as_uint64s(DCPS::Serializer& ser, CORBA::ULong size,
-                                               CORBA::ULong bound) const;
-    void serialized_size_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                          CORBA::ULong length, CORBA::ULong bitbound) const;
-    bool serialize_bitmask_sequence(DCPS::Serializer& ser, CORBA::ULong size,
-                                    CORBA::ULong bitbound, CORBA::ULong seqbound) const;
-
-    bool serialized_size_sequence_value(const DCPS::Encoding& encoding, size_t& size,
-                                        const SequenceValue& sv) const;
-    bool serialize_sequence_value(DCPS::Serializer& ser, const SequenceValue& sv) const;
-    bool get_index_to_id_map(IndexToIdMap& index_to_id, CORBA::ULong bound) const;
-    bool serialized_size_complex_member_i(const DCPS::Encoding& encoding, size_t& size,
-                                          DDS::MemberId id, DCPS::Sample::Extent ext) const;
-
-    template<typename SequenceType>
-    bool serialized_size_nested_basic_sequences(const DCPS::Encoding& encoding, size_t& size,
-      const IndexToIdMap& index_to_id, SequenceType protoseq) const;
-
-    template<typename SequenceType>
-    bool serialized_size_nesting_basic_sequence(const DCPS::Encoding& encoding, size_t& size,
-      const IndexToIdMap& index_to_id, SequenceType protoseq) const;
-
-    bool serialize_complex_member_i(DCPS::Serializer& ser, DDS::MemberId id, DCPS::Sample::Extent ext) const;
-
-    template<typename SequenceType>
-    bool serialize_nested_basic_sequences(DCPS::Serializer& ser, const IndexToIdMap& index_to_id,
-                                          SequenceType protoseq) const;
-
-    template<typename SequenceType>
-    bool serialize_nesting_basic_sequence_i(DCPS::Serializer& ser, CORBA::ULong size,
-                                            CORBA::ULong bound, SequenceType protoseq) const;
-
-    bool serialized_size_nesting_basic_sequence(const DCPS::Encoding& encoding, size_t& size,
-      TypeKind nested_elem_tk, const IndexToIdMap& index_to_id) const;
-    bool serialize_nesting_basic_sequence(DCPS::Serializer& ser, TypeKind nested_elem_tk,
-                                          CORBA::ULong size, CORBA::ULong bound) const;
-    bool serialized_size_nested_enum_sequences(const DCPS::Encoding& encoding, size_t& size,
-                                               const IndexToIdMap& index_to_id) const;
-    bool serialized_size_nesting_enum_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                               const IndexToIdMap& index_to_id) const;
-    bool serialize_nested_enum_sequences(DCPS::Serializer& ser, const IndexToIdMap& index_to_id) const;
-    bool serialize_nesting_enum_sequence(DCPS::Serializer& ser, CORBA::ULong size,
-                                         CORBA::ULong bound) const;
-    bool serialized_size_nested_bitmask_sequences(const DCPS::Encoding& encoding, size_t& size,
-                                                  const IndexToIdMap& index_to_id) const;
-    bool serialized_size_nesting_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                                  const IndexToIdMap& index_to_id) const;
-    bool serialize_nested_bitmask_sequences(DCPS::Serializer& ser,
-                                            const IndexToIdMap& index_to_id) const;
-    bool serialize_nesting_bitmask_sequence(DCPS::Serializer& ser, CORBA::ULong size,
-                                            CORBA::ULong bound) const;
-    bool serialized_size_complex_member(const DCPS::Encoding& encoding, size_t& size,
-                                        DDS::MemberId id, const DDS::DynamicType_var& elem_type,
-                                        DCPS::Sample::Extent ext) const;
-    bool serialized_size_complex_sequence(const DCPS::Encoding& encoding, size_t& size,
-      const IndexToIdMap& index_to_id, const DDS::DynamicType_var& elem_type, DCPS::Sample::Extent ext) const;
-    bool serialize_complex_sequence_i(DCPS::Serializer& ser, const IndexToIdMap& index_to_id,
-                                      const DDS::DynamicType_var& elem_type, DCPS::Sample::Extent ext) const;
-    bool serialize_complex_sequence(DCPS::Serializer& ser, CORBA::ULong size, CORBA::ULong bound,
-                                    const DDS::DynamicType_var& elem_type, DCPS::Sample::Extent ext) const;
-    bool get_index_to_id_from_complex(IndexToIdMap& index_to_id, CORBA::ULong bound) const;
-    bool serialized_size_sequence(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
-    bool serialize_sequence(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
-
-    // Serialize array
-    void serialized_size_primitive_array(const DCPS::Encoding& encoding, size_t& size,
-                                         TypeKind elem_tk, CORBA::ULong length) const;
-    bool serialize_primitive_array(DCPS::Serializer& ser, TypeKind elem_tk, CORBA::ULong length) const;
-
-    template<typename StringType>
-    bool serialized_size_generic_string_array(const DCPS::Encoding& encoding, size_t& size,
-                                              const IndexToIdMap& index_to_id) const;
-    template<typename StringType>
-    bool serialize_generic_string_array(DCPS::Serializer& ser, CORBA::ULong length) const;
-    void serialized_size_enum_array_as_int8s(const DCPS::Encoding& encoding, size_t& size,
-                                             CORBA::ULong length) const;
-    bool serialize_enum_array_as_ints_i(DCPS::Serializer& ser, const DDS::Int8Seq& enumarr) const;
-    bool serialize_enum_array_as_int8s(DCPS::Serializer& ser, CORBA::ULong length,
-                                       const DDS::DynamicType_var& enum_type) const;
-    void serialized_size_enum_array_as_int16s(const DCPS::Encoding& encoding, size_t& size,
-                                              CORBA::ULong length) const;
-    bool serialize_enum_array_as_ints_i(DCPS::Serializer& ser, const DDS::Int16Seq& enumarr) const;
-    bool serialize_enum_array_as_int16s(DCPS::Serializer& ser, CORBA::ULong length,
-                                        const DDS::DynamicType_var& enum_type) const;
-    void serialized_size_enum_array_as_int32s(const DCPS::Encoding& encoding, size_t& size,
-                                              CORBA::ULong length) const;
-    bool serialize_enum_array_as_ints_i(DCPS::Serializer& ser, const DDS::Int32Seq& enumarr) const;
-    bool serialize_enum_array_as_int32s(DCPS::Serializer& ser, CORBA::ULong length,
-                                        const DDS::DynamicType_var& enum_type) const;
-    void serialized_size_enum_array(const DCPS::Encoding& encoding, size_t& size,
-                                    CORBA::ULong length, CORBA::ULong bitbound) const;
-    bool serialize_enum_array(DCPS::Serializer& ser, CORBA::ULong bitbound, CORBA::ULong length,
-                              const DDS::DynamicType_var& enum_type) const;
-
-    void serialized_size_bitmask_array_as_uint8s(const DCPS::Encoding& encoding, size_t& size,
-                                                 CORBA::ULong length) const;
-    bool serialize_bitmask_array_as_uints_i(DCPS::Serializer& ser,
-                                            const DDS::UInt8Seq& bitmask_arr) const;
-    bool serialize_bitmask_array_as_uint8s(DCPS::Serializer& ser, CORBA::ULong length) const;
-    void serialized_size_bitmask_array_as_uint16s(const DCPS::Encoding& encoding, size_t& size,
-                                                  CORBA::ULong length) const;
-    bool serialize_bitmask_array_as_uints_i(DCPS::Serializer& ser,
-                                            const DDS::UInt16Seq& bitmask_arr) const;
-    bool serialize_bitmask_array_as_uint16s(DCPS::Serializer& ser, CORBA::ULong length) const;
-    void serialized_size_bitmask_array_as_uint32s(const DCPS::Encoding& encoding, size_t& size,
-                                                  CORBA::ULong length) const;
-    bool serialize_bitmask_array_as_uints_i(DCPS::Serializer& ser,
-                                            const DDS::UInt32Seq& bitmask_arr) const;
-    bool serialize_bitmask_array_as_uint32s(DCPS::Serializer& ser, CORBA::ULong length) const;
-    void serialized_size_bitmask_array_as_uint64s(const DCPS::Encoding& encoding, size_t& size,
-                                                  CORBA::ULong length) const;
-    bool serialize_bitmask_array_as_uints_i(DCPS::Serializer& ser,
-                                            const DDS::UInt64Seq& bitmask_arr) const;
-    bool serialize_bitmask_array_as_uint64s(DCPS::Serializer& ser, CORBA::ULong length) const;
-    void serialized_size_bitmask_array(const DCPS::Encoding& encoding, size_t& size,
-                                       CORBA::ULong length, CORBA::ULong bitbound) const;
-    bool serialize_bitmask_array(DCPS::Serializer& ser, CORBA::ULong bitbound,
-                                 CORBA::ULong length) const;
-
-    template<typename SequenceType>
-    bool serialized_size_nesting_basic_array(const DCPS::Encoding& encoding, size_t& size,
-      const IndexToIdMap& index_to_id, SequenceType protoseq) const;
-
-    template<typename SequenceType>
-    bool serialize_nesting_basic_array_i(DCPS::Serializer& ser, CORBA::ULong length,
-                                         SequenceType protoseq) const;
-    bool serialized_size_nesting_basic_array(const DCPS::Encoding& encoding, size_t& size,
-      TypeKind nested_elem_tk, const IndexToIdMap& index_to_id) const;
-    bool serialize_nesting_basic_array(DCPS::Serializer& ser, TypeKind nested_elem_tk,
-                                       CORBA::ULong length) const;
-    bool serialized_size_nesting_enum_array(const DCPS::Encoding& encoding, size_t& size,
-                                            const IndexToIdMap& index_to_id) const;
-    bool serialize_nesting_enum_array(DCPS::Serializer& ser, CORBA::ULong length) const;
-    bool serialized_size_nesting_bitmask_array(const DCPS::Encoding& encoding, size_t& size,
-                                               const IndexToIdMap& index_to_id) const;
-    bool serialize_nesting_bitmask_array(DCPS::Serializer& ser, CORBA::ULong length) const;
-    bool serialized_size_complex_array(const DCPS::Encoding& encoding, size_t& size,
-      const IndexToIdMap& index_to_id, const DDS::DynamicType_var& elem_type, DCPS::Sample::Extent ext) const;
-    bool serialize_complex_array(DCPS::Serializer& ser, CORBA::ULong length,
-                                 const DDS::DynamicType_var& elem_type, DCPS::Sample::Extent ext) const;
-    bool serialized_size_array(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
-    bool serialize_array(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
-
-    bool serialized_size_primitive_member(const DCPS::Encoding& encoding, size_t& size,
-                                          TypeKind member_tk) const;
-
-    bool serialized_size_basic_member_default_value(const DCPS::Encoding& encoding, size_t& size,
-                                                    TypeKind member_tk) const;
-    bool serialized_size_basic_member(const DCPS::Encoding& encoding, size_t& size,
-                                      TypeKind member_tk, const_single_iterator it) const;
-    bool serialize_basic_member_default_value(DCPS::Serializer& ser, TypeKind member_tk) const;
-
-    bool serialized_size_single_aggregated_member_xcdr2(const DCPS::Encoding& encoding, size_t& size,
-      const_single_iterator it, const DDS::DynamicType_var& member_type, bool optional,
-      DDS::ExtensibilityKind extensibility, size_t& mutable_running_total) const;
-    bool serialize_single_aggregated_member_xcdr2(DCPS::Serializer& ser, const_single_iterator it,
-      const DDS::DynamicType_var& member_type, bool optional, bool must_understand,
-      DDS::ExtensibilityKind extensibility) const;
-    bool serialized_size_complex_aggregated_member_xcdr2_default(const DCPS::Encoding& encoding,
-      size_t& size, const DDS::DynamicType_var& member_type, bool optional,
-      DDS::ExtensibilityKind extensibility, size_t& mutable_running_total, DCPS::Sample::Extent ext) const;
-    bool serialize_complex_aggregated_member_xcdr2_default(DCPS::Serializer& ser, DDS::MemberId id,
-      const DDS::DynamicType_var& member_type, bool optional, bool must_understand,
-      DDS::ExtensibilityKind extensibility, DCPS::Sample::Extent ext) const;
-    bool serialized_size_complex_aggregated_member_xcdr2(const DCPS::Encoding& encoding, size_t& size,
-      const_complex_iterator it, bool optional, DDS::ExtensibilityKind extensibility,
-      size_t& mutable_running_total, DCPS::Sample::Extent ext) const;
-    bool serialize_complex_aggregated_member_xcdr2(DCPS::Serializer& ser, const_complex_iterator it,
-      bool optional, bool must_understand, DDS::ExtensibilityKind extensibility, DCPS::Sample::Extent ext) const;
-    bool serialized_size_basic_struct_member_xcdr2(const DCPS::Encoding& encoding, size_t& size,
-      DDS::MemberId id, const DDS::DynamicType_var& member_type, bool optional,
-      DDS::ExtensibilityKind extensibility, size_t& mutable_running_total) const;
-    bool serialize_basic_struct_member_xcdr2(DCPS::Serializer& ser, DDS::MemberId id,
-      const DDS::DynamicType_var& member_type, bool optional, bool must_understand,
-      DDS::ExtensibilityKind extensibility) const;
-
-    void serialized_size_sequence_member_default_value(const DCPS::Encoding& encoding,
-                                                       size_t& size, TypeKind elem_tk) const;
-    bool serialize_sequence_member_default_value(DCPS::Serializer& ser, TypeKind elem_tk) const;
-
-    bool serialized_size_basic_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                        const_sequence_iterator it) const;
-    bool serialize_basic_sequence(DCPS::Serializer& ser, const_sequence_iterator it) const;
-    bool serialized_size_enum_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                       const_sequence_iterator it) const;
-    bool serialize_enum_sequence(DCPS::Serializer& ser, const_sequence_iterator it) const;
-    bool serialized_size_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
-                                          const_sequence_iterator it) const;
-    bool serialize_bitmask_sequence(DCPS::Serializer& ser, const_sequence_iterator it) const;
-    void serialized_size_sequence_aggregated_member_xcdr2(const DCPS::Encoding& encoding,
-      size_t& size, const_sequence_iterator it, TypeKind elem_tk, bool optional,
-      DDS::ExtensibilityKind extensibility, size_t& mutable_running_total) const;
-    bool serialize_sequence_aggregated_member_xcdr2(DCPS::Serializer& ser, const_sequence_iterator it,
-      TypeKind elem_tk, bool optional, bool must_understand, DDS::ExtensibilityKind extensibility) const;
-    bool serialized_size_sequence_struct_member_xcdr2(const DCPS::Encoding& encoding, size_t& size,
-      DDS::MemberId id, TypeKind elem_tk, bool optional,
-      DDS::ExtensibilityKind extensibility, size_t& mutable_running_total, DCPS::Sample::Extent ext) const;
-    bool serialize_sequence_struct_member_xcdr2(DCPS::Serializer& ser, DDS::MemberId id,
-      TypeKind elem_tk, bool optional, bool must_understand, DDS::ExtensibilityKind extensibility, DCPS::Sample::Extent ext) const;
-    bool serialized_size_structure_xcdr2(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
-    bool serialize_structure_xcdr2(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
-    bool serialized_size_structure_xcdr1(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
-    bool serialize_structure_xcdr1(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
-    bool serialized_size_structure(const DCPS::Encoding& encoding, size_t& size,
-                                   DCPS::Sample::Extent ext) const;
-    bool serialize_structure(DCPS::Serializer& ser, DCPS::Sample::Extent) const;
-
-    bool set_default_discriminator_value(CORBA::Long& value,
-                                         const DDS::DynamicType_var& disc_type) const;
-    bool get_discriminator_value(CORBA::Long& value, const_single_iterator single_it,
-      const_complex_iterator complex_it, const DDS::DynamicType_var& disc_type) const;
-    bool serialized_size_discriminator_member_xcdr2(const DCPS::Encoding& encoding, size_t& size,
-      const DDS::DynamicType_var& disc_type, DDS::ExtensibilityKind extensibility,
-      size_t& mutable_running_total) const;
-    bool serialize_discriminator_member_xcdr2(DCPS::Serializer& ser, CORBA::Long value,
-      const DDS::DynamicType_var& disc_type, DDS::ExtensibilityKind extensibility) const;
-    bool serialized_size_selected_member_xcdr2(const DCPS::Encoding& encoding, size_t& size,
-      DDS::MemberId selected_id, DDS::ExtensibilityKind extensibility,
-      size_t& mutable_running_total) const;
-    bool serialize_selected_member_xcdr2(DCPS::Serializer& ser, DDS::MemberId selected_id,
-                                         DDS::ExtensibilityKind extensibility) const;
-    bool serialized_size_union_xcdr2(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
-    bool serialize_union_xcdr2(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
-    bool serialized_size_union_xcdr1(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
-    bool serialize_union_xcdr1(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
-    bool serialized_size_union(const DCPS::Encoding& encoding, size_t& size,
-                               DCPS::Sample::Extent ext) const;
-    bool serialize_union(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
 
     // Internal data
     OPENDDS_MAP(DDS::MemberId, SingleValue) single_map_;
@@ -1005,6 +659,354 @@ private:
   void clear_container();
 
   DataContainer container_;
+
+  // XCDR serialization functions
+  bool serialize_single_value(DCPS::Serializer& ser, const DynamicDataImpl::SingleValue& sv) const;
+
+  template<typename ElementType, typename CollectionType>
+  bool set_primitive_values(CollectionType& collection, CORBA::ULong bound,
+                            const ElementType& elem_tag) const;
+
+  template<typename PrimitiveType>
+  bool serialize_primitive_value(DCPS::Serializer& ser, PrimitiveType default_value) const;
+  bool serialized_size_enum(const DCPS::Encoding& encoding,
+                            size_t& size, const DDS::DynamicType_var& enum_type) const;
+  bool serialize_enum_default_value(DCPS::Serializer& ser,
+                                    const DDS::DynamicType_var& enum_type) const;
+  bool serialize_enum_value(DCPS::Serializer& ser) const;
+  bool serialized_size_bitmask(const DCPS::Encoding& encoding,
+                               size_t& size, const DDS::DynamicType_var& bitmask_type) const;
+  bool serialize_bitmask_default_value(DCPS::Serializer& ser,
+                                       const DDS::DynamicType_var& bitmask_type) const;
+  bool serialize_bitmask_value(DCPS::Serializer& ser) const;
+  bool reconstruct_string_value(CORBA::Char* str) const;
+  bool serialized_size_string(const DCPS::Encoding& encoding, size_t& size) const;
+  bool serialize_string_value(DCPS::Serializer& ser) const;
+  bool reconstruct_wstring_value(CORBA::WChar* wstr) const;
+  bool serialized_size_wstring(const DCPS::Encoding& encoding, size_t& size) const;
+  bool serialize_wstring_value(DCPS::Serializer& ser) const;
+  void serialized_size_primitive_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                          TypeKind elem_tk, CORBA::ULong length) const;
+
+  template<typename ElementType, typename CollectionType>
+  bool reconstruct_primitive_collection(CollectionType& collection,
+    CORBA::ULong size, CORBA::ULong bound, const ElementType& elem_tag) const;
+
+  bool serialize_primitive_sequence(DCPS::Serializer& ser, TypeKind elem_tk,
+                                    CORBA::ULong size, CORBA::ULong bound) const;
+
+  void serialized_size_string_common(const DCPS::Encoding& encoding, size_t& size,
+                                     const char* str) const;
+#ifdef DDS_HAS_WCHAR
+  void serialized_size_string_common(const DCPS::Encoding& encoding, size_t& size,
+                                     const CORBA::WChar* wstr) const;
+#endif
+  void serialized_size_string_common(const DCPS::Encoding& encoding, size_t& size,
+                                     const SingleValue& sv) const;
+
+  template<typename StringType>
+  bool serialized_size_generic_string_collection(const DCPS::Encoding& encoding, size_t& size,
+                                                 const IndexToIdMap& index_to_id) const;
+  template<typename StringType>
+  bool serialized_size_generic_string_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                               const IndexToIdMap& index_to_id) const;
+  template<typename StringType>
+  bool serialize_generic_string_collection(DCPS::Serializer& ser,
+                                           const IndexToIdMap& index_to_id) const;
+  template<typename StringType>
+  bool serialize_generic_string_sequence(DCPS::Serializer& ser, CORBA::ULong length,
+                                         CORBA::ULong bound) const;
+
+  template<typename ElementType, typename WrapElementType, typename CollectionType>
+  bool reconstruct_enum_collection(CollectionType& collection, CORBA::ULong size,
+    CORBA::ULong bound, const DDS::DynamicType_var& enum_type, const WrapElementType& elem_tag) const;
+
+  void serialized_size_enum_sequence_as_int8s(const DCPS::Encoding& encoding, size_t& size,
+                                              CORBA::ULong length) const;
+  void serialized_size_enum_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                     const DDS::Int8Seq& seq) const;
+  bool serialize_enum_sequence_as_ints_i(DCPS::Serializer& ser, const DDS::Int8Seq& enumseq) const;
+  bool serialize_enum_sequence_as_int8s(DCPS::Serializer& ser, CORBA::ULong size,
+    CORBA::ULong bound, const DDS::DynamicType_var& enum_type) const;
+  void serialized_size_enum_sequence_as_int16s(const DCPS::Encoding& encoding, size_t& size,
+                                               CORBA::ULong length) const;
+  void serialized_size_enum_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                     const DDS::Int16Seq& seq) const;
+  bool serialize_enum_sequence_as_ints_i(DCPS::Serializer& ser, const DDS::Int16Seq& enumseq) const;
+  bool serialize_enum_sequence_as_int16s(DCPS::Serializer& ser, CORBA::ULong size,
+    CORBA::ULong bound, const DDS::DynamicType_var& enum_type) const;
+  void serialized_size_enum_sequence_as_int32s(const DCPS::Encoding& encoding, size_t& size,
+                                               CORBA::ULong length) const;
+  void serialized_size_enum_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                     const DDS::Int32Seq& seq) const;
+  bool serialize_enum_sequence_as_ints_i(DCPS::Serializer& ser, const DDS::Int32Seq& enumseq) const;
+  bool serialize_enum_sequence_as_int32s(DCPS::Serializer& ser, CORBA::ULong size,
+    CORBA::ULong bound, const DDS::DynamicType_var& enum_type) const;
+
+  void serialized_size_enum_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                     CORBA::ULong length, CORBA::ULong bitbound) const;
+  bool serialize_enum_sequence(DCPS::Serializer& ser, CORBA::ULong size, CORBA::ULong bitbound,
+                               CORBA::ULong seqbound, const DDS::DynamicType_var& enum_type) const;
+
+  template<typename WrapElementType, typename CollectionType>
+  bool reconstruct_bitmask_collection(CollectionType& collection, CORBA::ULong size,
+                                      CORBA::ULong bound, const WrapElementType& elem_tag) const;
+  void serialized_size_bitmask_sequence_as_uint8s(const DCPS::Encoding& encoding,
+                                                  size_t& size, CORBA::ULong length) const;
+  void serialized_size_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                        const DDS::UInt8Seq& seq) const;
+  bool serialize_bitmask_sequence_as_uints_i(DCPS::Serializer& ser,
+                                             const DDS::UInt8Seq& bitmask_seq) const;
+  bool serialize_bitmask_sequence_as_uint8s(DCPS::Serializer& ser, CORBA::ULong size,
+                                            CORBA::ULong bound) const;
+  void serialized_size_bitmask_sequence_as_uint16s(const DCPS::Encoding& encoding, size_t& size,
+                                                   CORBA::ULong length) const;
+  void serialized_size_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                        const DDS::UInt16Seq& seq) const;
+  bool serialize_bitmask_sequence_as_uints_i(DCPS::Serializer& ser,
+                                             const DDS::UInt16Seq& bitmask_seq) const;
+  bool serialize_bitmask_sequence_as_uint16s(DCPS::Serializer& ser, CORBA::ULong size,
+                                             CORBA::ULong bound) const;
+  void serialized_size_bitmask_sequence_as_uint32s(const DCPS::Encoding& encoding, size_t& size,
+                                                   CORBA::ULong length) const;
+  void serialized_size_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                        const DDS::UInt32Seq& seq) const;
+  bool serialize_bitmask_sequence_as_uints_i(DCPS::Serializer& ser,
+                                             const DDS::UInt32Seq& bitmask_seq) const;
+  bool serialize_bitmask_sequence_as_uint32s(DCPS::Serializer& ser, CORBA::ULong size,
+                                             CORBA::ULong bound) const;
+  void serialized_size_bitmask_sequence_as_uint64s(const DCPS::Encoding& encoding, size_t& size,
+                                                   CORBA::ULong length) const;
+  void serialized_size_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                        const DDS::UInt64Seq& seq) const;
+  bool serialize_bitmask_sequence_as_uints_i(DCPS::Serializer& ser,
+                                             const DDS::UInt64Seq& bitmask_seq) const;
+  bool serialize_bitmask_sequence_as_uint64s(DCPS::Serializer& ser, CORBA::ULong size,
+                                             CORBA::ULong bound) const;
+  void serialized_size_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                        CORBA::ULong length, CORBA::ULong bitbound) const;
+  bool serialize_bitmask_sequence(DCPS::Serializer& ser, CORBA::ULong size,
+                                  CORBA::ULong bitbound, CORBA::ULong seqbound) const;
+
+  bool serialized_size_sequence_value(const DCPS::Encoding& encoding, size_t& size,
+                                      const SequenceValue& sv) const;
+  bool serialize_sequence_value(DCPS::Serializer& ser, const SequenceValue& sv) const;
+  bool get_index_to_id_map(IndexToIdMap& index_to_id, CORBA::ULong bound) const;
+  bool serialized_size_complex_member_i(const DCPS::Encoding& encoding, size_t& size,
+                                        DDS::MemberId id, DCPS::Sample::Extent ext) const;
+
+  template<typename SequenceType>
+  bool serialized_size_nested_basic_sequences(const DCPS::Encoding& encoding, size_t& size,
+    const IndexToIdMap& index_to_id, SequenceType protoseq) const;
+
+  template<typename SequenceType>
+  bool serialized_size_nesting_basic_sequence(const DCPS::Encoding& encoding, size_t& size,
+    const IndexToIdMap& index_to_id, SequenceType protoseq) const;
+
+  bool serialize_complex_member_i(DCPS::Serializer& ser, DDS::MemberId id, DCPS::Sample::Extent ext) const;
+
+  template<typename SequenceType>
+  bool serialize_nested_basic_sequences(DCPS::Serializer& ser, const IndexToIdMap& index_to_id,
+                                        SequenceType protoseq) const;
+
+  template<typename SequenceType>
+  bool serialize_nesting_basic_sequence_i(DCPS::Serializer& ser, CORBA::ULong size,
+                                          CORBA::ULong bound, SequenceType protoseq) const;
+
+  bool serialized_size_nesting_basic_sequence(const DCPS::Encoding& encoding, size_t& size,
+    TypeKind nested_elem_tk, const IndexToIdMap& index_to_id) const;
+  bool serialize_nesting_basic_sequence(DCPS::Serializer& ser, TypeKind nested_elem_tk,
+                                        CORBA::ULong size, CORBA::ULong bound) const;
+  bool serialized_size_nested_enum_sequences(const DCPS::Encoding& encoding, size_t& size,
+                                             const IndexToIdMap& index_to_id) const;
+  bool serialized_size_nesting_enum_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                             const IndexToIdMap& index_to_id) const;
+  bool serialize_nested_enum_sequences(DCPS::Serializer& ser, const IndexToIdMap& index_to_id) const;
+  bool serialize_nesting_enum_sequence(DCPS::Serializer& ser, CORBA::ULong size,
+                                       CORBA::ULong bound) const;
+  bool serialized_size_nested_bitmask_sequences(const DCPS::Encoding& encoding, size_t& size,
+                                                const IndexToIdMap& index_to_id) const;
+  bool serialized_size_nesting_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                                const IndexToIdMap& index_to_id) const;
+  bool serialize_nested_bitmask_sequences(DCPS::Serializer& ser,
+                                          const IndexToIdMap& index_to_id) const;
+  bool serialize_nesting_bitmask_sequence(DCPS::Serializer& ser, CORBA::ULong size,
+                                          CORBA::ULong bound) const;
+  bool serialized_size_complex_member(const DCPS::Encoding& encoding, size_t& size,
+                                      DDS::MemberId id, const DDS::DynamicType_var& elem_type,
+                                      DCPS::Sample::Extent ext) const;
+  bool serialized_size_complex_sequence(const DCPS::Encoding& encoding, size_t& size,
+    const IndexToIdMap& index_to_id, const DDS::DynamicType_var& elem_type, DCPS::Sample::Extent ext) const;
+  bool serialize_complex_sequence_i(DCPS::Serializer& ser, const IndexToIdMap& index_to_id,
+                                    const DDS::DynamicType_var& elem_type, DCPS::Sample::Extent ext) const;
+  bool serialize_complex_sequence(DCPS::Serializer& ser, CORBA::ULong size, CORBA::ULong bound,
+                                  const DDS::DynamicType_var& elem_type, DCPS::Sample::Extent ext) const;
+  bool get_index_to_id_from_complex(IndexToIdMap& index_to_id, CORBA::ULong bound) const;
+  bool serialized_size_sequence(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
+  bool serialize_sequence(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
+
+  // Serialize array
+  void serialized_size_primitive_array(const DCPS::Encoding& encoding, size_t& size,
+                                       TypeKind elem_tk, CORBA::ULong length) const;
+  bool serialize_primitive_array(DCPS::Serializer& ser, TypeKind elem_tk, CORBA::ULong length) const;
+
+  template<typename StringType>
+  bool serialized_size_generic_string_array(const DCPS::Encoding& encoding, size_t& size,
+                                            const IndexToIdMap& index_to_id) const;
+  template<typename StringType>
+  bool serialize_generic_string_array(DCPS::Serializer& ser, CORBA::ULong length) const;
+  void serialized_size_enum_array_as_int8s(const DCPS::Encoding& encoding, size_t& size,
+                                           CORBA::ULong length) const;
+  bool serialize_enum_array_as_ints_i(DCPS::Serializer& ser, const DDS::Int8Seq& enumarr) const;
+  bool serialize_enum_array_as_int8s(DCPS::Serializer& ser, CORBA::ULong length,
+                                     const DDS::DynamicType_var& enum_type) const;
+  void serialized_size_enum_array_as_int16s(const DCPS::Encoding& encoding, size_t& size,
+                                            CORBA::ULong length) const;
+  bool serialize_enum_array_as_ints_i(DCPS::Serializer& ser, const DDS::Int16Seq& enumarr) const;
+  bool serialize_enum_array_as_int16s(DCPS::Serializer& ser, CORBA::ULong length,
+                                      const DDS::DynamicType_var& enum_type) const;
+  void serialized_size_enum_array_as_int32s(const DCPS::Encoding& encoding, size_t& size,
+                                            CORBA::ULong length) const;
+  bool serialize_enum_array_as_ints_i(DCPS::Serializer& ser, const DDS::Int32Seq& enumarr) const;
+  bool serialize_enum_array_as_int32s(DCPS::Serializer& ser, CORBA::ULong length,
+                                      const DDS::DynamicType_var& enum_type) const;
+  void serialized_size_enum_array(const DCPS::Encoding& encoding, size_t& size,
+                                  CORBA::ULong length, CORBA::ULong bitbound) const;
+  bool serialize_enum_array(DCPS::Serializer& ser, CORBA::ULong bitbound, CORBA::ULong length,
+                            const DDS::DynamicType_var& enum_type) const;
+
+  void serialized_size_bitmask_array_as_uint8s(const DCPS::Encoding& encoding, size_t& size,
+                                               CORBA::ULong length) const;
+  bool serialize_bitmask_array_as_uints_i(DCPS::Serializer& ser,
+                                          const DDS::UInt8Seq& bitmask_arr) const;
+  bool serialize_bitmask_array_as_uint8s(DCPS::Serializer& ser, CORBA::ULong length) const;
+  void serialized_size_bitmask_array_as_uint16s(const DCPS::Encoding& encoding, size_t& size,
+                                                CORBA::ULong length) const;
+  bool serialize_bitmask_array_as_uints_i(DCPS::Serializer& ser,
+                                          const DDS::UInt16Seq& bitmask_arr) const;
+  bool serialize_bitmask_array_as_uint16s(DCPS::Serializer& ser, CORBA::ULong length) const;
+  void serialized_size_bitmask_array_as_uint32s(const DCPS::Encoding& encoding, size_t& size,
+                                                CORBA::ULong length) const;
+  bool serialize_bitmask_array_as_uints_i(DCPS::Serializer& ser,
+                                          const DDS::UInt32Seq& bitmask_arr) const;
+  bool serialize_bitmask_array_as_uint32s(DCPS::Serializer& ser, CORBA::ULong length) const;
+  void serialized_size_bitmask_array_as_uint64s(const DCPS::Encoding& encoding, size_t& size,
+                                                CORBA::ULong length) const;
+  bool serialize_bitmask_array_as_uints_i(DCPS::Serializer& ser,
+                                          const DDS::UInt64Seq& bitmask_arr) const;
+  bool serialize_bitmask_array_as_uint64s(DCPS::Serializer& ser, CORBA::ULong length) const;
+  void serialized_size_bitmask_array(const DCPS::Encoding& encoding, size_t& size,
+                                     CORBA::ULong length, CORBA::ULong bitbound) const;
+  bool serialize_bitmask_array(DCPS::Serializer& ser, CORBA::ULong bitbound,
+                               CORBA::ULong length) const;
+
+  template<typename SequenceType>
+  bool serialized_size_nesting_basic_array(const DCPS::Encoding& encoding, size_t& size,
+    const IndexToIdMap& index_to_id, SequenceType protoseq) const;
+
+  template<typename SequenceType>
+  bool serialize_nesting_basic_array_i(DCPS::Serializer& ser, CORBA::ULong length,
+                                       SequenceType protoseq) const;
+  bool serialized_size_nesting_basic_array(const DCPS::Encoding& encoding, size_t& size,
+    TypeKind nested_elem_tk, const IndexToIdMap& index_to_id) const;
+  bool serialize_nesting_basic_array(DCPS::Serializer& ser, TypeKind nested_elem_tk,
+                                     CORBA::ULong length) const;
+  bool serialized_size_nesting_enum_array(const DCPS::Encoding& encoding, size_t& size,
+                                          const IndexToIdMap& index_to_id) const;
+  bool serialize_nesting_enum_array(DCPS::Serializer& ser, CORBA::ULong length) const;
+  bool serialized_size_nesting_bitmask_array(const DCPS::Encoding& encoding, size_t& size,
+                                             const IndexToIdMap& index_to_id) const;
+  bool serialize_nesting_bitmask_array(DCPS::Serializer& ser, CORBA::ULong length) const;
+  bool serialized_size_complex_array(const DCPS::Encoding& encoding, size_t& size,
+    const IndexToIdMap& index_to_id, const DDS::DynamicType_var& elem_type, DCPS::Sample::Extent ext) const;
+  bool serialize_complex_array(DCPS::Serializer& ser, CORBA::ULong length,
+                               const DDS::DynamicType_var& elem_type, DCPS::Sample::Extent ext) const;
+  bool serialized_size_array(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
+  bool serialize_array(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
+
+  bool serialized_size_primitive_member(const DCPS::Encoding& encoding, size_t& size,
+                                        TypeKind member_tk) const;
+
+  bool serialized_size_basic_member_default_value(const DCPS::Encoding& encoding, size_t& size,
+                                                  TypeKind member_tk) const;
+  bool serialized_size_basic_member(const DCPS::Encoding& encoding, size_t& size,
+                                    TypeKind member_tk, const_single_iterator it) const;
+  bool serialize_basic_member_default_value(DCPS::Serializer& ser, TypeKind member_tk) const;
+
+  bool serialized_size_single_aggregated_member_xcdr2(const DCPS::Encoding& encoding, size_t& size,
+    const_single_iterator it, const DDS::DynamicType_var& member_type, bool optional,
+    DDS::ExtensibilityKind extensibility, size_t& mutable_running_total) const;
+  bool serialize_single_aggregated_member_xcdr2(DCPS::Serializer& ser, const_single_iterator it,
+    const DDS::DynamicType_var& member_type, bool optional, bool must_understand,
+    DDS::ExtensibilityKind extensibility) const;
+  bool serialized_size_complex_aggregated_member_xcdr2_default(const DCPS::Encoding& encoding,
+    size_t& size, const DDS::DynamicType_var& member_type, bool optional,
+    DDS::ExtensibilityKind extensibility, size_t& mutable_running_total, DCPS::Sample::Extent ext) const;
+  bool serialize_complex_aggregated_member_xcdr2_default(DCPS::Serializer& ser, DDS::MemberId id,
+    const DDS::DynamicType_var& member_type, bool optional, bool must_understand,
+    DDS::ExtensibilityKind extensibility, DCPS::Sample::Extent ext) const;
+  bool serialized_size_complex_aggregated_member_xcdr2(const DCPS::Encoding& encoding, size_t& size,
+    const_complex_iterator it, bool optional, DDS::ExtensibilityKind extensibility,
+    size_t& mutable_running_total, DCPS::Sample::Extent ext) const;
+  bool serialize_complex_aggregated_member_xcdr2(DCPS::Serializer& ser, const_complex_iterator it,
+    bool optional, bool must_understand, DDS::ExtensibilityKind extensibility, DCPS::Sample::Extent ext) const;
+  bool serialized_size_basic_struct_member_xcdr2(const DCPS::Encoding& encoding, size_t& size,
+    DDS::MemberId id, const DDS::DynamicType_var& member_type, bool optional,
+    DDS::ExtensibilityKind extensibility, size_t& mutable_running_total) const;
+  bool serialize_basic_struct_member_xcdr2(DCPS::Serializer& ser, DDS::MemberId id,
+    const DDS::DynamicType_var& member_type, bool optional, bool must_understand,
+    DDS::ExtensibilityKind extensibility) const;
+
+  void serialized_size_sequence_member_default_value(const DCPS::Encoding& encoding,
+                                                     size_t& size, TypeKind elem_tk) const;
+  bool serialize_sequence_member_default_value(DCPS::Serializer& ser, TypeKind elem_tk) const;
+
+  bool serialized_size_basic_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                      const_sequence_iterator it) const;
+  bool serialize_basic_sequence(DCPS::Serializer& ser, const_sequence_iterator it) const;
+  bool serialized_size_enum_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                     const_sequence_iterator it) const;
+  bool serialize_enum_sequence(DCPS::Serializer& ser, const_sequence_iterator it) const;
+  bool serialized_size_bitmask_sequence(const DCPS::Encoding& encoding, size_t& size,
+                                        const_sequence_iterator it) const;
+  bool serialize_bitmask_sequence(DCPS::Serializer& ser, const_sequence_iterator it) const;
+  void serialized_size_sequence_aggregated_member_xcdr2(const DCPS::Encoding& encoding,
+    size_t& size, const_sequence_iterator it, TypeKind elem_tk, bool optional,
+    DDS::ExtensibilityKind extensibility, size_t& mutable_running_total) const;
+  bool serialize_sequence_aggregated_member_xcdr2(DCPS::Serializer& ser, const_sequence_iterator it,
+    TypeKind elem_tk, bool optional, bool must_understand, DDS::ExtensibilityKind extensibility) const;
+  bool serialized_size_sequence_struct_member_xcdr2(const DCPS::Encoding& encoding, size_t& size,
+    DDS::MemberId id, TypeKind elem_tk, bool optional,
+    DDS::ExtensibilityKind extensibility, size_t& mutable_running_total, DCPS::Sample::Extent ext) const;
+  bool serialize_sequence_struct_member_xcdr2(DCPS::Serializer& ser, DDS::MemberId id,
+    TypeKind elem_tk, bool optional, bool must_understand, DDS::ExtensibilityKind extensibility, DCPS::Sample::Extent ext) const;
+  bool serialized_size_structure_xcdr2(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
+  bool serialize_structure_xcdr2(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
+  bool serialized_size_structure_xcdr1(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
+  bool serialize_structure_xcdr1(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
+  bool serialized_size_structure(const DCPS::Encoding& encoding, size_t& size,
+                                 DCPS::Sample::Extent ext) const;
+  bool serialize_structure(DCPS::Serializer& ser, DCPS::Sample::Extent) const;
+
+  bool get_discriminator_value(CORBA::Long& value, const_single_iterator single_it,
+    const_complex_iterator complex_it, const DDS::DynamicType_var& disc_type) const;
+  bool serialized_size_discriminator_member_xcdr2(const DCPS::Encoding& encoding, size_t& size,
+    const DDS::DynamicType_var& disc_type, DDS::ExtensibilityKind extensibility,
+    size_t& mutable_running_total) const;
+  bool serialize_discriminator_member_xcdr2(DCPS::Serializer& ser, CORBA::Long value,
+    const DDS::DynamicType_var& disc_type, DDS::ExtensibilityKind extensibility) const;
+  bool serialized_size_selected_member_xcdr2(const DCPS::Encoding& encoding, size_t& size,
+    DDS::MemberId selected_id, DDS::ExtensibilityKind extensibility,
+    size_t& mutable_running_total) const;
+  bool serialize_selected_member_xcdr2(DCPS::Serializer& ser, DDS::MemberId selected_id,
+                                       DDS::ExtensibilityKind extensibility) const;
+  bool serialized_size_union_xcdr2(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
+  bool serialize_union_xcdr2(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
+  bool serialized_size_union_xcdr1(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
+  bool serialize_union_xcdr1(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
+  bool serialized_size_union(const DCPS::Encoding& encoding, size_t& size,
+                             DCPS::Sample::Extent ext) const;
+  bool serialize_union(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
 
   bool serialized_size_i(const DCPS::Encoding& encoding, size_t& size, DCPS::Sample::Extent ext) const;
   bool serialize_i(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;

--- a/dds/DCPS/XTypes/DynamicDataImpl.h
+++ b/dds/DCPS/XTypes/DynamicDataImpl.h
@@ -629,8 +629,7 @@ private:
 
   // Copy a value of a basic member from single map to a DynamicData object.
   bool move_single_to_complex(const const_single_iterator& it, DynamicDataImpl* data);
-  bool move_single_to_complex_i(const const_single_iterator& it, DynamicDataImpl* data,
-                                const TypeKind treat_as);
+  bool move_single_to_complex_i(const const_single_iterator& it, DynamicDataImpl* data, TypeKind treat_as);
 
   template<typename SequenceType>
   void move_sequence_helper(const const_sequence_iterator& it, DynamicDataImpl* data);

--- a/dds/DCPS/XTypes/DynamicDataImpl.h
+++ b/dds/DCPS/XTypes/DynamicDataImpl.h
@@ -625,18 +625,15 @@ private:
   };
 
   // Copy a value of a basic member from single map to a DynamicData object.
-  bool move_single_to_complex(const DataContainer::const_single_iterator& it,
-                              DynamicDataImpl* data);
-  bool move_single_to_complex_i(const DataContainer::const_single_iterator& it,
-                                DynamicDataImpl* data, const TypeKind treat_as);
+  bool move_single_to_complex(const const_single_iterator& it, DynamicDataImpl* data);
+  bool move_single_to_complex_i(const const_single_iterator& it, DynamicDataImpl* data,
+                                const TypeKind treat_as);
 
   template<typename SequenceType>
-  void move_sequence_helper(const DataContainer::const_sequence_iterator& it,
-                            DynamicDataImpl* data);
+  void move_sequence_helper(const const_sequence_iterator& it, DynamicDataImpl* data);
 
   // Copy values of a basic sequence member from sequence map to a DynamicData object.
-  bool move_sequence_to_complex(const DataContainer::const_sequence_iterator& it,
-                                DynamicDataImpl* data);
+  bool move_sequence_to_complex(const const_sequence_iterator& it, DynamicDataImpl* data);
 
   // Indicate whether the value of a member is found in the complex map or
   // one of the other two maps or not found from any map in the container.
@@ -651,7 +648,7 @@ private:
   bool get_complex_from_collection(DDS::DynamicData_ptr& value, DDS::MemberId id);
 
   bool read_discriminator(CORBA::Long& disc_val, const DDS::DynamicType_var& disc_type,
-                          DataContainer::const_single_iterator it) const;
+                          const_single_iterator it) const;
 
   // Add a single value for any valid discriminator value that selects the given member
   bool insert_valid_discriminator(DDS::MemberDescriptor* memberSelected);

--- a/dds/DCPS/XTypes/DynamicDataImpl.h
+++ b/dds/DCPS/XTypes/DynamicDataImpl.h
@@ -226,6 +226,9 @@ public:
   DDS::ReturnCode_t get_simple_value(DCPS::Value& value, DDS::MemberId id);
 #endif
 
+  bool serialized_size(const DCPS::Encoding& enc, size_t& size, DCPS::Sample::Extent ext) const;
+  bool serialize(DCPS::Serializer& ser, DCPS::Sample::Extent ext) const;
+
 private:
 #ifndef OPENDDS_NO_CONTENT_SUBSCRIPTION_PROFILE
   DDS::ReturnCode_t get_simple_value_boolean(DCPS::Value& value, DDS::MemberId id) const;

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.h
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.h
@@ -342,6 +342,18 @@ public:
   DDS::ReturnCode_t get_simple_value(DCPS::Value& value, DDS::MemberId id);
 #endif
 
+  bool serialized_size(const DCPS::Encoding&, size_t&, DCPS::Sample::Extent) const
+  {
+    // Not supported.
+    return false;
+  }
+
+  bool serialize(DCPS::Serializer&, DCPS::Sample::Extent) const
+  {
+    // Not supported.
+    return false;
+  }
+
 private:
 
   class ScopedChainManager {

--- a/dds/DCPS/XTypes/DynamicSample.cpp
+++ b/dds/DCPS/XTypes/DynamicSample.cpp
@@ -44,16 +44,16 @@ size_t DynamicSample::serialized_size(const Encoding& enc) const
 {
   const DynamicDataBase* const ddb = dynamic_cast<DynamicDataBase*>(data_.in());
   if (!ddb) {
-    if (log_level >= LogLevel::Notice) {
-      ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DynamicSample::serialized_size: "
+    if (log_level >= LogLevel::Warning) {
+      ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: DynamicSample::serialized_size: "
                  "DynamicData must be a DynamicDataBase\n"));
     }
-    return false;
+    return 0;
   }
   size_t size = 0;
   if (!ddb->serialized_size(enc, size, extent_)) {
-    if (log_level >= LogLevel::Notice) {
-      ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DynamicSample::serialized_size: "
+    if (log_level >= LogLevel::Warning) {
+      ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: DynamicSample::serialized_size: "
                  "DynamicDataBase::serialized_size failed!\n"));
     }
     return 0;

--- a/dds/DCPS/XTypes/DynamicSample.cpp
+++ b/dds/DCPS/XTypes/DynamicSample.cpp
@@ -50,7 +50,7 @@ size_t DynamicSample::serialized_size(const Encoding& enc) const
     }
     return false;
   }
-  size_t size;
+  size_t size = 0;
   if (!ddb->serialized_size(enc, size, extent_)) {
     if (log_level >= LogLevel::Notice) {
       ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DynamicSample::serialized_size: "

--- a/dds/DCPS/XTypes/DynamicSample.cpp
+++ b/dds/DCPS/XTypes/DynamicSample.cpp
@@ -42,32 +42,36 @@ DynamicSample& DynamicSample::operator=(const DynamicSample& rhs)
 
 size_t DynamicSample::serialized_size(const Encoding& enc) const
 {
-  const DynamicDataImpl* const ddi = dynamic_cast<DynamicDataImpl*>(data_.in());
-  if (!ddi) {
-    if (log_level >= LogLevel::Warning) {
-      ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: DynamicSample::serialized_size: "
-        "DynamicData must be DynamicDataImpl, the type supplied by DynamicDataFactory\n"));
+  const DynamicDataBase* const ddb = dynamic_cast<DynamicDataBase*>(data_.in());
+  if (!ddb) {
+    if (log_level >= LogLevel::Notice) {
+      ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DynamicSample::serialized_size: "
+                 "DynamicData must be a DynamicDataBase\n"));
+    }
+    return false;
+  }
+  size_t size;
+  if (!ddb->serialized_size(enc, size, extent_)) {
+    if (log_level >= LogLevel::Notice) {
+      ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DynamicSample::serialized_size: "
+                 "DynamicDataBase::serialized_size failed!\n"));
     }
     return 0;
   }
-  return key_only()
-    ? DCPS::serialized_size(enc, DCPS::KeyOnly<const DynamicDataImpl>(*ddi))
-    : DCPS::serialized_size(enc, *ddi);
+  return size;
 }
 
 bool DynamicSample::serialize(Serializer& ser) const
 {
-  const DynamicDataImpl* const ddi = dynamic_cast<DynamicDataImpl*>(data_.in());
-  if (!ddi) {
+  const DynamicDataBase* const ddb = dynamic_cast<DynamicDataBase*>(data_.in());
+  if (!ddb) {
     if (log_level >= LogLevel::Notice) {
       ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: DynamicSample::serialize: "
-        "DynamicData must be DynamicDataImpl, the type supplied by DynamicDataFactory\n"));
+                 "DynamicData must be a DynamicDataBase\n"));
     }
     return false;
   }
-  return key_only()
-    ? ser << DCPS::KeyOnly<const DynamicDataImpl>(*ddi)
-    : ser << *ddi;
+  return ddb->serialize(ser, extent_);
 }
 
 bool DynamicSample::deserialize(Serializer& ser)

--- a/dds/idl/dynamic_data_adapter_generator.cpp
+++ b/dds/idl/dynamic_data_adapter_generator.cpp
@@ -572,6 +572,9 @@ namespace {
 
     {
       NoSafetyProfileGuard nspg;
+      if (!generate) {
+        wrapper.generate_tag();
+      }
 
       std::string export_macro = be_global->export_macro().c_str();
       if (export_macro.size()) {

--- a/dds/idl/dynamic_data_adapter_generator.cpp
+++ b/dds/idl/dynamic_data_adapter_generator.cpp
@@ -450,6 +450,54 @@ namespace {
           "\n";
       }
 
+      if (struct_node || union_node) {
+        be_global->impl_ <<
+          "  bool serialized_size(const OpenDDS::DCPS::Encoding& enc, size_t& size, OpenDDS::DCPS::Sample::Extent ext) const\n"
+          "  {\n"
+          "    using namespace OpenDDS::DCPS;\n"
+          "    if (ext == Sample::Full) {\n"
+          "      DCPS::serialized_size(enc, size, value_);\n"
+          "    } else if (ext == Sample::NestedKeyOnly) {\n"
+          "      NestedKeyOnly<const " << cpp_name << "> nested_key_only(value_);\n"
+          "      DCPS::serialized_size(enc, size, nested_key_only);\n"
+          "    } else {\n";
+        const bool is_topic_type = be_global->is_topic_type(node);
+        if (is_topic_type) {
+          be_global->impl_ <<
+            "      KeyOnly<const " << cpp_name << "> key_only(value_);\n"
+            "      DCPS::serialized_size(enc, size, key_only);\n";
+        } else {
+          be_global->impl_ <<
+            "      return false; // Non-topic type\n";
+        }
+        be_global->impl_ <<
+          "    }\n"
+          "    return true;\n"
+          "  }\n"
+          "\n"
+          "  bool serialize(OpenDDS::DCPS::Serializer& ser, OpenDDS::DCPS::Sample::Extent ext) const\n"
+          "  {\n"
+          "    using namespace OpenDDS::DCPS;\n"
+          "    if (ext == Sample::Full) {\n"
+          "      return ser << value_;\n"
+          "    } else if (ext == Sample::NestedKeyOnly) {\n"
+          "      NestedKeyOnly<const " << cpp_name << "> nested_key_only(value_);\n"
+          "      return ser << nested_key_only;\n"
+          "    } else {\n";
+          if (is_topic_type) {
+            be_global->impl_ <<
+              "      KeyOnly<const " << cpp_name << "> key_only(value_);\n"
+              "      return ser << key_only;\n";
+          } else {
+            be_global->impl_ <<
+              "      return false; // Non-topic type\n";
+          }
+          be_global->impl_ <<
+          "    }\n"
+          "  }\n"
+          "\n";
+      }
+
       be_global->impl_ <<
         "protected:\n";
 

--- a/dds/idl/dynamic_data_adapter_generator.cpp
+++ b/dds/idl/dynamic_data_adapter_generator.cpp
@@ -455,6 +455,7 @@ namespace {
       }
 
       be_global->header_ <<
+        "  DDS::DynamicData_ptr clone();\n"
         "  bool serialized_size(const OpenDDS::DCPS::Encoding& enc, size_t& size, OpenDDS::DCPS::Sample::Extent ext) const;\n"
         "  bool serialize(OpenDDS::DCPS::Serializer& ser, OpenDDS::DCPS::Sample::Extent ext) const;\n"
         "\n";
@@ -463,6 +464,11 @@ namespace {
       const bool forany = needs_forany(dynamic_cast<AST_Type*>(node));
       const bool distinct_type = needs_distinct_type(dynamic_cast<AST_Type*>(node));
       be_global->impl_ <<
+        "DDS::DynamicData_ptr " << impl_classname << "::clone()\n"
+        "{\n"
+        "  return new DynamicDataAdapterImpl(type_, value_);\n"
+        "}\n"
+        "\n"
         "bool " << impl_classname << "::serialized_size(\n"
         "  const OpenDDS::DCPS::Encoding& enc, size_t& size, OpenDDS::DCPS::Sample::Extent ext) const\n"
         "{\n";

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -952,6 +952,7 @@ namespace {
     {
       RefWrapper wrapper(base_wrapper);
       wrapper.done();
+
       Function serialized_size("serialized_size", "void");
       serialized_size.addArg("encoding", "const Encoding&");
       serialized_size.addArg("size", "size_t&");

--- a/docs/internal/dev_guidelines.rst
+++ b/docs/internal/dev_guidelines.rst
@@ -211,6 +211,7 @@ Language Usage
 * Modifiers like ``const`` appear left of the types they modify, like: ``const char* cstring = ...``.
   ``char const*`` is equivalent but not conventional.
 * For function arguments that are not modified by the callee, pass by value for small objects (8 bytes?) and pass by const-reference for everything else.
+  Function argument that is passed by value should not have ``const`` qualifier in the function declaration; use of ``const`` in the definition is optional.
 * Arguments unused by the implementation have no names (in the definition that is, the declarations still have names), or a ``/*commented-out*/`` name.
 * Use ``explicit`` constructors unless implicit conversions are intended and desirable.
 * Use the constructor initializer list and make sure its order matches the declaration order.

--- a/tests/DCPS/DynamicData/publisher.cpp
+++ b/tests/DCPS/DynamicData/publisher.cpp
@@ -93,7 +93,15 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     if (check_rc(dd->set_string_value(0, HelloWorld::MESSAGE_EXAMPLE_VALUE), "set_string_value failed")) {
       return 1;
     }
-    if (check_rc(ddw->write(dd, DDS::HANDLE_NIL), "write (dynamic) failed")) {
+    if (check_rc(ddw->write(dd, DDS::HANDLE_NIL), "write (DynamicDataImpl) failed")) {
+      return 1;
+    }
+  } else if (/*adapter*/true) { // TODO(sonndinh): Add "adapter" option.
+    DDS::DynamicDataWriter_var ddw = DDS::DynamicDataWriter::_narrow(data_writer);
+    HelloWorld::Message msg;
+    msg.value = HelloWorld::MESSAGE_EXAMPLE_VALUE;
+    OpenDDS::XTypes::DynamicDataAdapterImpl<HelloWorld::Message, HelloWorld::Message> ddai(dt, msg);
+    if (check_rc(ddw->write(&ddai, DDS::HANDLE_NIL), "write (DynamicDataAdapter) failed")) {
       return 1;
     }
   } else {

--- a/tests/DCPS/DynamicData/publisher.cpp
+++ b/tests/DCPS/DynamicData/publisher.cpp
@@ -91,8 +91,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 
   if (dynamic) {
     if (adapter) {
-#ifndef OPENDDS_SAFETY_PROFILE
-#  if OPENDDS_HAS_DYNAMIC_DATA_ADAPTER
+#if OPENDDS_HAS_DYNAMIC_DATA_ADAPTER
       DDS::DynamicDataWriter_var ddw = DDS::DynamicDataWriter::_narrow(data_writer);
       HelloWorld::Message msg;
       msg.value = HelloWorld::MESSAGE_EXAMPLE_VALUE;
@@ -100,7 +99,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       if (check_rc(ddw->write(ddai, DDS::HANDLE_NIL), "write (DynamicDataAdapter) failed")) {
         return 1;
       }
-#  endif
 #endif
     } else {
       DDS::DynamicDataWriter_var ddw = DDS::DynamicDataWriter::_narrow(data_writer);

--- a/tests/DCPS/DynamicData/publisher.cpp
+++ b/tests/DCPS/DynamicData/publisher.cpp
@@ -96,15 +96,21 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     if (check_rc(ddw->write(dd, DDS::HANDLE_NIL), "write (DynamicDataImpl) failed")) {
       return 1;
     }
-  } else if (/*adapter*/true) { // TODO(sonndinh): Add "adapter" option.
-    DDS::DynamicDataWriter_var ddw = DDS::DynamicDataWriter::_narrow(data_writer);
-    HelloWorld::Message msg;
-    msg.value = HelloWorld::MESSAGE_EXAMPLE_VALUE;
-    OpenDDS::XTypes::DynamicDataAdapterImpl<HelloWorld::Message, HelloWorld::Message> ddai(dt, msg);
-    if (check_rc(ddw->write(&ddai, DDS::HANDLE_NIL), "write (DynamicDataAdapter) failed")) {
-      return 1;
-    }
-  } else {
+  }
+// #ifndef OPENDDS_SAFETY_PROFILE
+// #if OPENDDS_HAS_DYNAMIC_DATA_ADAPTER
+//   else if (/*adapter*/true) { // TODO(sonndinh): Add "adapter" option.
+//     DDS::DynamicDataWriter_var ddw = DDS::DynamicDataWriter::_narrow(data_writer);
+//     HelloWorld::Message msg;
+//     msg.value = HelloWorld::MESSAGE_EXAMPLE_VALUE;
+//     OpenDDS::XTypes::DynamicDataAdapterImpl<HelloWorld::Message, HelloWorld::Message> ddai(dt, msg);
+//     if (check_rc(ddw->write(&ddai, DDS::HANDLE_NIL), "write (DynamicDataAdapter) failed")) {
+//       return 1;
+//     }
+//   }
+// #endif
+// #endif
+  else {
     HelloWorld::MessageDataWriter_var mdw = HelloWorld::MessageDataWriter::_narrow(data_writer);
     HelloWorld::Message msg;
     msg.value = HelloWorld::MESSAGE_EXAMPLE_VALUE;

--- a/tests/DCPS/DynamicData/run_test.pl
+++ b/tests/DCPS/DynamicData/run_test.pl
@@ -17,9 +17,17 @@ $test->setup_discovery();
 
 my $dyn;
 $test->flag('dyn', \$dyn);
+my $adapt = 0;
+if ($test->flag('adapt')) {
+  $adapt = 1;
+}
+
+my @pub_args = ();
+push(@pub_args, "-dynamic") if ($dyn eq 'dw');
+push(@pub_args, "-adapter") if ($adapt);
 
 $test->process('subscriber', 'subscriber', $dyn eq 'dr' ? '-dynamic' : '');
-$test->process('publisher', 'publisher', $dyn eq 'dw' ? '-dynamic' : '');
+$test->process('publisher', 'publisher', join(' ', @pub_args));
 
 rmtree './DCS';
 

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -509,5 +509,6 @@ tests/DCPS/TypeSupportPlugin/run_test.pl: !DCPS_MIN !BROKEN_DLCLOSE
 
 tests/DCPS/DynamicData/run_test.pl dyn=dw ini=rtps.ini: RTPS !OPENDDS_SAFETY_PROFILE
 tests/DCPS/DynamicData/run_test.pl dyn=dr ini=rtps.ini: RTPS !OPENDDS_SAFETY_PROFILE
+tests/DCPS/DynamicData/run_test.pl dyn=dw ini=rtps.ini adapt: RTPS !OPENDDS_SAFETY_PROFILE !DDS_NO_CONTENT_SUBSCRIPTION
 
 tests/DCPS/DynamicResponse/run_test.pl: RTPS !OPENDDS_SAFETY_PROFILE !DDS_NO_OWNERSHIP_PROFILE !NO_BUILT_IN_TOPICS


### PR DESCRIPTION
- Move the internal XCDR serialization functions for `DynamicDataImpl` out of its `DataContainer`. `DataContainer` now is just a container of the sample data which would facilitate serializing to other formats.
- Add new interfaces for XCDR serialization to `DynamicDataBase` that allow dynamic writers to send dynamic samples constructed from `DynamicDataAdapter` in addition to `DynamicDataImpl`.