### PR TITLE
ConfigValue lacks assignment operator

### DIFF
--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -250,6 +250,17 @@ public:
     return (delegate_.*getter_)();
   }
 
+  T get() const
+  {
+    return (delegate_.*getter_)();
+  }
+
+  ConfigValue& operator=(const ConfigValue& cv)
+  {
+    (delegate_.*setter_)(cv.get());
+    return *this;
+  }
+
 private:
   Delegate& delegate_;
   Setter setter_;
@@ -279,6 +290,17 @@ public:
   operator T() const
   {
     return (delegate_.*getter_)();
+  }
+
+  T get() const
+  {
+    return (delegate_.*getter_)();
+  }
+
+  ConfigValueRef& operator=(const ConfigValueRef& cv)
+  {
+    (delegate_.*setter_)(cv.get());
+    return *this;
   }
 
 private:

--- a/tests/unit-tests/dds/DCPS/transport/framework/TransportInst.cpp
+++ b/tests/unit-tests/dds/DCPS/transport/framework/TransportInst.cpp
@@ -10,6 +10,9 @@ struct MockTransportInst {
     : my_int_(*this, &MockTransportInst::my_int, &MockTransportInst::my_int)
     , my_int__(0)
     , my_string_(*this, &MockTransportInst::my_string, &MockTransportInst::my_string)
+    , my_int2_(*this, &MockTransportInst::my_int2, &MockTransportInst::my_int2)
+    , my_int2__(0)
+    , my_string2_(*this, &MockTransportInst::my_string2, &MockTransportInst::my_string2)
   {}
 
   ConfigValue<MockTransportInst, int> my_int_;
@@ -37,6 +40,32 @@ struct MockTransportInst {
   }
 
   String my_string__;
+
+  ConfigValue<MockTransportInst, int> my_int2_;
+  void my_int2(int x)
+  {
+    my_int2__ = x;
+  }
+
+  int my_int2() const
+  {
+    return my_int2__;
+  }
+
+  int my_int2__;
+
+  ConfigValueRef<MockTransportInst, String> my_string2_;
+  void my_string2(const String& x)
+  {
+    my_string2__ = x;
+  }
+
+  String my_string2() const
+  {
+    return my_string2__;
+  }
+
+  String my_string2__;
 };
 
 TEST(dds_DCPS_transport_framework_ConfigValue, assign_read)
@@ -46,6 +75,8 @@ TEST(dds_DCPS_transport_framework_ConfigValue, assign_read)
   mtt.my_int_ = 39;
   EXPECT_EQ(mtt.my_int__, 39);
   EXPECT_EQ(mtt.my_int_, 39);
+  mtt.my_int2_ = mtt.my_int_;
+  EXPECT_EQ(mtt.my_int2_, 39);
 }
 
 TEST(dds_DCPS_transport_framework_ConfigValueRef, assign_read)
@@ -57,4 +88,7 @@ TEST(dds_DCPS_transport_framework_ConfigValueRef, assign_read)
   EXPECT_EQ(mtt.my_string__, a_string);
   const String b_string = mtt.my_string_;
   EXPECT_EQ(b_string, a_string);
+  mtt.my_string2_ = mtt.my_string_;
+  const String c_string = mtt.my_string2_;
+  EXPECT_EQ(c_string, a_string);
 }


### PR DESCRIPTION
Problem
-------

ConfigValue and ConfigValueRef don't have an assignment operator which prevents users from copying values between TransportInsts.

Solution
--------

Add an assignment operator.