### PR TITLE
`ShmemInst` does not use `ConfigStore`

### DIFF
--- a/dds/DCPS/transport/shmem/ShmemInst.cpp
+++ b/dds/DCPS/transport/shmem/ShmemInst.cpp
@@ -23,10 +23,6 @@ const TimeDuration ShmemInst::default_association_resend_period(0, 250000);
 
 ShmemInst::ShmemInst(const std::string& name)
   : TransportInst("shmem", name)
-  , pool_size_(16 * 1024 * 1024)
-  , datalink_control_size_(4 * 1024)
-  , hostname_(get_fully_qualified_hostname())
-  , association_resend_period_(default_association_resend_period)
 {
   std::ostringstream pool;
   pool << "OpenDDS-" << ACE_OS::getpid() << '-' << this->name();
@@ -44,20 +40,6 @@ ShmemInst::load(ACE_Configuration_Heap& cf,
                 ACE_Configuration_Section_Key& sect)
 {
   TransportInst::load(cf, sect);
-
-  std::string host_name;
-  GET_CONFIG_STRING_VALUE(cf, sect, ACE_TEXT("host_name"), host_name);
-
-  if (!host_name.empty()) {
-    hostname_ = host_name;
-  }
-
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("pool_size"), pool_size_, size_t)
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("datalink_control_size"),
-                   datalink_control_size_, size_t)
-  GET_CONFIG_TIME_VALUE(cf, sect,
-    ACE_TEXT("association_resend_period"), association_resend_period_);
-
   return 0;
 }
 
@@ -66,11 +48,11 @@ ShmemInst::dump_to_str() const
 {
   std::ostringstream os;
   os << TransportInst::dump_to_str();
-  os << formatNameForDump("pool_size") << pool_size_ << "\n"
-     << formatNameForDump("datalink_control_size") << datalink_control_size_ << "\n"
+  os << formatNameForDump("pool_size") << pool_size() << "\n"
+     << formatNameForDump("datalink_control_size") << datalink_control_size() << "\n"
      << formatNameForDump("pool_name") << this->poolname_ << "\n"
-     << formatNameForDump("host_name") << this->hostname_ << "\n"
-     << formatNameForDump("association_resend_period") << association_resend_period_.str() << "\n";
+     << formatNameForDump("host_name") << this->hostname() << "\n"
+     << formatNameForDump("association_resend_period") << association_resend_period().str() << "\n";
   return OPENDDS_STRING(os.str());
 }
 
@@ -79,17 +61,71 @@ ShmemInst::populate_locator(OpenDDS::DCPS::TransportLocator& info, ConnectionInf
 {
   info.transport_type = "shmem";
 
-  const size_t len = hostname_.size() + 1 /* null */ + poolname_.size();
+  const String host = hostname();
+  const size_t len = host.size() + 1 /* null */ + poolname_.size();
   info.data.length(static_cast<CORBA::ULong>(len));
 
   CORBA::Octet* buff = info.data.get_buffer();
-  std::memcpy(buff, hostname_.c_str(), hostname_.size());
-  buff += hostname_.size();
+  std::memcpy(buff, host.c_str(), host.size());
+  buff += host.size();
 
   *(buff++) = 0;
   std::memcpy(buff, poolname_.c_str(), poolname_.size());
 
   return 1;
+}
+
+void
+ShmemInst::pool_size(size_t ps)
+{
+  TheServiceParticipant->config_store()->set_uint32(config_key("POOL_SIZE").c_str(), static_cast<DDS::UInt32>(ps));
+}
+
+size_t
+ShmemInst::pool_size() const
+{
+  return TheServiceParticipant->config_store()->get_uint32(config_key("POOL_SIZE").c_str(), 16 * 1024 * 1024);
+}
+
+void
+ShmemInst::datalink_control_size(size_t dcs)
+{
+  TheServiceParticipant->config_store()->set_uint32(config_key("DATALINK_CONTROL_SIZE").c_str(),
+                                                    static_cast<DDS::UInt32>(dcs));
+}
+
+size_t
+ShmemInst::datalink_control_size() const
+{
+  return TheServiceParticipant->config_store()->get_uint32(config_key("DATALINK_CONTROL_SIZE").c_str(), 4 * 1024);
+}
+
+void
+ShmemInst::hostname(const String& h)
+{
+  TheServiceParticipant->config_store()->set(config_key("HOSTNAME").c_str(), h);
+}
+
+String
+ShmemInst::hostname() const
+{
+  return TheServiceParticipant->config_store()->get(config_key("HOSTNAME").c_str(), get_fully_qualified_hostname(), false);
+}
+
+void
+ShmemInst::association_resend_period(const TimeDuration& arp)
+{
+  TheServiceParticipant->config_store()->set(config_key("ASSOCIATION_RESEND_PERIOD").c_str(),
+                                             arp,
+                                             ConfigStoreImpl::Format_IntegerMilliseconds);
+}
+
+TimeDuration
+ShmemInst::association_resend_period() const
+{
+  return TheServiceParticipant->config_store()->get(config_key("ASSOCIATION_RESEND_PERIOD").c_str(),
+                                                    default_association_resend_period,
+                                                    ConfigStoreImpl::Format_IntegerMilliseconds);
 }
 
 } // namespace DCPS

--- a/dds/DCPS/transport/shmem/ShmemInst.h
+++ b/dds/DCPS/transport/shmem/ShmemInst.h
@@ -28,24 +28,26 @@ public:
 
   /// Size (in bytes) of the single shared-memory pool allocated by this
   /// transport instance.  Defaults to 16 megabytes.
-  size_t pool_size_;
+  void pool_size(size_t ps);
+  size_t pool_size() const;
 
   /// Size (in bytes) of the control area allocated for each data link.
   /// This allocation comes out of the shared-memory pool defined by pool_size_.
   /// Defaults to 4 kilobytes.
-  size_t datalink_control_size_;
+  void datalink_control_size(size_t dcs);
+  size_t datalink_control_size() const;
 
   bool is_reliable() const { return true; }
 
   virtual size_t populate_locator(OpenDDS::DCPS::TransportLocator& trans_info, ConnectionInfoFlags flags) const;
 
-  const std::string& hostname() const { return hostname_; }
+  void hostname(const String& h);
+  String hostname() const;
+
   const std::string& poolname() const { return poolname_; }
 
-  TimeDuration association_resend_period() const
-  {
-    return association_resend_period_;
-  }
+  void association_resend_period(const TimeDuration& arp);
+  TimeDuration association_resend_period() const;
 
 private:
   friend class ShmemType;
@@ -54,9 +56,7 @@ private:
   explicit ShmemInst(const std::string& name);
 
   TransportImpl_rch new_impl();
-  std::string hostname_;
   std::string poolname_;
-  TimeDuration association_resend_period_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/shmem/ShmemSendStrategy.cpp
+++ b/dds/DCPS/transport/shmem/ShmemSendStrategy.cpp
@@ -25,7 +25,7 @@ ShmemSendStrategy::ShmemSendStrategy(ShmemDataLink* link)
                           make_rch<NullSynchStrategy>())
   , link_(link)
   , current_data_(0)
-  , datalink_control_size_(link->config()->datalink_control_size_)
+  , datalink_control_size_(link->config()->datalink_control_size())
 {
 #ifdef OPENDDS_SHMEM_UNIX
   memset(&peer_semaphore_, 0, sizeof(peer_semaphore_));

--- a/dds/DCPS/transport/shmem/ShmemTransport.cpp
+++ b/dds/DCPS/transport/shmem/ShmemTransport.cpp
@@ -149,10 +149,10 @@ ShmemTransport::configure_i(const ShmemInst_rch& config)
 
   ShmemAllocator::MEMORY_POOL_OPTIONS alloc_opts;
 #  if defined OPENDDS_SHMEM_WINDOWS
-  alloc_opts.max_size_ = config->pool_size_;
+  alloc_opts.max_size_ = config->pool_size();
 #  elif defined OPENDDS_SHMEM_UNIX
   alloc_opts.base_addr_ = 0;
-  alloc_opts.segment_size_ = config->pool_size_;
+  alloc_opts.segment_size_ = config->pool_size();
   alloc_opts.minimum_bytes_ = alloc_opts.segment_size_;
   alloc_opts.max_segments_ = 1;
 #  endif /* OPENDDS_SHMEM_WINDOWS */

--- a/docs/news.d/config_store.rst
+++ b/docs/news.d/config_store.rst
@@ -1,4 +1,4 @@
-.. news-prs: 4162 4241
+.. news-prs: 4162 4241 4242
 .. news-start-section: Additions
 - OpenDDS now stores ``rtps_udp`` transport configuration in the key-value store.
   The following members of ``RtpsUdpInst`` must now be accessed with getters and setters:
@@ -35,5 +35,11 @@
   -  ``ttl_``
   -  ``rcv_buffer_size_``
   -  ``async_send_``
+
+- OpenDDS now stores ``shmem`` transport configuration in the key-value store.
+  The following members of ``ShmemInst`` must now be accessed with getters and setters:
+
+  -  ``pool_size_``
+  -  ``datalink_control_size_``
 
 .. news-end-section


### PR DESCRIPTION
Problem
-------

`ShmemInst` does not use `ConfigStore`.  See #4134.

Solution
--------

Convert `ShmemInst` to use `ConfigStore`.

* The following members have been replaced with getters and setters:
  - `pool_size_`
  - `datalink_control_size_`
