### PR TITLE
`TcpInst` does not use `ConfigStore`

### DIFF
--- a/MPC/config/dcps_default_discovery.mpb
+++ b/MPC/config/dcps_default_discovery.mpb
@@ -1,5 +1,5 @@
 feature(!no_opendds_safety_profile) : dcps_rtps {
 }
 
-feature(no_opendds_safety_profile) : dcps_inforepodiscovery, dcps_tcp {
+feature(no_opendds_safety_profile) : dcps_inforepodiscovery {
 }

--- a/MPC/config/dcps_inforepodiscovery.mpb
+++ b/MPC/config/dcps_inforepodiscovery.mpb
@@ -1,4 +1,4 @@
-project: dcps {
+project: dcps, dcps_tcp {
   after += OpenDDS_InfoRepoDiscovery
   libs  += OpenDDS_InfoRepoDiscovery
 }

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
@@ -299,7 +299,7 @@ InfoRepoDiscovery::bit_config()
 
     if (DCPS_debug_level) {
       ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) InfoRepoDiscovery::bit_config")
-                 ACE_TEXT(" - BIT tcp transport %C\n"), tcp_inst->local_address_string().c_str()));
+                 ACE_TEXT(" - BIT tcp transport %C\n"), tcp_inst->local_address().c_str()));
     }
   }
   return bit_config_;

--- a/dds/DCPS/transport/tcp/TcpInst.cpp
+++ b/dds/DCPS/transport/tcp/TcpInst.cpp
@@ -36,37 +36,6 @@ OpenDDS::DCPS::TcpInst::load(ACE_Configuration_Heap& cf,
                              ACE_Configuration_Section_Key& trans_sect)
 {
   TransportInst::load(cf, trans_sect);
-
-  std::string local_address;
-  GET_CONFIG_STRING_VALUE(cf, trans_sect, ACE_TEXT("local_address"), local_address);
-
-  if (!local_address.empty()) {
-    this->local_address(local_address.c_str());
-  }
-
-  GET_CONFIG_STRING_VALUE(cf, trans_sect, ACE_TEXT("pub_address"), pub_address_str_);
-
-  GET_CONFIG_VALUE(cf, trans_sect, ACE_TEXT("enable_nagle_algorithm"),
-                   this->enable_nagle_algorithm_, bool)
-
-  GET_CONFIG_VALUE(cf, trans_sect, ACE_TEXT("conn_retry_initial_delay"),
-                   this->conn_retry_initial_delay_, int)
-
-  GET_CONFIG_DOUBLE_VALUE(cf, trans_sect, ACE_TEXT("conn_retry_backoff_multiplier"),
-                   this->conn_retry_backoff_multiplier_)
-
-  GET_CONFIG_VALUE(cf, trans_sect, ACE_TEXT("conn_retry_attempts"),
-                   this->conn_retry_attempts_, int)
-
-  GET_CONFIG_VALUE(cf, trans_sect, ACE_TEXT("passive_reconnect_duration"),
-                   this->passive_reconnect_duration_, int)
-
-  GET_CONFIG_VALUE(cf, trans_sect, ACE_TEXT("max_output_pause_period"),
-                   this->max_output_pause_period_, int)
-
-  GET_CONFIG_VALUE(cf, trans_sect, ACE_TEXT("active_conn_timeout_period"),
-                   this->active_conn_timeout_period_, int)
-
   return 0;
 }
 
@@ -76,24 +45,27 @@ OpenDDS::DCPS::TcpInst::dump_to_str() const
   std::ostringstream os;
   os << TransportInst::dump_to_str();
 
-  os << formatNameForDump("local_address")                 << this->local_address_string() << std::endl;
-  os << formatNameForDump("pub_address")                   << this->pub_address_str_ << std::endl;
-  os << formatNameForDump("enable_nagle_algorithm")        << (this->enable_nagle_algorithm_ ? "true" : "false") << std::endl;
-  os << formatNameForDump("conn_retry_initial_delay")      << this->conn_retry_initial_delay_ << std::endl;
-  os << formatNameForDump("conn_retry_backoff_multiplier") << this->conn_retry_backoff_multiplier_ << std::endl;
-  os << formatNameForDump("conn_retry_attempts")           << this->conn_retry_attempts_ << std::endl;
-  os << formatNameForDump("passive_reconnect_duration")    << this->passive_reconnect_duration_ << std::endl;
-  os << formatNameForDump("max_output_pause_period")       << this->max_output_pause_period_ << std::endl;
-  os << formatNameForDump("active_conn_timeout_period")    << this->active_conn_timeout_period_ << std::endl;
+  os << formatNameForDump("local_address")                 << this->local_address() << std::endl;
+  os << formatNameForDump("pub_address")                   << this->pub_address_str() << std::endl;
+  os << formatNameForDump("enable_nagle_algorithm")        << (this->enable_nagle_algorithm() ? "true" : "false") << std::endl;
+  os << formatNameForDump("conn_retry_initial_delay")      << this->conn_retry_initial_delay() << std::endl;
+  os << formatNameForDump("conn_retry_backoff_multiplier") << this->conn_retry_backoff_multiplier() << std::endl;
+  os << formatNameForDump("conn_retry_attempts")           << this->conn_retry_attempts() << std::endl;
+  os << formatNameForDump("passive_reconnect_duration")    << this->passive_reconnect_duration() << std::endl;
+  os << formatNameForDump("max_output_pause_period")       << this->max_output_pause_period() << std::endl;
+  os << formatNameForDump("active_conn_timeout_period")    << this->active_conn_timeout_period() << std::endl;
   return OPENDDS_STRING(os.str());
 }
 
 size_t
 OpenDDS::DCPS::TcpInst::populate_locator(OpenDDS::DCPS::TransportLocator& local_info, ConnectionInfoFlags) const
 {
-  if (local_address() != ACE_INET_Addr() || !pub_address_str_.empty()) {
+  const std::string local_addr = local_address();
+  const std::string locator_addr = get_locator_address();
+  const std::string locator_a = locator_addr.empty() ? local_addr : locator_addr;
+  if (!locator_a.empty()) {
     // Get the public address string from the inst (usually the local address)
-    NetworkResource network_resource(get_public_address());
+    NetworkResource network_resource(locator_a);
 
     ACE_OutputCDR cdr;
     cdr << network_resource;
@@ -107,6 +79,162 @@ OpenDDS::DCPS::TcpInst::populate_locator(OpenDDS::DCPS::TransportLocator& local_
   } else {
     return 0;
   }
+}
+
+void
+OpenDDS::DCPS::TcpInst::pub_address_str(const String& pas)
+{
+  TheServiceParticipant->config_store()->set(config_key("PUB_ADDRESS").c_str(), pas);
+}
+
+OpenDDS::DCPS::String
+OpenDDS::DCPS::TcpInst::pub_address_str() const
+{
+  return TheServiceParticipant->config_store()->get(config_key("PUB_ADDRESS").c_str(), "");
+}
+
+void
+OpenDDS::DCPS::TcpInst::enable_nagle_algorithm(bool ena)
+{
+  TheServiceParticipant->config_store()->set_boolean(config_key("ENABLE_NAGLE_ALGORITHM").c_str(), ena);
+}
+
+bool
+OpenDDS::DCPS::TcpInst::enable_nagle_algorithm() const
+{
+  return TheServiceParticipant->config_store()->get_boolean(config_key("ENABLE_NAGLE_ALGORITHM").c_str(), false);
+}
+
+void
+OpenDDS::DCPS::TcpInst::conn_retry_initial_delay(int crid)
+{
+  TheServiceParticipant->config_store()->set_int32(config_key("CONN_RETRY_INITIAL_DELAY").c_str(), crid);
+}
+
+int
+OpenDDS::DCPS::TcpInst::conn_retry_initial_delay() const
+{
+  return TheServiceParticipant->config_store()->get_int32(config_key("CONN_RETRY_INITIAL_DELAY").c_str(), 500);
+}
+
+void
+OpenDDS::DCPS::TcpInst::conn_retry_backoff_multiplier(double crbm)
+{
+  TheServiceParticipant->config_store()->set_float64(config_key("CONN_RETRY_BACKOFF_MULTIPLIER").c_str(), crbm);
+}
+
+double
+OpenDDS::DCPS::TcpInst::conn_retry_backoff_multiplier() const
+{
+  return TheServiceParticipant->config_store()->get_float64(config_key("CONN_RETRY_BACKOFF_MULTIPLIER").c_str(), 2.0);
+}
+
+void
+OpenDDS::DCPS::TcpInst::conn_retry_attempts(int cra)
+{
+  TheServiceParticipant->config_store()->set_int32(config_key("CONN_RETRY_ATTEMPTS").c_str(), cra);
+}
+
+int
+OpenDDS::DCPS::TcpInst::conn_retry_attempts() const
+{
+  return TheServiceParticipant->config_store()->get_int32(config_key("CONN_RETRY_ATTEMPTS").c_str(), 3);
+}
+
+void
+OpenDDS::DCPS::TcpInst::max_output_pause_period(int mopp)
+{
+  TheServiceParticipant->config_store()->set_int32(config_key("MAX_OUTPUT_PAUSE_PERIOD").c_str(), mopp);
+}
+
+int
+OpenDDS::DCPS::TcpInst::max_output_pause_period() const
+{
+  return TheServiceParticipant->config_store()->get_int32(config_key("MAX_OUTPUT_PAUSE_PERIOD").c_str(), -1);
+}
+
+void
+OpenDDS::DCPS::TcpInst::passive_reconnect_duration(int prd)
+{
+  TheServiceParticipant->config_store()->set_int32(config_key("PASSIVE_RECONNECT_DURATION").c_str(), prd);
+}
+
+int
+OpenDDS::DCPS::TcpInst::passive_reconnect_duration() const
+{
+  return TheServiceParticipant->config_store()->get_int32(config_key("PASSIVE_RECONNECT_DURATION").c_str(),
+                                                          DEFAULT_PASSIVE_RECONNECT_DURATION);
+}
+
+void
+OpenDDS::DCPS::TcpInst::active_conn_timeout_period(int actp)
+{
+  TheServiceParticipant->config_store()->set_int32(config_key("ACTIVE_CONN_TIMEOUT_PERIOD").c_str(), actp);
+}
+
+int
+OpenDDS::DCPS::TcpInst::active_conn_timeout_period() const
+{
+  return TheServiceParticipant->config_store()->get_int32(config_key("ACTIVE_CONN_TIMEOUT_PERIOD").c_str(),
+                                                          DEFAULT_ACTIVE_CONN_TIMEOUT_PERIOD);
+}
+
+void
+OpenDDS::DCPS::TcpInst::local_address(const String& la)
+{
+  TheServiceParticipant->config_store()->set(config_key("LOCAL_ADDRESS").c_str(), la);
+}
+
+OpenDDS::DCPS::String
+OpenDDS::DCPS::TcpInst::local_address() const
+{
+  return TheServiceParticipant->config_store()->get(config_key("LOCAL_ADDRESS").c_str(), "");
+}
+
+bool
+OpenDDS::DCPS::TcpInst::set_locator_address(const ACE_INET_Addr& address)
+{
+  const ACE_INET_Addr local_addr = accept_address();
+  const unsigned short port = address.get_port_number();
+
+  if (local_addr.is_any()) {
+    // As default, the acceptor will be listening on INADDR_ANY but advertise with the fully
+    // qualified hostname and actual listening port number.
+    const std::string hostname = get_fully_qualified_hostname();
+    locator_address_ = hostname + ":" + to_dds_string(port);
+
+    const ACE_INET_Addr addr = choose_single_coherent_address(locator_address_);
+    if (addr == ACE_INET_Addr()) {
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("(%P|%t) ERROR: Failed to resolve a local address using fully qualified hostname '%C'\n"),
+                 hostname.c_str()));
+      return false;
+    }
+  } else if (local_addr.get_port_number() == 0) {
+    // Now we got the actual listening port. Update the port number in the configuration
+    // if it's 0 originally.
+    locator_address_ = local_address();
+    set_port_in_addr_string(locator_address_, port);
+  } else {
+    locator_address_ = local_address();
+  }
+
+  return true;
+}
+
+ACE_INET_Addr
+OpenDDS::DCPS::TcpInst::accept_address() const
+{
+  ACE_INET_Addr addr = choose_single_coherent_address(local_address(), false);
+  // Override with DCPSDefaultAddress.
+  if (addr == ACE_INET_Addr() &&
+      TheServiceParticipant->default_address() != NetworkAddress::default_IPV4) {
+    VDBG_LVL((LM_DEBUG,
+              ACE_TEXT("(%P|%t) TcpInst::accept_address overriding with DCPSDefaultAddress\n")), 2);
+    addr = TheServiceParticipant->default_address().to_addr();
+  }
+
+  return addr;
 }
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/transport/tcp/TcpInst.inl
+++ b/dds/DCPS/transport/tcp/TcpInst.inl
@@ -11,14 +11,15 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 ACE_INLINE
 OpenDDS::DCPS::TcpInst::TcpInst(const OPENDDS_STRING& name)
-  : TransportInst("tcp", name),
-    enable_nagle_algorithm_(false),
-    conn_retry_initial_delay_(500),
-    conn_retry_backoff_multiplier_(2.0),
-    conn_retry_attempts_(3),
-    max_output_pause_period_(-1),
-    passive_reconnect_duration_(DEFAULT_PASSIVE_RECONNECT_DURATION),
-    active_conn_timeout_period_(DEFAULT_ACTIVE_CONN_TIMEOUT_PERIOD)
+  : TransportInst("tcp", name)
+  , pub_address_str_(*this, &TcpInst::pub_address_str, &TcpInst::pub_address_str)
+  , enable_nagle_algorithm_(*this, &TcpInst::enable_nagle_algorithm, &TcpInst::enable_nagle_algorithm)
+  , conn_retry_initial_delay_(*this, &TcpInst::conn_retry_initial_delay, &TcpInst::conn_retry_initial_delay)
+  , conn_retry_backoff_multiplier_(*this, &TcpInst::conn_retry_backoff_multiplier, &TcpInst::conn_retry_backoff_multiplier)
+  , conn_retry_attempts_(*this, &TcpInst::conn_retry_attempts, &TcpInst::conn_retry_attempts)
+  , max_output_pause_period_(*this, &TcpInst::max_output_pause_period, &TcpInst::max_output_pause_period)
+  , passive_reconnect_duration_(*this, &TcpInst::passive_reconnect_duration, &TcpInst::passive_reconnect_duration)
+  , active_conn_timeout_period_(*this, &TcpInst::active_conn_timeout_period, &TcpInst::active_conn_timeout_period)
 {
   DBG_ENTRY_LVL("TcpInst", "TcpInst", 6);
 }

--- a/dds/DCPS/transport/tcp/TcpTransport.cpp
+++ b/dds/DCPS/transport/tcp/TcpTransport.cpp
@@ -66,7 +66,7 @@ TcpTransport::blob_to_key(const TransportBLOB& remote,
 {
   const ACE_INET_Addr remote_address = AssociationData::get_remote_address(remote);
   TcpInst_rch cfg = config();
-  const bool is_loopback = cfg && (remote_address == cfg->local_address());
+  const bool is_loopback = cfg && (remote_address == cfg->accept_address());
   return PriorityKey(priority, remote_address, is_loopback, active);
 }
 
@@ -127,7 +127,7 @@ TcpTransport::connect_datalink(const RemoteTransport& remote,
 
     // Can't make this call while holding onto TransportClient::lock_
     ACE_Time_Value conn_timeout;
-    conn_timeout.msec(cfg->active_conn_timeout_period_);
+    conn_timeout.msec(cfg->active_conn_timeout_period());
 
     ret = connector_.connect(pConn, key.address(), ACE_Synch_Options(ACE_Synch_Options::USE_REACTOR|ACE_Synch_Options::USE_TIMEOUT, conn_timeout));
   }
@@ -328,24 +328,15 @@ TcpTransport::configure_i(const TcpInst_rch& config)
 
   connector_.open(reactor_task()->get_reactor());
 
-  // Override with DCPSDefaultAddress.
-  if (config->local_address() == ACE_INET_Addr() &&
-      TheServiceParticipant->default_address() != NetworkAddress::default_IPV4) {
-    VDBG_LVL((LM_DEBUG,
-              ACE_TEXT("(%P|%t) TcpTransport::configure_i overriding with DCPSDefaultAddress\n")), 2);
-
-    config->local_address(TheServiceParticipant->default_address().to_addr());
-  }
-
   VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) TcpTransport::configure_i opening acceptor for %C on %C\n"),
-            config->local_address_string().c_str(), LogAddr(config->local_address()).c_str()), 2);
+            config->local_address().c_str(), LogAddr(config->accept_address()).c_str()), 2);
 
   // Open our acceptor object so that we can accept passive connections
   // on our config->local_address_.
-  if (this->acceptor_->open(config->local_address(),
+  if (this->acceptor_->open(config->accept_address(),
                             this->reactor_task()->get_reactor()) != 0) {
     ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Acceptor failed to open %C: %p\n"),
-                      LogAddr(config->local_address()).c_str(), ACE_TEXT("open")), false);
+                      LogAddr(config->accept_address()).c_str(), ACE_TEXT("open")), false);
   }
 
   // update the port number (incase port zero was given).
@@ -361,29 +352,7 @@ TcpTransport::configure_i(const TcpInst_rch& config)
   VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) TcpTransport::configure_i listening on %C\n"),
             LogAddr(address).c_str()), 2);
 
-  const unsigned short port = address.get_port_number();
-
-  // As default, the acceptor will be listening on INADDR_ANY but advertise with the fully
-  // qualified hostname and actual listening port number.
-  if (config->local_address().is_any()) {
-    const std::string hostname = get_fully_qualified_hostname();
-    config->local_address(port, hostname.c_str());
-    if (config->local_address() == ACE_INET_Addr()) {
-       ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("(%P|%t) ERROR: Failed to resolve a local address using fully qualified hostname '%C'\n"),
-                          hostname.c_str()),
-                          false);
-    }
-  }
-
-  // Now we got the actual listening port. Update the port number in the configuration
-  // if it's 0 originally.
-  else if (config->local_address().get_port_number() == 0) {
-    config->local_address_set_port(port);
-  }
-
-  // Ahhh...  The sweet smell of success!
-  return true;
+  return config->set_locator_address(address);
 }
 
 void
@@ -474,7 +443,7 @@ TcpTransport::connection_info_i(TransportLocator& local_info, ConnectionInfoFlag
   TcpInst_rch cfg = config();
   if (cfg) {
     VDBG_LVL((LM_DEBUG, "(%P|%t) TcpTransport public address string <%C>\n",
-              cfg->get_public_address().c_str()), 2);
+              cfg->get_locator_address().c_str()), 2);
 
     cfg->populate_locator(local_info, flags);
     return true;
@@ -613,7 +582,7 @@ TcpTransport::passive_connection(const ACE_INET_Addr& remote_address,
 
   const PriorityKey key(connection->transport_priority(),
                         remote_address,
-                        remote_address == cfg->local_address(),
+                        remote_address == cfg->accept_address(),
                         connection->is_connector());
 
   VDBG_LVL((LM_DEBUG, ACE_TEXT("(%P|%t) TcpTransport::passive_connection() - ")
@@ -699,7 +668,7 @@ TcpTransport::connect_tcp_datalink(TcpDataLink& link,
   TcpSendStrategy_rch send_strategy (
     make_rch<TcpSendStrategy>(last_link_.load(), ref(link),
                              new TcpSynchResource(link,
-                                                  cfg->max_output_pause_period_),
+                                                  cfg->max_output_pause_period()),
                              this->reactor_task(), link.transport_priority()));
 
   TcpReceiveStrategy_rch receive_strategy(
@@ -734,7 +703,7 @@ TcpTransport::fresh_link(TcpConnection_rch connection)
 
   PriorityKey key(connection->transport_priority(),
                   connection->get_remote_address(),
-                  connection->get_remote_address() == cfg->local_address(),
+                  connection->get_remote_address() == cfg->accept_address(),
                   connection->is_connector());
 
   if (this->links_.find(key, link) == 0) {

--- a/dds/InfoRepo/DCPSInfo_i.cpp
+++ b/dds/InfoRepo/DCPSInfo_i.cpp
@@ -2266,7 +2266,7 @@ int TAO_DDS_DCPSInfo_i::init_transport(int listen_address_given,
       OpenDDS::DCPS::dynamic_rchandle_cast<OpenDDS::DCPS::TcpInst>(inst);
     inst->datalink_release_delay(0);
 
-    tcp_inst->conn_retry_attempts_ = 0;
+    tcp_inst->conn_retry_attempts(0);
 
     if (listen_address_given) {
       tcp_inst->local_address(listen_str);

--- a/docs/news.d/config_store.rst
+++ b/docs/news.d/config_store.rst
@@ -1,9 +1,11 @@
-.. news-prs: 4162 4241 4242 4255
+.. news-prs: 4162 4241 4242 4255 4243
 .. news-start-section: Additions
 - OpenDDS now stores ``rtps_udp`` transport configuration in the key-value store.
 
 - OpenDDS now stores ``multicast`` transport configuration in the key-value store.
 
 - OpenDDS now stores ``shmem`` transport configuration in the key-value store.
+
+- OpenDDS now stores ``tcp`` transport configuration in the key-value store.
 
 .. news-end-section

--- a/java/dds/OpenDDS_DCPS_jni.cpp
+++ b/java/dds/OpenDDS_DCPS_jni.cpp
@@ -701,7 +701,7 @@ jstring JNICALL Java_OpenDDS_DCPS_transport_TcpInst_getLocalAddress
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::TcpInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS::TcpInst>(jni, jthis));
-  jstring retStr = jni->NewStringUTF(inst->local_address_string().c_str());
+  jstring retStr = jni->NewStringUTF(inst->local_address().c_str());
   return retStr;
 }
 

--- a/tests/DCPS/ConfigFile/ConfigFile.cpp
+++ b/tests/DCPS/ConfigFile/ConfigFile.cpp
@@ -72,13 +72,13 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     TEST_CHECK(tcp_inst->thread_per_connection() == true);
     TEST_CHECK(tcp_inst->datalink_release_delay() == 5000);
     TEST_CHECK(tcp_inst->datalink_control_chunks() == 16);
-    TEST_CHECK(tcp_inst->local_address_string() == "localhost:");
-    TEST_CHECK(tcp_inst->enable_nagle_algorithm_ == true);
-    TEST_CHECK(tcp_inst->conn_retry_initial_delay_ == 1000);
-    TEST_CHECK(tcp_inst->conn_retry_backoff_multiplier_ == 4);
-    TEST_CHECK(tcp_inst->conn_retry_attempts_ == 4);
-    TEST_CHECK(tcp_inst->passive_reconnect_duration_ == 4000);
-    TEST_CHECK(tcp_inst->max_output_pause_period_ == 1000);
+    TEST_CHECK(tcp_inst->local_address() == "localhost:");
+    TEST_CHECK(tcp_inst->enable_nagle_algorithm() == true);
+    TEST_CHECK(tcp_inst->conn_retry_initial_delay() == 1000);
+    TEST_CHECK(tcp_inst->conn_retry_backoff_multiplier() == 4);
+    TEST_CHECK(tcp_inst->conn_retry_attempts() == 4);
+    TEST_CHECK(tcp_inst->passive_reconnect_duration() == 4000);
+    TEST_CHECK(tcp_inst->max_output_pause_period() == 1000);
 
     TransportInst_rch inst2 = TransportRegistry::instance()->get_inst("anothertcp");
     TEST_CHECK(inst2);

--- a/tests/transport/error_handling/main.cpp
+++ b/tests/transport/error_handling/main.cpp
@@ -8,17 +8,6 @@
 
 #include <ace/SOCK_Acceptor.h>
 
-class DDS_TEST
-{
-public:
-  DDS_TEST()
-  {
-  }
-  ACE_INET_Addr& local_address(OpenDDS::DCPS::TcpInst* tcp_inst) {
-    return tcp_inst->local_address_;
-  }
-};
-
 bool testConnectionErrorHandling()
 {
   // Open an acceptor to force an existing port number to be used.
@@ -38,8 +27,7 @@ bool testConnectionErrorHandling()
   OpenDDS::DCPS::TcpInst_rch tcp_inst =
     OpenDDS::DCPS::dynamic_rchandle_cast<OpenDDS::DCPS::TcpInst>(inst);
 
-  DDS_TEST test;
-  acceptor.get_local_addr(test.local_address(tcp_inst.in()));
+  tcp_inst->local_address(addr);
 
   OpenDDS::DCPS::TransportConfig_rch cfg =
     TheTransportRegistry->create_config("cfg");


### PR DESCRIPTION
Problem
-------

`TcpInst` does not use `ConfigStore`.  See #4134.

Solution
--------

Convert `TcpInst` to use `ConfigStore`.

The signatures for methods manipulating the local address have changed
to be more consistent and to prevent the system from overwriting the
configuration provided by the user.
