### PR TITLE
Fixed a corner case in RTPS ParameterList parsing

### DIFF
--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -398,10 +398,10 @@ Serializer::ScopedAlignmentContext::ScopedAlignmentContext(Serializer& ser, size
   : ser_(ser)
   , max_align_(ser.encoding().max_align())
   , start_rpos_(ser.rpos())
-  , rblock_(max_align_ ? (ptrdiff_t(ser.current_->rd_ptr()) - ser.align_rshift_) % max_align_ : 0)
+  , rblock_((max_align_ && ser.current_) ? (ptrdiff_t(ser.current_->rd_ptr()) - ser.align_rshift_) % max_align_ : 0)
   , min_read_(min_read)
   , start_wpos_(ser.wpos())
-  , wblock_(max_align_ ? (ptrdiff_t(ser.current_->wr_ptr()) - ser.align_wshift_) % max_align_ : 0)
+  , wblock_((max_align_ && ser.current_) ? (ptrdiff_t(ser.current_->wr_ptr()) - ser.align_wshift_) % max_align_ : 0)
 {
   ser_.reset_alignment();
 }

--- a/tests/unit-tests/dds/DCPS/RTPS/RtpsCoreTypeSupportImpl.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/RtpsCoreTypeSupportImpl.cpp
@@ -257,3 +257,21 @@ TEST(RtpsCoreTypeSupportImpl, Serializer_test_parameterlist)
   ParameterList plist;
   ASSERT_FALSE(ser >> plist);
 }
+
+TEST(RtpsCoreTypeSupportImpl, Serializer_test_parameterlist_invalid)
+{
+  static const ACE_CDR::Octet x[] = {
+    0x14,0x40,0x08,0x00, // PID, length
+    0x01,0x00,0x00,0x00, // string length
+    0x00,0x00,0x00,0x00, // string contents
+    0x00,0x00,0x00,0x00, // invalid termination, 0 is PID_PAD; no PID_SENTINEL
+  };
+  Message_Block_Ptr amb(new ACE_Message_Block(sizeof x));
+  const Encoding enc(Encoding::KIND_XCDR1, ENDIAN_LITTLE);
+  Serializer ser_w(amb.get(), enc);
+  ASSERT_TRUE(ser_w.write_octet_array(x, sizeof x));
+
+  Serializer ser(amb.get(), enc);
+  ParameterList plist;
+  ASSERT_FALSE(ser >> plist);
+}


### PR DESCRIPTION
Without this fix, when the end of the stream is reached before PID_SENTINEL the parser may attempt to dereference an invalid pointer.