### PR TITLE
`UdpInst` does not use `ConfigStore`

### DIFF
--- a/dds/DCPS/transport/udp/UdpInst.cpp
+++ b/dds/DCPS/transport/udp/UdpInst.cpp
@@ -23,14 +23,9 @@ namespace OpenDDS {
 namespace DCPS {
 
 UdpInst::UdpInst(const std::string& name)
-  : TransportInst("udp", name),
-#if defined (ACE_DEFAULT_MAX_SOCKET_BUFSIZ)
-    send_buffer_size_(ACE_DEFAULT_MAX_SOCKET_BUFSIZ),
-    rcv_buffer_size_(ACE_DEFAULT_MAX_SOCKET_BUFSIZ)
-#else
-    send_buffer_size_(0),
-    rcv_buffer_size_(0)
-#endif
+  : TransportInst("udp", name)
+  , send_buffer_size_(*this, &UdpInst::send_buffer_size, &UdpInst::send_buffer_size)
+  , rcv_buffer_size_(*this, &UdpInst::rcv_buffer_size, &UdpInst::rcv_buffer_size)
 {
 }
 
@@ -45,20 +40,6 @@ UdpInst::load(ACE_Configuration_Heap& cf,
               ACE_Configuration_Section_Key& sect)
 {
   TransportInst::load(cf, sect); // delegate to parent
-
-  // Explicitly initialize this string to stop gcc 11 from issuing a warning.
-  ACE_TString local_address_s(ACE_TEXT(""));
-  GET_CONFIG_TSTRING_VALUE(cf, sect, ACE_TEXT("local_address"),
-                           local_address_s);
-
-  if (!local_address_s.empty()) {
-    local_address(ACE_TEXT_ALWAYS_CHAR(local_address_s.c_str()));
-  }
-
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("send_buffer_size"), this->send_buffer_size_, ACE_UINT32);
-
-  GET_CONFIG_VALUE(cf, sect, ACE_TEXT("rcv_buffer_size"), this->rcv_buffer_size_, ACE_UINT32);
-
   return 0;
 }
 
@@ -68,22 +49,18 @@ UdpInst::dump_to_str() const
   std::ostringstream os;
   os << TransportInst::dump_to_str();
 
-  os << formatNameForDump("local_address") << LogAddr(local_address()).str() << std::endl;
-  os << formatNameForDump("send_buffer_size") << this->send_buffer_size_ << std::endl;
-  os << formatNameForDump("rcv_buffer_size") << this->rcv_buffer_size_ << std::endl;
+  os << formatNameForDump("local_address") << local_address() << std::endl;
+  os << formatNameForDump("send_buffer_size") << this->send_buffer_size() << std::endl;
+  os << formatNameForDump("rcv_buffer_size") << this->rcv_buffer_size() << std::endl;
   return OPENDDS_STRING(os.str());
 }
 
 size_t
 UdpInst::populate_locator(OpenDDS::DCPS::TransportLocator& info, ConnectionInfoFlags) const
 {
-  if (this->local_address() != ACE_INET_Addr()) {
-    NetworkResource network_resource;
-    if (!this->local_address_string().empty()) {
-      network_resource = NetworkResource(this->local_address_string());
-    } else {
-      network_resource = NetworkResource(get_fully_qualified_hostname());
-    }
+  const std::string locator_addr = get_locator_address();
+  if (!locator_addr.empty()) {
+    NetworkResource network_resource(locator_addr);
     ACE_OutputCDR cdr;
     cdr << network_resource;
 
@@ -96,6 +73,100 @@ UdpInst::populate_locator(OpenDDS::DCPS::TransportLocator& info, ConnectionInfoF
   } else {
     return 0;
   }
+}
+
+void
+UdpInst::send_buffer_size(ACE_INT32 sbs)
+{
+  TheServiceParticipant->config_store()->set_uint32(config_key("SEND_BUFFER_SIZE").c_str(), sbs);
+}
+
+ACE_INT32
+UdpInst::send_buffer_size() const
+{
+  return TheServiceParticipant->config_store()->get_uint32(config_key("SEND_BUFFER_SIZE").c_str(),
+#if defined (ACE_DEFAULT_MAX_SOCKET_BUFSIZ)
+                                                           ACE_DEFAULT_MAX_SOCKET_BUFSIZ
+#else
+                                                           0
+#endif
+                                                           );
+}
+
+void
+UdpInst::rcv_buffer_size(ACE_INT32 sbs)
+{
+  TheServiceParticipant->config_store()->set_uint32(config_key("RCV_BUFFER_SIZE").c_str(), sbs);
+}
+
+ACE_INT32
+UdpInst::rcv_buffer_size() const
+{
+  return TheServiceParticipant->config_store()->get_uint32(config_key("RCV_BUFFER_SIZE").c_str(),
+#if defined (ACE_DEFAULT_MAX_SOCKET_BUFSIZ)
+                                                           ACE_DEFAULT_MAX_SOCKET_BUFSIZ
+#else
+                                                           0
+#endif
+                                                           );
+}
+
+void
+UdpInst::local_address(const String& la)
+{
+  TheServiceParticipant->config_store()->set(config_key("LOCAL_ADDRESS").c_str(), la);
+}
+
+String
+UdpInst::local_address() const
+{
+  return TheServiceParticipant->config_store()->get(config_key("LOCAL_ADDRESS").c_str(), "");
+}
+
+ACE_INET_Addr
+UdpInst::send_receive_address() const
+{
+  ACE_INET_Addr addr = choose_single_coherent_address(local_address(), false);
+  // Override with DCPSDefaultAddress.
+  if (addr == ACE_INET_Addr() &&
+      TheServiceParticipant->default_address() != NetworkAddress::default_IPV4) {
+    VDBG_LVL((LM_DEBUG,
+              ACE_TEXT("(%P|%t) UdpInst::accept_address overriding with DCPSDefaultAddress\n")), 2);
+    addr = TheServiceParticipant->default_address().to_addr();
+  }
+
+  return addr;
+}
+
+bool
+UdpInst::set_locator_address(const ACE_INET_Addr& address)
+{
+  const ACE_INET_Addr local_addr = send_receive_address();
+  const unsigned short port = address.get_port_number();
+
+  // If listening on "any" host/port, need to record the actual port number
+  // selected by the OS, as well as our actual hostname, into the config_
+  // object's local_address_ for use in UdpTransport::connection_info_i().
+  if (local_addr.is_any()) {
+    const std::string hostname = get_fully_qualified_hostname();
+    locator_address_ = hostname + ":" + to_dds_string(port);
+
+    const ACE_INET_Addr addr = choose_single_coherent_address(locator_address_);
+    if (addr == ACE_INET_Addr()) {
+      ACE_ERROR((LM_ERROR,
+                 ACE_TEXT("(%P|%t) ERROR: Failed to resolve a local address using fully qualified hostname '%C'\n"),
+                 hostname.c_str()));
+      return false;
+    }
+  } else if (local_addr.get_port_number() == 0) {
+    // Similar case to the "if" case above, but with a bound host/IP but no port
+    locator_address_ = local_address();
+    set_port_in_addr_string(locator_address_, port);
+  } else {
+    locator_address_ = local_address();
+  }
+
+  return true;
 }
 
 } // namespace DCPS

--- a/docs/news.d/config_store.rst
+++ b/docs/news.d/config_store.rst
@@ -1,4 +1,4 @@
-.. news-prs: 4162 4241 4242 4255 4243
+.. news-prs: 4162 4241 4242 4255 4243 4249
 .. news-start-section: Additions
 - OpenDDS now stores ``rtps_udp`` transport configuration in the key-value store.
 
@@ -7,5 +7,7 @@
 - OpenDDS now stores ``shmem`` transport configuration in the key-value store.
 
 - OpenDDS now stores ``tcp`` transport configuration in the key-value store.
+
+- OpenDDS now stores ``udp`` transport configuration in the key-value store.
 
 .. news-end-section

--- a/java/dds/OpenDDS_DCPS_jni.cpp
+++ b/java/dds/OpenDDS_DCPS_jni.cpp
@@ -817,7 +817,7 @@ jstring JNICALL Java_OpenDDS_DCPS_transport_UdpInst_getLocalAddress
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::UdpInst_rch inst = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS:: UdpInst>(jni, jthis)); // Don't take ownership
-  jstring retStr = jni->NewStringUTF(inst->local_address_string().c_str());
+  jstring retStr = jni->NewStringUTF(inst->local_address().c_str());
   return retStr;
 }
 


### PR DESCRIPTION
Problem
-------
UdpInst does not use ConfigStore. See #4134.

Solution
--------
Convert UdpInst to use ConfigStore.

The signatures for methods manipulating the local address have changed
to be more consistent and to prevent the system from overwriting the
configuration provided by the user.
