### PR TITLE
`MulticastInst` does not use `ConfigStore`

### DIFF
--- a/dds/DCPS/ConfigStoreImpl.cpp
+++ b/dds/DCPS/ConfigStoreImpl.cpp
@@ -398,7 +398,8 @@ ConfigStoreImpl::set(const char* key,
 
 String
 ConfigStoreImpl::get(const char* key,
-                     const String& value) const
+                     const String& value,
+                     bool allow_empty) const
 {
   const ConfigPair cp(key, "");
   String retval = value;
@@ -410,7 +411,7 @@ ConfigStoreImpl::get(const char* key,
   for (size_t idx = 0; idx != samples.size(); ++idx) {
     const ConfigPair& sample = samples[idx];
     const DDS::SampleInfo& info = infos[idx];
-    if (info.valid_data) {
+    if (info.valid_data && (allow_empty || !sample.value().empty())) {
       retval = sample.value();
     }
   }
@@ -502,6 +503,12 @@ namespace {
                      ConfigStoreImpl::NetworkAddressKind kind)
   {
     switch (kind) {
+    case ConfigStoreImpl::Kind_ANY:
+      return value.get_type() == AF_INET
+#ifdef ACE_HAS_IPV6
+        || value.get_type() == AF_INET6
+#endif
+        ;
     case ConfigStoreImpl::Kind_IPV4:
       return value.get_type() == AF_INET;
 #ifdef ACE_HAS_IPV6

--- a/dds/DCPS/ConfigStoreImpl.h
+++ b/dds/DCPS/ConfigStoreImpl.h
@@ -95,6 +95,7 @@ public:
   };
 
   enum NetworkAddressKind {
+    Kind_ANY,
     Kind_IPV4
 #ifdef ACE_HAS_IPV6
     , Kind_IPV6
@@ -142,7 +143,8 @@ public:
   void set(const char* key,
            const String& value);
   String get(const char* key,
-             const String& value) const;
+             const String& value,
+             bool allow_empty = true) const;
 
   void set(const char* key,
            const TimeDuration& value,

--- a/dds/DCPS/transport/multicast/MulticastDataLink.cpp
+++ b/dds/DCPS/transport/multicast/MulticastDataLink.cpp
@@ -54,7 +54,7 @@ MulticastDataLink::MulticastDataLink(const MulticastTransport_rch& transport,
   // A send buffer may be bound to the send strategy to ensure a
   // configured number of most-recent datagrams are retained:
   if (session_factory_->requires_send_buffer()) {
-    const size_t nak_depth = config ? config->nak_depth_ : MulticastInst::DEFAULT_NAK_DEPTH;
+    const size_t nak_depth = config ? config->nak_depth() : MulticastInst::DEFAULT_NAK_DEPTH;
     const size_t default_max_samples = DEFAULT_CONFIG_MAX_SAMPLES_PER_PACKET;
     const size_t max_samples_per_packet = config ? config->max_samples_per_packet() : default_max_samples;
     send_buffer_.reset(new SingleSendBuffer(nak_depth, max_samples_per_packet));
@@ -78,7 +78,7 @@ MulticastDataLink::join(const ACE_INET_Addr& group_address)
     return false;
   }
 
-  const std::string& net_if = cfg->local_address_;
+  const String net_if = cfg->local_address();
 #ifdef ACE_HAS_MAC_OSX
   socket_.opts(ACE_SOCK_Dgram_Mcast::OPT_BINDADDR_NO |
                ACE_SOCK_Dgram_Mcast::DEFOPT_NULLIFACE);
@@ -95,7 +95,7 @@ MulticastDataLink::join(const ACE_INET_Addr& group_address)
 
   ACE_HANDLE handle = this->socket_.get_handle();
 
-  if (!OpenDDS::DCPS::set_socket_multicast_ttl(this->socket_, cfg->ttl_)) {
+  if (!OpenDDS::DCPS::set_socket_multicast_ttl(this->socket_, cfg->ttl())) {
     ACE_ERROR_RETURN((LM_ERROR,
         ACE_TEXT("(%P|%t) ERROR: ")
         ACE_TEXT("MulticastDataLink::join: ")
@@ -103,7 +103,7 @@ MulticastDataLink::join(const ACE_INET_Addr& group_address)
         false);
   }
 
-  int rcv_buffer_size = ACE_Utils::truncate_cast<int>(cfg->rcv_buffer_size_);
+  int rcv_buffer_size = ACE_Utils::truncate_cast<int>(cfg->rcv_buffer_size());
   if (rcv_buffer_size != 0
       && ACE_OS::setsockopt(handle, SOL_SOCKET,
           SO_RCVBUF,

--- a/dds/DCPS/transport/multicast/MulticastInst.cpp
+++ b/dds/DCPS/transport/multicast/MulticastInst.cpp
@@ -44,31 +44,8 @@ namespace OpenDDS {
 namespace DCPS {
 
 MulticastInst::MulticastInst(const std::string& name)
-  : TransportInst("multicast", name),
-    default_to_ipv6_(DEFAULT_TO_IPV6),
-    port_offset_(DEFAULT_PORT_OFFSET),
-    reliable_(DEFAULT_RELIABLE),
-    syn_backoff_(DEFAULT_SYN_BACKOFF),
-    nak_depth_(DEFAULT_NAK_DEPTH),
-    nak_delay_intervals_(DEFAULT_NAK_DELAY_INTERVALS),
-    nak_max_(DEFAULT_NAK_MAX),
-    ttl_(DEFAULT_TTL),
-#if defined (ACE_DEFAULT_MAX_SOCKET_BUFSIZ)
-    rcv_buffer_size_(ACE_DEFAULT_MAX_SOCKET_BUFSIZ),
-#else
-    // Use system default values.
-    rcv_buffer_size_(0),
-#endif
-    async_send_(DEFAULT_ASYNC_SEND)
-{
-  default_group_address(this->group_address_);
-
-  syn_interval_ = TimeDuration::from_msec(DEFAULT_SYN_INTERVAL);
-  syn_timeout_ = TimeDuration::from_msec(DEFAULT_SYN_TIMEOUT);
-
-  nak_interval_ = TimeDuration::from_msec(DEFAULT_NAK_INTERVAL);
-  nak_timeout_ = TimeDuration::from_msec(DEFAULT_NAK_TIMEOUT);
-}
+  : TransportInst("multicast", name)
+{}
 
 int
 MulticastInst::load(ACE_Configuration_Heap& cf,
@@ -76,67 +53,7 @@ MulticastInst::load(ACE_Configuration_Heap& cf,
 {
   TransportInst::load(cf, sect); // delegate to parent
 
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("default_to_ipv6"),
-                   this->default_to_ipv6_, bool)
-
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("port_offset"),
-                   this->port_offset_, u_short)
-
-  // Explicitly initialize this string to stop gcc 11 from issuing a warning.
-  ACE_TString group_address_s(ACE_TEXT(""));
-  GET_CONFIG_TSTRING_VALUE(cf, sect, ACE_TEXT("group_address"),
-                           group_address_s)
-  if (group_address_s.is_empty()) {
-    // TODO: Passing 0 instead of transport id.  Does this cause complications?
-    default_group_address(this->group_address_);
-  } else {
-    this->group_address_.set(group_address_s.c_str());
-  }
-
-  GET_CONFIG_STRING_VALUE(cf, sect, ACE_TEXT("local_address"),
-                          this->local_address_);
-
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("reliable"), this->reliable_, bool)
-
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("syn_backoff"),
-                   this->syn_backoff_, double)
-
-  GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("syn_interval"), this->syn_interval_)
-
-  GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("syn_timeout"), this->syn_timeout_)
-
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("nak_depth"),
-                   this->nak_depth_, size_t)
-
-  GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("nak_interval"), this->nak_interval_)
-
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("nak_delay_intervals"),
-                        this->nak_delay_intervals_, size_t)
-
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("nak_max"), this->nak_max_, size_t)
-
-  GET_CONFIG_TIME_VALUE(cf, sect, ACE_TEXT("nak_timeout"), this->nak_timeout_)
-
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("ttl"), this->ttl_, unsigned char)
-
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("rcv_buffer_size"),
-                   this->rcv_buffer_size_, size_t)
-
-#if defined (ACE_WIN32) && defined (ACE_HAS_WIN32_OVERLAPPED_IO)
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("async_send"), this->async_send_, bool)
-#endif
-
   return 0;
-}
-
-void
-MulticastInst::default_group_address(ACE_INET_Addr& group_address)
-{
-  if (this->default_to_ipv6_) {
-    group_address.set(this->port_offset_, DEFAULT_IPV6_GROUP_ADDRESS);
-  } else {
-    group_address.set(this->port_offset_, DEFAULT_IPV4_GROUP_ADDRESS);
-  }
 }
 
 TransportImpl_rch
@@ -151,32 +68,32 @@ MulticastInst::dump_to_str() const
   std::ostringstream os;
   os << TransportInst::dump_to_str();
 
-  os << formatNameForDump("group_address")       << LogAddr(group_address_).str() << std::endl;
-  os << formatNameForDump("local_address")       << this->local_address_ << std::endl;
-  os << formatNameForDump("default_to_ipv6")     << (this->default_to_ipv6_ ? "true" : "false") << std::endl;
-  os << formatNameForDump("port_offset")         << this->port_offset_ << std::endl;
-  os << formatNameForDump("reliable")            << (this->reliable_ ? "true" : "false") << std::endl;
-  os << formatNameForDump("syn_backoff")         << this->syn_backoff_ << std::endl;
-  os << formatNameForDump("syn_interval")        << this->syn_interval_.str() << std::endl;
-  os << formatNameForDump("syn_timeout")         << this->syn_timeout_.str() << std::endl;
-  os << formatNameForDump("nak_depth")           << this->nak_depth_ << std::endl;
-  os << formatNameForDump("nak_interval")        << this->nak_interval_.str() << std::endl;
-  os << formatNameForDump("nak_delay_intervals") << this->nak_delay_intervals_ << std::endl;
-  os << formatNameForDump("nak_max")             << this->nak_max_ << std::endl;
-  os << formatNameForDump("nak_timeout")         << this->nak_timeout_.str() << std::endl;
-  os << formatNameForDump("ttl")                 << int(this->ttl_) << std::endl;
+  os << formatNameForDump("group_address")       << LogAddr(group_address()).str() << std::endl;
+  os << formatNameForDump("local_address")       << this->local_address() << std::endl;
+  os << formatNameForDump("default_to_ipv6")     << (this->default_to_ipv6() ? "true" : "false") << std::endl;
+  os << formatNameForDump("port_offset")         << this->port_offset() << std::endl;
+  os << formatNameForDump("reliable")            << (this->reliable() ? "true" : "false") << std::endl;
+  os << formatNameForDump("syn_backoff")         << this->syn_backoff() << std::endl;
+  os << formatNameForDump("syn_interval")        << this->syn_interval().str() << std::endl;
+  os << formatNameForDump("syn_timeout")         << this->syn_timeout().str() << std::endl;
+  os << formatNameForDump("nak_depth")           << this->nak_depth() << std::endl;
+  os << formatNameForDump("nak_interval")        << this->nak_interval().str() << std::endl;
+  os << formatNameForDump("nak_delay_intervals") << this->nak_delay_intervals() << std::endl;
+  os << formatNameForDump("nak_max")             << this->nak_max() << std::endl;
+  os << formatNameForDump("nak_timeout")         << this->nak_timeout().str() << std::endl;
+  os << formatNameForDump("ttl")                 << int(this->ttl()) << std::endl;
   os << formatNameForDump("rcv_buffer_size");
 
-  if (this->rcv_buffer_size_ == 0) {
+  if (this->rcv_buffer_size() == 0) {
     os << "System Default Value" << std::endl;
   } else {
-    os << this->rcv_buffer_size_ << std::endl;
+    os << this->rcv_buffer_size() << std::endl;
   }
 
   os << formatNameForDump("async_send");
 
 #if defined (ACE_WIN32) && defined (ACE_HAS_WIN32_OVERLAPPED_IO)
-  os << (this->async_send_ ? "true" : "false") << std::endl;
+  os << (this->async_send() ? "true" : "false") << std::endl;
 #else
   os << "Not Supported on this Platform" << std::endl;
 #endif
@@ -186,8 +103,13 @@ MulticastInst::dump_to_str() const
 size_t
 MulticastInst::populate_locator(OpenDDS::DCPS::TransportLocator& info, ConnectionInfoFlags) const
 {
-  if (group_address_ != ACE_INET_Addr()) {
-    NetworkResource network_resource(group_address_);
+  const NetworkAddress ga = group_address();
+  if (ga != NetworkAddress::default_IPV4
+#ifdef ACE_HAS_IPV6
+      && ga != NetworkAddress::default_IPV6
+#endif
+      ) {
+    NetworkResource network_resource(ga.to_addr());
 
     ACE_OutputCDR cdr;
     cdr << network_resource;
@@ -202,6 +124,251 @@ MulticastInst::populate_locator(OpenDDS::DCPS::TransportLocator& info, Connectio
   } else {
     return 0;
   }
+}
+
+void
+MulticastInst::default_to_ipv6(bool flag)
+{
+  TheServiceParticipant->config_store()->set_boolean(config_key("DEFAULT_TO_IPV6").c_str(), flag);
+}
+
+bool
+MulticastInst::default_to_ipv6() const
+{
+  return TheServiceParticipant->config_store()->get_boolean(config_key("DEFAULT_TO_IPV6").c_str(), DEFAULT_TO_IPV6);
+}
+
+void
+MulticastInst::port_offset(u_short po)
+{
+  TheServiceParticipant->config_store()->set_uint32(config_key("PORT_OFFSET").c_str(), po);
+}
+
+u_short
+MulticastInst::port_offset() const
+{
+  return TheServiceParticipant->config_store()->get_uint32(config_key("PORT_OFFSET").c_str(), DEFAULT_PORT_OFFSET);
+}
+
+void
+MulticastInst::group_address(const NetworkAddress& na)
+{
+  TheServiceParticipant->config_store()->set(config_key("GROUP_ADDRESS").c_str(),
+                                             na,
+                                             ConfigStoreImpl::Format_Required_Port,
+                                             ConfigStoreImpl::Kind_ANY);
+}
+
+NetworkAddress
+MulticastInst::group_address() const
+{
+  ACE_INET_Addr default_group_address;
+  if (default_to_ipv6()) {
+    default_group_address.set(port_offset(), DEFAULT_IPV6_GROUP_ADDRESS);
+  } else {
+    default_group_address.set(port_offset(), DEFAULT_IPV4_GROUP_ADDRESS);
+  }
+
+  return TheServiceParticipant->config_store()->get(config_key("GROUP_ADDRESS").c_str(),
+                                                    NetworkAddress(default_group_address),
+                                                    ConfigStoreImpl::Format_Required_Port,
+                                                    ConfigStoreImpl::Kind_ANY);
+}
+
+void
+MulticastInst::local_address(const String& la)
+{
+  TheServiceParticipant->config_store()->set(config_key("LOCAL_ADDRESS").c_str(), la);
+}
+
+String
+MulticastInst::local_address() const
+{
+  String la = TheServiceParticipant->config_store()->get(config_key("LOCAL_ADDRESS").c_str(), "");
+  // Override with DCPSDefaultAddress.
+  if (la.empty() &&
+      TheServiceParticipant->default_address() != NetworkAddress::default_IPV4) {
+    char buffer[INET6_ADDRSTRLEN];
+    la = TheServiceParticipant->default_address().to_addr().get_host_addr(buffer, sizeof buffer);
+  }
+  return la;
+}
+
+void
+MulticastInst::reliable(bool flag)
+{
+  TheServiceParticipant->config_store()->set_boolean(config_key("RELIABLE").c_str(), flag);
+}
+
+bool
+MulticastInst::reliable() const
+{
+  return TheServiceParticipant->config_store()->get_boolean(config_key("RELIABLE").c_str(), DEFAULT_RELIABLE);
+}
+
+void
+MulticastInst::syn_backoff(double sb)
+{
+  TheServiceParticipant->config_store()->set_float64(config_key("SYN_BACKOFF").c_str(), sb);
+}
+
+double
+MulticastInst::syn_backoff() const
+{
+  return TheServiceParticipant->config_store()->get_float64(config_key("SYN_BACKOFF").c_str(), DEFAULT_SYN_BACKOFF);
+}
+
+void
+MulticastInst::syn_interval(const TimeDuration& si)
+{
+  TheServiceParticipant->config_store()->set(config_key("SYN_INTERVAL").c_str(),
+                                             si,
+                                             ConfigStoreImpl::Format_IntegerMilliseconds);
+}
+
+TimeDuration
+MulticastInst::syn_interval() const
+{
+  return TheServiceParticipant->config_store()->get(config_key("SYN_INTERVAL").c_str(),
+                                                    TimeDuration::from_msec(DEFAULT_SYN_INTERVAL),
+                                                    ConfigStoreImpl::Format_IntegerMilliseconds);
+}
+
+void
+MulticastInst::syn_timeout(const TimeDuration& st)
+{
+  TheServiceParticipant->config_store()->set(config_key("SYN_TIMEOUT").c_str(),
+                                             st,
+                                             ConfigStoreImpl::Format_IntegerMilliseconds);
+}
+
+TimeDuration
+MulticastInst::syn_timeout() const
+{
+  return TheServiceParticipant->config_store()->get(config_key("SYN_TIMEOUT").c_str(),
+                                                    TimeDuration::from_msec(DEFAULT_SYN_TIMEOUT),
+                                                    ConfigStoreImpl::Format_IntegerMilliseconds);
+}
+
+void
+MulticastInst::nak_depth(size_t nd)
+{
+  TheServiceParticipant->config_store()->set_uint32(config_key("NAK_DEPTH").c_str(), static_cast<DDS::UInt32>(nd));
+}
+
+size_t
+MulticastInst::nak_depth() const
+{
+  return TheServiceParticipant->config_store()->get_uint32(config_key("NAK_DEPTH").c_str(), DEFAULT_NAK_DEPTH);
+}
+
+void
+MulticastInst::nak_interval(const TimeDuration& ni)
+{
+  TheServiceParticipant->config_store()->set(config_key("NAK_INTERVAL").c_str(),
+                                             ni,
+                                             ConfigStoreImpl::Format_IntegerMilliseconds);
+}
+
+TimeDuration
+MulticastInst::nak_interval() const
+{
+  return TheServiceParticipant->config_store()->get(config_key("NAK_INTERVAL").c_str(),
+                                                    TimeDuration::from_msec(DEFAULT_NAK_INTERVAL),
+                                                    ConfigStoreImpl::Format_IntegerMilliseconds);
+}
+
+void
+MulticastInst::nak_delay_intervals(size_t ndi)
+{
+  TheServiceParticipant->config_store()->set_uint32(config_key("NAK_DELAY_INTERVALS").c_str(),
+                                                    static_cast<DDS::UInt32>(ndi));
+}
+
+size_t
+MulticastInst::nak_delay_intervals() const
+{
+  return TheServiceParticipant->config_store()->get_uint32(config_key("NAK_DELAY_INTERVALS").c_str(),
+                                                           DEFAULT_NAK_DELAY_INTERVALS);
+}
+
+void
+MulticastInst::nak_max(size_t nm)
+{
+  TheServiceParticipant->config_store()->set_uint32(config_key("NAK_MAX").c_str(), static_cast<DDS::UInt32>(nm));
+}
+
+size_t
+MulticastInst::nak_max() const
+{
+  return TheServiceParticipant->config_store()->get_uint32(config_key("NAK_MAX").c_str(), DEFAULT_NAK_MAX);
+}
+
+void
+MulticastInst::nak_timeout(const TimeDuration& nt)
+{
+  TheServiceParticipant->config_store()->set(config_key("NAK_TIMEOUT").c_str(),
+                                             nt,
+                                             ConfigStoreImpl::Format_IntegerMilliseconds);
+}
+
+TimeDuration
+MulticastInst::nak_timeout() const
+{
+  return TheServiceParticipant->config_store()->get(config_key("NAK_TIMEOUT").c_str(),
+                                                    TimeDuration::from_msec(DEFAULT_NAK_TIMEOUT),
+                                                    ConfigStoreImpl::Format_IntegerMilliseconds);
+}
+
+void
+MulticastInst::ttl(unsigned char t)
+{
+  TheServiceParticipant->config_store()->set_uint32(config_key("TTL").c_str(), t);
+}
+
+unsigned char
+MulticastInst::ttl() const
+{
+  return TheServiceParticipant->config_store()->get_uint32(config_key("TTL").c_str(), DEFAULT_TTL);
+}
+
+void
+MulticastInst::rcv_buffer_size(size_t rbs)
+{
+  TheServiceParticipant->config_store()->set_uint32(config_key("RCV_BUFFER_SIZE").c_str(), static_cast<DDS::UInt32>(rbs));
+}
+
+size_t
+MulticastInst::rcv_buffer_size() const
+{
+  return TheServiceParticipant->config_store()->get_uint32(config_key("RCV_BUFFER_SIZE").c_str(),
+#if defined (ACE_DEFAULT_MAX_SOCKET_BUFSIZ)
+                                                           ACE_DEFAULT_MAX_SOCKET_BUFSIZ
+#else
+                                                           // Use system default values.
+                                                           0
+#endif
+                                                           );
+}
+
+void
+MulticastInst::async_send(bool flag)
+{
+  ACE_UNUSED_ARG(flag);
+#if defined (ACE_WIN32) && defined (ACE_HAS_WIN32_OVERLAPPED_IO)
+  TheServiceParticipant->config_store()->set_boolean(config_key("ASYNC_SEND").c_str(), flag);
+#endif
+}
+
+bool
+MulticastInst::async_send() const
+{
+#if defined (ACE_WIN32) && defined (ACE_HAS_WIN32_OVERLAPPED_IO)
+  return TheServiceParticipant->config_store()->get_boolean(config_key("ASYNC_SEND").c_str(), DEFAULT_ASYNC_SEND);
+#else
+  ACE_UNUSED_ARG(DEFAULT_ASYNC_SEND);
+  return false;
+#endif
 }
 
 } // namespace DCPS

--- a/dds/DCPS/transport/multicast/MulticastInst.h
+++ b/dds/DCPS/transport/multicast/MulticastInst.h
@@ -35,82 +35,98 @@ public:
 
   /// Enables IPv6 default group address selection.
   /// The default value is: false.
-  bool default_to_ipv6_;
+  void default_to_ipv6(bool flag);
+  bool default_to_ipv6() const;
 
   /// The default port number (when group_address is not set)
   /// The default value is: 49152 [IANA 2009-11-16].
-  u_short port_offset_;
+  void port_offset(u_short po);
+  u_short port_offset() const;
 
   /// The multicast group to join to send/receive data.
   /// The default value is:
   ///   224.0.0.128:<port> [IANA 2009-11-17], or
   ///    [FF01::80]:<port> [IANA 2009-08-28]
-  ACE_INET_Addr group_address_;
+  void group_address(const NetworkAddress& na);
+  NetworkAddress group_address() const;
 
   /// If non-empty, the address to pass to ACE which indicates the
   /// local network interface which should be used for joining the
   /// multicast group.
-  std::string local_address_;
+  void local_address(const String& la);
+  String local_address() const;
 
   /// Enables reliable communication. This option will eventually
   /// be deprecated.
   /// The default value is: true.
-  bool reliable_;
+  void reliable(bool flag);
+  bool reliable() const;
 
   /// The exponential base used during handshake retries; smaller
   /// values yield shorter delays between attempts.
   /// The default value is: 2.0.
-  double syn_backoff_;
+  void syn_backoff(double sb);
+  double syn_backoff() const;
 
   /// The minimum number of milliseconds to wait between handshake
   /// attempts during association.
   /// The default value is: 250.
-  TimeDuration syn_interval_;
+  void syn_interval(const TimeDuration& si);
+  TimeDuration syn_interval() const;
 
   /// The maximum number of milliseconds to wait before giving up
   /// on a handshake response during association.
   /// The default value is: 30000 (30 seconds).
-  TimeDuration syn_timeout_;
+  void syn_timeout(const TimeDuration& st);
+  TimeDuration syn_timeout() const;
 
   /// The number of datagrams to retain in order to service repair
   /// requests (reliable only).
   /// The default value is: 32.
-  size_t nak_depth_;
+  void nak_depth(size_t nd);
+  size_t nak_depth() const;
 
   /// The minimum number of milliseconds to wait between repair
   /// requests (reliable only).
   /// The default value is: 500.
-  TimeDuration nak_interval_;
+  void nak_interval(const TimeDuration& ni);
+  TimeDuration nak_interval() const;
 
   /// The number of interval's between nak's for a sample
   /// (after initial nak).
   /// The default value is: 4.
-  size_t nak_delay_intervals_;
+  void nak_delay_intervals(size_t ndi);
+  size_t nak_delay_intervals() const;
 
   /// The maximum number of a missing sample will be nak'ed.
   /// The default value is: 3.
-  size_t nak_max_;
+  void nak_max(size_t nm);
+  size_t nak_max() const;
 
   /// The maximum number of milliseconds to wait before giving up
   /// on a repair response (reliable only).
   /// The default value is: 30000 (30 seconds).
-  TimeDuration nak_timeout_;
+  void nak_timeout(const TimeDuration& nt);
+  TimeDuration nak_timeout() const;
 
   /// time-to-live.
   /// The default value is: 1 (in same subnet)
-  unsigned char ttl_;
+  void ttl(unsigned char t);
+  unsigned char ttl() const;
 
   /// The size of the socket receive buffer.
   /// The default value is: ACE_DEFAULT_MAX_SOCKET_BUFSIZ if it's defined,
   /// otherwise, 0.
   /// If the value is 0, the system default value is used.
-  size_t rcv_buffer_size_;
+  void rcv_buffer_size(size_t rbs);
+  size_t rcv_buffer_size() const;
 
   /// Sending using asynchronous I/O on Windows platforms that support it.
   /// The default value is: false.
   /// This parameter has no effect on non-Windows platforms and Windows platforms
   /// that don't support asynchronous I/O.
-  bool async_send_;
+  void async_send(bool as);
+  bool async_send() const;
 
   virtual int load(ACE_Configuration_Heap& cf,
                    ACE_Configuration_Section_Key& sect);
@@ -118,9 +134,7 @@ public:
   /// Diagnostic aid.
   virtual OPENDDS_STRING dump_to_str() const;
 
-  bool is_reliable() const { return this->reliable_; }
-
-  bool async_send() const { return this->async_send_; }
+  bool is_reliable() const { return reliable(); }
 
   virtual size_t populate_locator(OpenDDS::DCPS::TransportLocator& trans_info, ConnectionInfoFlags flags) const;
 
@@ -129,8 +143,6 @@ private:
   template <typename T, typename U>
   friend RcHandle<T> OpenDDS::DCPS::make_rch(U const&);
   explicit MulticastInst(const std::string& name);
-
-  void default_group_address(ACE_INET_Addr& group_address);
 
   TransportImpl_rch new_impl();
 };

--- a/dds/DCPS/transport/multicast/MulticastLoader.cpp
+++ b/dds/DCPS/transport/multicast/MulticastLoader.cpp
@@ -54,7 +54,7 @@ MulticastLoader::init(int /*argc*/, ACE_TCHAR* /*argv*/[])
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) MulticastLoader::init:")
       ACE_TEXT(" failed to obtain MulticastInst.\n")), -1);
   }
-  mi->reliable_ = false;
+  mi->reliable(false);
   cfg->sorted_insert(default_unrel);
 
   TransportInst_rch default_rel =

--- a/dds/DCPS/transport/multicast/MulticastSendStrategy.cpp
+++ b/dds/DCPS/transport/multicast/MulticastSendStrategy.cpp
@@ -19,8 +19,10 @@ MulticastSendStrategy::MulticastSendStrategy(MulticastDataLink* link)
   : TransportSendStrategy(0, link->impl(),
                           0,  // synch_resource
                           link->transport_priority(),
-                          make_rch<NullSynchStrategy>()),
-    link_(link)
+                          make_rch<NullSynchStrategy>())
+  , link_(link)
+  , async_send_(link->config()->async_send())
+  , group_address_(link->config()->group_address())
 #if defined (ACE_HAS_WIN32_OVERLAPPED_IO) || defined (ACE_HAS_AIO_CALLS)
   , async_init_(false)
 #endif
@@ -40,8 +42,7 @@ MulticastSendStrategy::prepare_header_i()
 ssize_t
 MulticastSendStrategy::send_bytes_i(const iovec iov[], int n)
 {
-  MulticastInst_rch cfg = link_->config();
-  return (cfg && cfg->async_send()) ? async_send(iov, n, cfg->group_address_) : sync_send(iov, n);
+  return async_send_ ? async_send(iov, n, group_address_.to_addr()) : sync_send(iov, n);
 }
 
 ssize_t

--- a/dds/DCPS/transport/multicast/MulticastSendStrategy.h
+++ b/dds/DCPS/transport/multicast/MulticastSendStrategy.h
@@ -10,7 +10,9 @@
 
 #include "Multicast_Export.h"
 
+#include "dds/DCPS/NetworkAddress.h"
 #include "dds/DCPS/transport/framework/TransportSendStrategy.h"
+
 #include "ace/Asynch_IO.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -51,6 +53,8 @@ protected:
 
 private:
   MulticastDataLink* link_;
+  const bool async_send_;
+  const NetworkAddress group_address_;
 
 #if defined (ACE_HAS_WIN32_OVERLAPPED_IO) || defined (ACE_HAS_AIO_CALLS)
   ACE_Asynch_Write_Dgram async_writer_;

--- a/dds/DCPS/transport/multicast/MulticastSession.cpp
+++ b/dds/DCPS/transport/multicast/MulticastSession.cpp
@@ -42,7 +42,7 @@ MulticastSession::MulticastSession(RcHandle<ReactorInterceptor> interceptor,
                                      interceptor,
                                      rchandle_from(this),
                                      &MulticastSession::send_all_syn))
-  , initial_syn_delay_(link->config()->syn_interval_)
+  , initial_syn_delay_(link->config()->syn_interval())
   , config_name(link->config()->name())
 {}
 

--- a/dds/DCPS/transport/multicast/MulticastTransport.cpp
+++ b/dds/DCPS/transport/multicast/MulticastTransport.cpp
@@ -76,10 +76,10 @@ MulticastTransport::make_datalink(const GUID_t& local_id,
                                                          active));
 
   // Join multicast group:
-  if (!link->join(cfg->group_address_)) {
+  if (!link->join(cfg->group_address().to_addr())) {
     ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: MulticastTransport::make_datalink: ")
                ACE_TEXT("failed to join multicast group: %C!\n"),
-               LogAddr(cfg->group_address_, LogAddr::HostPort).c_str()));
+               LogAddr(cfg->group_address(), LogAddr::HostPort).c_str()));
     return MulticastDataLink_rch();
   }
 
@@ -371,20 +371,13 @@ MulticastTransport::configure_i(const MulticastInst_rch& config)
     return false;
   }
 
-  // Override with DCPSDefaultAddress.
-  if (config->local_address_.empty() &&
-      TheServiceParticipant->default_address() != NetworkAddress::default_IPV4) {
-    char buffer[INET6_ADDRSTRLEN];
-    config->local_address_ = TheServiceParticipant->default_address().to_addr().get_host_addr(buffer, sizeof buffer);
-  }
-
-  if (!config->group_address_.is_multicast()) {
+  if (!config->group_address().is_multicast()) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: MulticastTransport[%@]::configure_i: ")
                       ACE_TEXT("invalid configuration: address %C is not multicast.\n"),
-                      this, LogAddr::ip(config->group_address_).c_str()), false);
+                      this, LogAddr::ip(config->group_address().to_addr()).c_str()), false);
   }
 
-  this->create_reactor_task(config->async_send_, "MulticastTransport" + config->name());
+  this->create_reactor_task(config->async_send(), "MulticastTransport" + config->name());
 
   return true;
 }

--- a/dds/DCPS/transport/multicast/ReliableSession.cpp
+++ b/dds/DCPS/transport/multicast/ReliableSession.cpp
@@ -38,6 +38,10 @@ ReliableSession::ReliableSession(RcHandle<ReactorInterceptor> interceptor,
                                      interceptor,
                                      rchandle_from(this),
                                      &ReliableSession::process_naks))
+  , nak_timeout_(link->config()->nak_timeout())
+  , nak_delay_intervals_(link->config()->nak_delay_intervals())
+  , nak_max_(link->config()->nak_max())
+  , nak_interval_(link->config()->nak_interval())
 {}
 
 ReliableSession::~ReliableSession()
@@ -225,9 +229,7 @@ ReliableSession::expire_naks()
 {
   if (this->nak_requests_.empty()) return; // nothing to expire
 
-  MulticastInst_rch cfg = link_->config();
-  const TimeDuration timeout = cfg ? cfg->nak_timeout_: TimeDuration::from_msec(MulticastInst::DEFAULT_NAK_TIMEOUT);
-  const MonotonicTimePoint deadline(MonotonicTimePoint::now() - timeout);
+  const MonotonicTimePoint deadline(MonotonicTimePoint::now() - nak_timeout_);
   NakRequestMap::iterator first(this->nak_requests_.begin());
   NakRequestMap::iterator last(this->nak_requests_.upper_bound(deadline));
 
@@ -337,9 +339,6 @@ ReliableSession::send_naks()
     // The sequences between rbegin - 1 and rbegin will not be ignored for naking.
     ++itr;
 
-    MulticastInst_rch cfg = link_->config();
-    size_t nak_delay_intervals = cfg ? cfg->nak_delay_intervals_ : MulticastInst::DEFAULT_NAK_DELAY_INTERVALS;
-    size_t nak_max = cfg ? cfg->nak_max_ : MulticastInst::DEFAULT_NAK_MAX;
     size_t sz = nak_requests_.size();
 
     // Image i is the index of element in nak_requests_ in reverse order.
@@ -351,7 +350,7 @@ ReliableSession::send_naks()
     //  are skipped for naking due to nak_delay_intervals and 20 - 16 are skipped for
     //  naking due to nak_max.
     for (size_t i = 1; i < sz; ++i) {
-      if ((i * 1.0) / (nak_delay_intervals + 1) > nak_max) {
+      if ((i * 1.0) / (nak_delay_intervals_ + 1) > nak_max_) {
         if (first != SequenceNumber()) {
           first = this->nak_requests_.begin()->second;
         }
@@ -361,14 +360,14 @@ ReliableSession::send_naks()
         break;
       }
 
-      if (i % (nak_delay_intervals + 1) == 1) {
+      if (i % (nak_delay_intervals_ + 1) == 1) {
         second = itr->second;
       }
       if (second != SequenceNumber()) {
         first = itr->second;
       }
 
-      if (i % (nak_delay_intervals + 1) == 0) {
+      if (i % (nak_delay_intervals_ + 1) == 0) {
         first = itr->second;
 
         if (first != SequenceNumber() && second != SequenceNumber()) {
@@ -685,8 +684,7 @@ ReliableSession::stop()
 TimeDuration
 ReliableSession::nak_delay()
 {
-  MulticastInst_rch cfg = link_->config();
-  TimeDuration interval = cfg ? cfg->nak_interval_ : TimeDuration::from_msec(MulticastInst::DEFAULT_NAK_INTERVAL);
+  TimeDuration interval = nak_interval_;
 
   // Apply random backoff to minimize potential collisions:
   interval *= static_cast<double>(std::rand()) /

--- a/dds/DCPS/transport/multicast/ReliableSession.h
+++ b/dds/DCPS/transport/multicast/ReliableSession.h
@@ -76,6 +76,11 @@ private:
 
   typedef OPENDDS_SET(SequenceRange) NakPeerSet;
   NakPeerSet nak_peers_;
+
+  const TimeDuration nak_timeout_;
+  const size_t nak_delay_intervals_;
+  const size_t nak_max_;
+  const TimeDuration nak_interval_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/udp/UdpInst.h
+++ b/dds/DCPS/transport/udp/UdpInst.h
@@ -25,6 +25,11 @@ public:
   ACE_INT32 send_buffer_size_;
   ACE_INT32 rcv_buffer_size_;
 
+  void rcv_buffer_size(ACE_INT32 rbs)
+  {
+    rcv_buffer_size_ = rbs;
+  }
+
   virtual int load(ACE_Configuration_Heap& cf,
                    ACE_Configuration_Section_Key& sect);
 

--- a/docs/news.d/config_store.rst
+++ b/docs/news.d/config_store.rst
@@ -1,6 +1,6 @@
-.. news-prs: 4162
+.. news-prs: 4162 4241
 .. news-start-section: Additions
-- OpenDDS now stores ``rtps_udp_transport`` configuration in the key-value store.
+- OpenDDS now stores ``rtps_udp`` transport configuration in the key-value store.
   The following members of ``RtpsUdpInst`` must now be accessed with getters and setters:
 
   -  ``send_buffer_size_``
@@ -15,5 +15,25 @@
   -  ``heartbeat_period_``
   -  ``receive_address_duration_``
   -  ``responsive_mode_``
+
+- OpenDDS now stores ``multicast`` transport configuration in the key-value store.
+  The following members of ``MulticastInst`` must now be accessed with getters and setters:
+
+  -  ``default_to_ipv6_``
+  -  ``port_offset_``
+  -  ``group_address_``
+  -  ``local_address_``
+  -  ``reliable_``
+  -  ``syn_backoff_``
+  -  ``syn_interval_``
+  -  ``syn_timeout_``
+  -  ``nak_depth_``
+  -  ``nak_interval_``
+  -  ``nak_delay_intervals_``
+  -  ``nak_max_``
+  -  ``mak_timeout_``
+  -  ``ttl_``
+  -  ``rcv_buffer_size_``
+  -  ``async_send_``
 
 .. news-end-section

--- a/java/dds/OpenDDS_DCPS_jni.cpp
+++ b/java/dds/OpenDDS_DCPS_jni.cpp
@@ -837,7 +837,7 @@ jboolean JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getDefaultToIPv6
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return inst->default_to_ipv6_;
+  return inst->default_to_ipv6();
 }
 
 // MulticastInst::setDefaultToIPv6
@@ -845,7 +845,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setDefaultToIPv6
 (JNIEnv * jni, jobject jthis, jboolean val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->default_to_ipv6_ = val;
+  inst->default_to_ipv6(val);
 }
 
 // MulticastInst::getPortOffset
@@ -853,7 +853,7 @@ jshort JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getPortOffset
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return inst->port_offset_;
+  return inst->port_offset();
 }
 
 // MulticastInst::setPortOffset
@@ -861,7 +861,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setPortOffset
 (JNIEnv * jni, jobject jthis, jshort val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->port_offset_ = val;
+  inst->port_offset(val);
 }
 
 // MulticastInst::getGroupAddress
@@ -869,7 +869,7 @@ jstring JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getGroupAddress
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return jni->NewStringUTF(OpenDDS::DCPS::LogAddr(inst->group_address_).c_str());
+  return jni->NewStringUTF(OpenDDS::DCPS::LogAddr(inst->group_address()).c_str());
 }
 
 // MulticastInst::setGroupAddress
@@ -878,7 +878,9 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setGroupAddress
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
   JStringMgr jsm_val(jni, val);
-  inst->group_address_.set(jsm_val.c_str());
+  ACE_INET_Addr addr;
+  addr.set(jsm_val.c_str());
+  inst->group_address(OpenDDS::DCPS::NetworkAddress(addr));
 }
 
 // MulticastInst::getReliable
@@ -886,7 +888,7 @@ jboolean JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getReliable
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return inst->reliable_;
+  return inst->reliable();
 }
 
 // MulticastInst::setReliable
@@ -894,7 +896,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setReliable
 (JNIEnv * jni, jobject jthis, jboolean val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->reliable_ = val;
+  inst->reliable(val);
 }
 
 // MulticastInst::getSynBackoff
@@ -902,7 +904,7 @@ jdouble JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getSynBackoff
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return inst->syn_backoff_;
+  return inst->syn_backoff();
 }
 
 // MulticastInst::setSynBackoff
@@ -910,7 +912,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setSynBackoff
 (JNIEnv * jni, jobject jthis, jdouble val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->syn_backoff_ = val;
+  inst->syn_backoff(val);
 }
 
 // MulticastInst::getSynInterval
@@ -918,7 +920,7 @@ jlong JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getSynInterval
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return inst->syn_interval_.value().msec();
+  return inst->syn_interval().value().msec();
 }
 
 // MulticastInst::setSynInterval
@@ -926,7 +928,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setSynInterval
 (JNIEnv * jni, jobject jthis, jlong val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->syn_interval_ = OpenDDS::DCPS::TimeDuration::from_msec(val);
+  inst->syn_interval(OpenDDS::DCPS::TimeDuration::from_msec(val));
 }
 
 // MulticastInst::getSynTimeout
@@ -934,7 +936,7 @@ jlong JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getSynTimeout
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return inst->syn_timeout_.value().msec();
+  return inst->syn_timeout().value().msec();
 }
 
 // MulticastInst::setSynTimeout
@@ -942,7 +944,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setSynTimeout
 (JNIEnv * jni, jobject jthis, jlong val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->syn_timeout_ = OpenDDS::DCPS::TimeDuration::from_msec(val);
+  inst->syn_timeout(OpenDDS::DCPS::TimeDuration::from_msec(val));
 }
 
 // MulticastInst::getNakDepth
@@ -950,7 +952,7 @@ jint JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getNakDepth
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return static_cast<jint>(inst->nak_depth_);
+  return static_cast<jint>(inst->nak_depth());
 }
 
 // MulticastInst::setNakDepth
@@ -958,7 +960,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setNakDepth
 (JNIEnv * jni, jobject jthis, jint val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->nak_depth_ = val;
+  inst->nak_depth(val);
 }
 
 // MulticastInst::getNakInterval
@@ -966,7 +968,7 @@ jlong JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getNakInterval
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return inst->nak_interval_.value().msec();
+  return inst->nak_interval().value().msec();
 }
 
 // MulticastInst::setNakInterval
@@ -974,7 +976,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setNakInterval
 (JNIEnv * jni, jobject jthis, jlong val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->nak_interval_ = OpenDDS::DCPS::TimeDuration::from_msec(val);
+  inst->nak_interval(OpenDDS::DCPS::TimeDuration::from_msec(val));
 }
 
 // MulticastInst::getNakDelayInterval
@@ -982,7 +984,7 @@ jint JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getNakDelayInterval
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return static_cast<jint>(inst->nak_delay_intervals_);
+  return static_cast<jint>(inst->nak_delay_intervals());
 }
 
 // MulticastInst::setNakDelayInterval
@@ -990,7 +992,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setNakDelayInterval
 (JNIEnv * jni, jobject jthis, jint val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->nak_delay_intervals_ = val;
+  inst->nak_delay_intervals(val);
 }
 
 // MulticastInst::getNakMax
@@ -998,7 +1000,7 @@ jint JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getNakMax
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return static_cast<jint>(inst->nak_max_);
+  return static_cast<jint>(inst->nak_max());
 }
 
 // MulticastInst::setNakMax
@@ -1006,7 +1008,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setNakMax
 (JNIEnv * jni, jobject jthis, jint val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->nak_max_ = val;
+  inst->nak_max(val);
 }
 
 // MulticastInst::getNakTimeout
@@ -1014,7 +1016,7 @@ jlong JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getNakTimeout
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return inst->nak_timeout_.value().msec();
+  return inst->nak_timeout().value().msec();
 }
 
 // MulticastInst::setNakTimeout
@@ -1022,7 +1024,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setNakTimeout
 (JNIEnv * jni, jobject jthis, jlong val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->nak_timeout_ = OpenDDS::DCPS::TimeDuration::from_msec(val);
+  inst->nak_timeout(OpenDDS::DCPS::TimeDuration::from_msec(val));
 }
 
 // MulticastInst::getTimeToLive
@@ -1030,7 +1032,7 @@ jbyte JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getTimeToLive
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return inst->ttl_;
+  return inst->ttl();
 }
 
 // MulticastInst::setTimeToLive
@@ -1038,7 +1040,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setTimeToLive
 (JNIEnv * jni, jobject jthis, jbyte val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->ttl_ = static_cast<unsigned char>(val);
+  inst->ttl(static_cast<unsigned char>(val));
 }
 
 // MulticastInst::getRcvBufferSize
@@ -1046,7 +1048,7 @@ jint JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_getRcvBufferSize
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  return static_cast<jint>(inst->rcv_buffer_size_);
+  return static_cast<jint>(inst->rcv_buffer_size());
 }
 
 // MulticastInst::setRcvBufferSize
@@ -1054,7 +1056,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_MulticastInst_setRcvBufferSize
 (JNIEnv * jni, jobject jthis, jint val)
 {
   OpenDDS::DCPS::MulticastInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: MulticastInst>(jni, jthis));
-  inst->rcv_buffer_size_ = val;
+  inst->rcv_buffer_size(val);
 }
 
 // RtpsUdpInst

--- a/java/dds/dcps_java.mpc
+++ b/java/dds/dcps_java.mpc
@@ -1,5 +1,5 @@
 // dcpslib needs to come after idl2jni to set libout correctly
-project: idl2jni, javah, dcpslib, optional_jni_check, dcps_java_optional, dcps_tcp, dcps_udp, dcps_rtps_udp, install {
+project: idl2jni, javah, dcpslib, optional_jni_check, dcps_java_optional, dcps_multicast, dcps_tcp, dcps_udp, dcps_rtps_udp, install {
 
   sharedname    = OpenDDS_DCPS_Java
   after        += tao_java

--- a/tests/unit-tests/dds/DCPS/ConfigStoreImpl.cpp
+++ b/tests/unit-tests/dds/DCPS/ConfigStoreImpl.cpp
@@ -154,6 +154,9 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_String)
   EXPECT_EQ(store.get("key", default_string), default_string);
   store.set("key", other_string);
   EXPECT_EQ(store.get("key", default_string), other_string);
+
+  store.set("key", "");
+  EXPECT_EQ(store.get("key", default_string, false), default_string);
 }
 
 TEST(dds_DCPS_ConfigStoreImpl, set_get_TimeDuration_seconds)
@@ -219,6 +222,12 @@ TEST(dds_DCPS_ConfigStoreImpl, get_NetworkAddress)
       store.set_string("key", "not a network address");
       EXPECT_EQ(store.get("key", default_value, ConfigStoreImpl::Format_Optional_Port, ConfigStoreImpl::Kind_IPV4), default_value);
     }
+
+    {
+      const NetworkAddress value_required_port("127.0.0.1:80");
+      store.set("key", value_required_port, ConfigStoreImpl::Format_Required_Port, ConfigStoreImpl::Kind_ANY);
+      EXPECT_EQ(store.get("key", default_value, ConfigStoreImpl::Format_Required_Port, ConfigStoreImpl::Kind_ANY), value_required_port);
+    }
   }
 
 #if ACE_HAS_IPV6
@@ -253,6 +262,12 @@ TEST(dds_DCPS_ConfigStoreImpl, get_NetworkAddress)
     {
       store.set_string("key6", "not a network address");
       EXPECT_EQ(store.get("key6", default_value, ConfigStoreImpl::Format_Optional_Port, ConfigStoreImpl::Kind_IPV6), default_value);
+    }
+
+    {
+      const NetworkAddress value_required_port("[::1]:80");
+      store.set("key6", value_required_port, ConfigStoreImpl::Format_Required_Port, ConfigStoreImpl::Kind_ANY);
+      EXPECT_EQ(store.get("key6", default_value, ConfigStoreImpl::Format_Required_Port, ConfigStoreImpl::Kind_ANY), value_required_port);
     }
   }
 #endif

--- a/tools/modeling/plugins/org.opendds.modeling.sdk.model/xsl/traits_cpp.xsl
+++ b/tools/modeling/plugins/org.opendds.modeling.sdk.model/xsl/traits_cpp.xsl
@@ -228,9 +228,9 @@
   <xsl:variable name="value">
     <xsl:call-template name="str-value"/>
   </xsl:variable>
-  <xsl:value-of select="concat('    child_inst->group_address_ = ',
-                               'ACE_INET_Addr(&quot;', $value, '&quot;)',
-                               ';', $newline)"/>
+  <xsl:value-of select="concat('    child_inst->group_address(',
+                               'OpenDDS::DCPS::NetworkAddress(&quot;', $value, '&quot;)',
+                               ');', $newline)"/>
 </xsl:template>
 
 <!-- Output IP address conversion for local address -->
@@ -244,23 +244,31 @@
 </xsl:template>
 
 <!-- Output type-specific configuration settings -->
+<xsl:template match="default_to_ipv6
+                   | port_offset
+                   | reliable
+                   | syn_backoff
+                   | nak_depth
+                   | ttl
+                   | rcv_buffer_size">
+  <xsl:value-of select="concat('    child_inst->', name(), '(',
+                               @value, ');', $newline)"/>
+</xsl:template>
+
+<xsl:template match="syn_interval
+                   | syn_timeout
+                   | nak_interval
+                   | nak_timeout">
+  <xsl:value-of select="concat('    child_inst->', name(), '(OpenDDS::DCPS::TimeDuration::from_msec(',
+                               @value, '));', $newline)"/>
+</xsl:template>
+
 <xsl:template match="enable_nagle_algorithm
                    | conn_retry_initial_delay
                    | conn_retry_backoff_multiplier
                    | conn_retry_attempts
                    | max_output_pause_period
-                   | passive_reconnect_duration
-                   | default_to_ipv6
-                   | port_offset
-                   | reliable
-                   | syn_backoff
-                   | syn_interval
-                   | syn_timeout
-                   | nak_depth
-                   | ttl
-                   | rcv_buffer_size
-                   | nak_interval
-                   | nak_timeout">
+                   | passive_reconnect_duration">
 
   <xsl:value-of select="concat('    child_inst->', name(),  '_ = ',
                                @value, ';', $newline)"/>


### PR DESCRIPTION
Problem
-------

`MulticastInst` does not use `ConfigStore`.  See #4134.

Solution
--------

Convert `MulticastInst` to use `ConfigStore`.

* The following members have been replaced with getters and setters:
  - default_to_ipv6
  - port_offset
  - group_address
  - local_address
  - reliable
  - syn_backoff
  - syn_interval
  - syn_timeout
  - nak_depth
  - nak_interval
  - nak_delay_intervals
  - nak_max
  - mak_timeout
  - ttl
  - rcv_buffer_size
  - async_send