### PR TITLE
`run_lease_duration_test.pl` uses common port

### DIFF
--- a/performance-tests/bench/example/config/scenario/ci-disco-relay.json
+++ b/performance-tests/bench/example/config/scenario/ci-disco-relay.json
@@ -26,7 +26,7 @@
   "any_node": [
     {
       "executable": "RtpsRelay",
-      "command" : "%executable% -Id relay1 -UserData relay1 -DCPSDebugLevel 1 -DCPSSecurityDebugLevel 2 -LogDiscovery 1 -LogActivity 1 -DCPSThreadStatusInterval 1 -LogRelayStatistics 3 -LogParticipantStatistics 1 -DCPSConfigFile %bench_root%%ds%example%ds%config%ds%relay%ds%ci-disco-relay.ini -ApplicationDomain 7 -VerticalAddress 4444 -MetaDiscoveryAddress 0 -ORBLogFile %log% -DCPSPendingTimeout 3",
+      "command" : "%executable% -Id relay1 -UserData relay1 -DCPSDebugLevel 1 -DCPSSecurityDebugLevel 2 -LogDiscovery 1 -LogActivity 1 -DCPSThreadStatusInterval 1 -LogRelayStatistics 3 -LogParticipantStatistics 1 -DCPSConfigFile %bench_root%%ds%example%ds%config%ds%relay%ds%ci-disco-relay.ini -ApplicationDomain 7 -VerticalAddress 4444 -MetaDiscoveryAddress 127.0.0.1:0 -ORBLogFile %log% -DCPSPendingTimeout 3",
       "no_report": true,
       "ignore_errors": true,
       "count": 1

--- a/tests/DCPS/ParticipantLocationTopic/run_test.pl
+++ b/tests/DCPS/ParticipantLocationTopic/run_test.pl
@@ -52,9 +52,9 @@ my $relay_security_opts = "-IdentityCA ../../security/certs/identity/identity_ca
   " -Governance governance_signed.p7s -Permissions permissions_relay_signed.p7s -DCPSSecurity 1";
 
 if ($ipv6_opt) {
-    $test->process("relay", "$ENV{DDS_ROOT}/bin/RtpsRelay", "-Id relay -DCPSConfigFile relay_ipv6.ini -ApplicationDomain 42 -VerticalAddress [::]:4444 -HorizontalAddress [::1]:11444 $relay_security_opts");
+    $test->process("relay", "$ENV{DDS_ROOT}/bin/RtpsRelay", "-Id relay -DCPSConfigFile relay_ipv6.ini -ApplicationDomain 42 -VerticalAddress [::]:4444 -HorizontalAddress [::1]:11444 $relay_security_opts -MetaDiscoveryAddress 127.0.0.1:0");
 } else {
-    $test->process("relay", "$ENV{DDS_ROOT}/bin/RtpsRelay", "-Id relay -DCPSConfigFile relay.ini -ApplicationDomain 42 -VerticalAddress 4444 -HorizontalAddress 127.0.0.1:11444 $relay_security_opts");
+    $test->process("relay", "$ENV{DDS_ROOT}/bin/RtpsRelay", "-Id relay -DCPSConfigFile relay.ini -ApplicationDomain 42 -VerticalAddress 4444 -HorizontalAddress 127.0.0.1:11444 $relay_security_opts -MetaDiscoveryAddress 127.0.0.1:0");
 }
 
 $test->process("ParticipantLocationTest", "ParticipantLocationTest", "$no_ice_opt $ipv6_opt -ORBDebugLevel 1 -DCPSConfigFile ". $pub_sub_ini);

--- a/tests/DCPS/RtpsRelay/STUN/run_test.pl
+++ b/tests/DCPS/RtpsRelay/STUN/run_test.pl
@@ -23,10 +23,10 @@ $test->{dcps_transport_debug_level} = 1;
 $test->{add_transport_config} = 0;
 
 if ($test->flag('ipv6')) {
-    $test->process("server", "$DDS_ROOT/bin/RtpsRelay", "-Id relay -DCPSConfigFile relay_ipv6.ini -ApplicationDomain 42 -VerticalAddress [::1]:4444 -HorizontalAddress [::1]:11444");
+    $test->process("server", "$DDS_ROOT/bin/RtpsRelay", "-Id relay -DCPSConfigFile relay_ipv6.ini -ApplicationDomain 42 -VerticalAddress [::1]:4444 -HorizontalAddress [::1]:11444 -MetaDiscoveryAddress 127.0.0.1:0");
     $test->process("client", "StunClient", "-ipv6 1");
 } else {
-    $test->process("server", "$DDS_ROOT/bin/RtpsRelay", "-Id relay -DCPSConfigFile relay.ini -ApplicationDomain 42 -VerticalAddress 127.0.0.1:4444 -HorizontalAddress 127.0.0.1:11444");
+    $test->process("server", "$DDS_ROOT/bin/RtpsRelay", "-Id relay -DCPSConfigFile relay.ini -ApplicationDomain 42 -VerticalAddress 127.0.0.1:4444 -HorizontalAddress 127.0.0.1:11444 -MetaDiscoveryAddress 127.0.0.1:0");
     $test->process("client", "StunClient");
 }
 

--- a/tests/DCPS/RtpsRelay/Smoke/run_lease_duration_test.pl
+++ b/tests/DCPS/RtpsRelay/Smoke/run_lease_duration_test.pl
@@ -41,8 +41,8 @@ if ($test->flag('reverse')) {
 }
 
 $test->process("monitor", "monitor", "-DCPSConfigFile monitor.ini");
-$test->process("relay1a", "$ENV{DDS_ROOT}/bin/RtpsRelay", "-Id relay1a -LogDiscovery 1 -LogActivity 1 -LogRelayStatistics 3 -DCPSConfigFile relay1.ini -ApplicationDomain 42 -VerticalAddress 4444 -HorizontalAddress 127.0.0.1:11444 -UserData relay1a" . $relay_security_opts);
-$test->process("relay1b", "$ENV{DDS_ROOT}/bin/RtpsRelay", "-Id relay1b -LogDiscovery 1 -LogActivity 1 -LogRelayStatistics 3 -DCPSConfigFile relay1.ini -ApplicationDomain 42 -VerticalAddress 4444 -HorizontalAddress 127.0.0.1:11444 -UserData relay1b" . $relay_security_opts);
+$test->process("relay1a", "$ENV{DDS_ROOT}/bin/RtpsRelay", "-Id relay1a -LogDiscovery 1 -LogActivity 1 -LogRelayStatistics 3 -DCPSConfigFile relay1.ini -ApplicationDomain 42 -VerticalAddress 4444 -HorizontalAddress 127.0.0.1:11444 -UserData relay1a -MetaDiscoveryAddress 127.0.0.1:0" . $relay_security_opts);
+$test->process("relay1b", "$ENV{DDS_ROOT}/bin/RtpsRelay", "-Id relay1b -LogDiscovery 1 -LogActivity 1 -LogRelayStatistics 3 -DCPSConfigFile relay1.ini -ApplicationDomain 42 -VerticalAddress 4444 -HorizontalAddress 127.0.0.1:11444 -UserData relay1b -MetaDiscoveryAddress 127.0.0.1:0" . $relay_security_opts);
 $test->process("publisher", "publisher", "-l -ORBDebugLevel 1 -DCPSConfigFile". $pub_ini . $pub_sub_security_opts);
 $test->process("subscriber", "subscriber", "-l -ORBDebugLevel 1 -DCPSConfigFile" . $sub_ini . $pub_sub_security_opts);
 


### PR DESCRIPTION
Problem
-------

The default -MetaDiscoveryAddress uses port 8080 which is often used by other services.  This causes the
`run_lease_duration_test.pl` to fail.

Solution
--------

Set the port to 0.