### PR TITLE
Add Read the Docs Config File

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+  builder: html
+  fail_on_warning: true
+
+# NOTE: These are in addition to the main HTML
+formats:
+  - pdf
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
This is apparently going to be required going forward: https://blog.readthedocs.com/migrate-configuration-v2/