### PR TITLE
MemberDescriptor implementation is incomplete

### DIFF
--- a/dds/CMakeLists.txt
+++ b/dds/CMakeLists.txt
@@ -120,6 +120,7 @@ add_library(OpenDDS_Dcps
   DCPS/XTypes/DynamicTypeImpl.cpp
   DCPS/XTypes/DynamicTypeMemberImpl.cpp
   DCPS/XTypes/DynamicTypeSupport.cpp
+  DCPS/XTypes/IdlScanner.cpp
   DCPS/XTypes/MemberDescriptorImpl.cpp
   DCPS/XTypes/TypeAssignability.cpp
   DCPS/XTypes/TypeDescriptorImpl.cpp
@@ -400,6 +401,7 @@ target_sources(OpenDDS_Dcps
     DCPS/XTypes/DynamicTypeMemberImpl.h
     DCPS/XTypes/DynamicTypeSupport.h
     DCPS/XTypes/External.h
+    DCPS/XTypes/IdlScanner.h
     DCPS/XTypes/MemberDescriptorImpl.h
     DCPS/XTypes/TypeAssignability.h
     DCPS/XTypes/TypeDescriptorImpl.h

--- a/dds/DCPS/XTypes/DynamicTypeImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicTypeImpl.cpp
@@ -199,12 +199,12 @@ bool test_equality(DDS::DynamicType_ptr lhs, DDS::DynamicType_ptr rhs, DynamicTy
     return true;
   }
 
-  OPENDDS_ASSERT(lhs);
-  OPENDDS_ASSERT(rhs);
-
   if (lhs == 0 || rhs == 0) {
     return false;
   }
+
+  OPENDDS_ASSERT(lhs);
+  OPENDDS_ASSERT(rhs);
 
   const DynamicTypePtrPair this_pair = std::make_pair(lhs, rhs);
   DynamicTypePtrPairSeen::const_iterator have_seen = dt_ptr_pair.find(this_pair);

--- a/dds/DCPS/XTypes/IdlScanner.cpp
+++ b/dds/DCPS/XTypes/IdlScanner.cpp
@@ -1,0 +1,148 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include <DCPS/DdsDcps_pch.h>
+
+#ifndef OPENDDS_SAFETY_PROFILE
+#  include "IdlScanner.h"
+
+#  include "DynamicTypeImpl.h"
+
+#  include <ace/Basic_Types.h>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS {
+namespace XTypes {
+
+IdlToken
+IdlScanner::scan_token(DDS::DynamicType_ptr type)
+{
+  OPENDDS_ASSERT(type);
+
+  DDS::DynamicType_var bt = get_base_type(type);
+
+  switch (bt->get_kind()) {
+  case TK_BOOLEAN: {
+    const IdlToken token = scan_identifier();
+    if (token.is_boolean()) {
+      return token;
+    }
+    break;
+  }
+  case TK_BYTE: {
+    const IdlToken token = scan_numeric_literal();
+    if (token.is_integer() && !token.is_signed() && token.integer_value() <= ACE_UINT8_MAX) {
+      return token;
+    }
+    break;
+  }
+  case TK_INT8: {
+    const IdlToken token = scan_numeric_literal();
+    const ACE_UINT64 limit = static_cast<ACE_UINT64>(ACE_INT8_MAX) + (token.is_signed() ? 1 : 0);
+    if (token.is_integer() && token.integer_value() <= limit) {
+      return token;
+    }
+    break;
+  }
+  case TK_INT16: {
+    const IdlToken token = scan_numeric_literal();
+    const ACE_UINT64 limit = static_cast<ACE_UINT64>(ACE_INT16_MAX) + (token.is_signed() ? 1 : 0);
+    if (token.is_integer() && token.integer_value() <= limit) {
+      return token;
+    }
+    break;
+  }
+  case TK_INT32: {
+    const IdlToken token = scan_numeric_literal();
+    const ACE_UINT64 limit = static_cast<ACE_UINT64>(ACE_INT32_MAX) + (token.is_signed() ? 1 : 0);
+    if (token.is_integer() && token.integer_value() <= limit) {
+      return token;
+    }
+    break;
+  }
+  case TK_INT64: {
+    const IdlToken token = scan_numeric_literal();
+    const ACE_UINT64 limit = static_cast<ACE_UINT64>(ACE_INT64_MAX) + (token.is_signed() ? 1 : 0);
+    if (token.is_integer() && token.integer_value() <= limit) {
+      return token;
+    }
+    break;
+  }
+  case TK_UINT8: {
+    const IdlToken token = scan_numeric_literal();
+    if (token.is_integer() && !token.is_signed() && token.integer_value() <= ACE_UINT8_MAX) {
+      return token;
+    }
+    break;
+  }
+  case TK_UINT16: {
+    const IdlToken token = scan_numeric_literal();
+    if (token.is_integer() && !token.is_signed() && token.integer_value() <= ACE_UINT16_MAX) {
+      return token;
+    }
+    break;
+  }
+  case TK_UINT32: {
+    const IdlToken token = scan_numeric_literal();
+    if (token.is_integer() && !token.is_signed() && token.integer_value() <= ACE_UINT32_MAX) {
+      return token;
+    }
+    break;
+  }
+  case TK_UINT64: {
+    const IdlToken token = scan_numeric_literal();
+    if (token.is_integer() && !token.is_signed() && token.integer_value() <= ACE_UINT64_MAX) {
+      return token;
+    }
+    break;
+  }
+  case TK_FLOAT32:
+  case TK_FLOAT64:
+  case TK_FLOAT128: {
+    const IdlToken token = scan_numeric_literal();
+    // TODO: Bounds checking.
+    if (token.is_float()) {
+      return token;
+    }
+    break;
+  }
+  case TK_CHAR8: {
+    if (scan_character_value(true)) {
+      return IdlToken::make_character(character_literal_);
+    }
+    break;
+  }
+  case TK_CHAR16:
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERRROR: IdlScanner::scan_token does not support wide characters\n"));
+    break;
+  case TK_STRING8: {
+    if (scan_string_value(false)) {
+      return IdlToken::make_string(string_literal_);
+    }
+    break;
+  }
+  case TK_STRING16:
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERRROR: IdlScanner::scan_token does not support wide strings\n"));
+    break;
+  case TK_ENUM: {
+    const IdlToken token = scan_identifier();
+    DDS::DynamicTypeMember_var dtm;
+    if (token.is_identifier() && bt->get_member_by_name(dtm, token.identifier_value().c_str()) == DDS::RETCODE_OK) {
+      return token;
+    }
+    break;
+  }
+  default:
+    break;
+  }
+
+  return IdlToken::make_error();
+}
+
+} // namespace XTypes
+} // namespace OpenDDS
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif // OPENDDS_SAFETY_PROFILE

--- a/dds/DCPS/XTypes/IdlScanner.h
+++ b/dds/DCPS/XTypes/IdlScanner.h
@@ -1,0 +1,899 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_XTYPES_IDL_SCANNER_H
+#define OPENDDS_DCPS_XTYPES_IDL_SCANNER_H
+
+#ifndef OPENDDS_SAFETY_PROFILE
+
+#  include <dds/DCPS/dcps_export.h>
+
+#  include <dds/DCPS/Definitions.h>
+#  include <dds/DdsDynamicDataC.h>
+
+#  include <string>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+namespace OpenDDS {
+namespace XTypes {
+
+class OpenDDS_Dcps_Export CharacterScanner {
+public:
+  CharacterScanner(const std::string& str)
+    : str_(str)
+    , idx_(0)
+  {}
+
+  char peek() const
+  {
+    OPENDDS_ASSERT(!eoi());
+    return str_[idx_];
+  }
+
+  bool eoi() const
+  {
+    return idx_ == str_.size();
+  }
+
+  void consume()
+  {
+    OPENDDS_ASSERT(!eoi());
+    ++idx_;
+  }
+
+  bool match(char c)
+  {
+    if (eoi() || peek() != c) {
+      return false;
+    }
+
+    consume();
+    return true;
+  }
+
+private:
+  const std::string str_;
+  size_t idx_;
+};
+
+class OpenDDS_Dcps_Export IdlToken {
+public:
+  enum Kind {
+    Error,
+    EOI,
+    BooleanLiteral,
+    IntegerLiteral,
+    FloatLiteral,
+    StringLiteral,
+    CharacterLiteral,
+    Identifier
+  };
+
+  static IdlToken make_error()
+  {
+    IdlToken token;
+    token.kind_ = Error;
+    return token;
+  }
+
+  static IdlToken make_eoi()
+  {
+    IdlToken token;
+    token.kind_ = EOI;
+    return token;
+  }
+
+  static IdlToken make_boolean(bool value)
+  {
+    IdlToken token;
+    token.kind_ = BooleanLiteral;
+    token.boolean_value_ = value;
+    return token;
+  }
+
+  static IdlToken make_character(char value)
+  {
+    IdlToken token;
+    token.kind_ = CharacterLiteral;
+    token.character_value_ = value;
+    return token;
+  }
+
+  static IdlToken make_string(const std::string& value)
+  {
+    IdlToken token;
+    token.kind_ = StringLiteral;
+    token.string_value_ = value;
+    return token;
+  }
+
+  static IdlToken make_integer(bool is_signed, ACE_UINT64 value)
+  {
+    IdlToken token;
+    token.kind_ = IntegerLiteral;
+    token.signed_ = is_signed;
+    token.integer_value_ = value;
+    return token;
+  }
+
+  static IdlToken make_float(bool is_signed, ACE_UINT64 value, bool exponent_is_signed, ACE_UINT64 exponent_value)
+  {
+    IdlToken token;
+    token.kind_ = FloatLiteral;
+    token.signed_ = is_signed;
+    token.integer_value_ = value;
+    token.exponent_signed_ = exponent_is_signed;
+    token.exponent_value_ = exponent_value;
+    return token;
+  }
+
+  static IdlToken make_identifier(const std::string& value)
+  {
+    IdlToken token;
+    if (value == "TRUE") {
+      token.kind_ = BooleanLiteral;
+      token.boolean_value_ = true;
+    } else if (value == "FALSE") {
+      token.kind_ = BooleanLiteral;
+      token.boolean_value_ = false;
+    } else {
+      token.kind_ = Identifier;
+      token.identifier_value_ = value;
+    }
+    return token;
+  }
+
+  bool operator==(const IdlToken& other) const
+  {
+    if (kind_ != other.kind_) {
+      return false;
+    }
+
+    switch (kind_) {
+    case Error:
+    case EOI:
+      return true;
+    case BooleanLiteral:
+      return boolean_value_ == other.boolean_value_;
+    case IntegerLiteral:
+      return signed_ == other.signed_ && integer_value_ == other.integer_value_;
+    case FloatLiteral:
+      return signed_ == other.signed_ && integer_value_ == other.integer_value_
+        && exponent_signed_ == other.exponent_signed_ && exponent_value_ == other.exponent_value_;
+    case StringLiteral:
+      return string_value_ == other.string_value_;
+    case CharacterLiteral:
+      return character_value_ == other.character_value_;
+    case Identifier:
+      return identifier_value_ == other.identifier_value_;
+    default:
+      return false;
+    }
+  }
+
+  bool is_error() const
+  {
+    return kind_ == Error;
+  }
+
+  bool is_boolean() const
+  {
+    return kind_ == BooleanLiteral;
+  }
+
+  bool is_integer() const
+  {
+    return kind_ == IntegerLiteral;
+  }
+
+  bool is_float() const
+  {
+    return kind_ == FloatLiteral;
+  }
+
+  bool is_identifier() const
+  {
+    return kind_ == Identifier;
+  }
+
+  bool is_signed() const
+  {
+    return signed_;
+  }
+
+  ACE_UINT64 integer_value() const
+  {
+    return integer_value_;
+  }
+
+  bool exponent_is_signed() const
+  {
+    return exponent_signed_;
+  }
+
+  ACE_UINT64 exponent_value() const
+  {
+    return exponent_value_;
+  }
+
+  const std::string& identifier_value() const
+  {
+    return identifier_value_;
+  }
+
+private:
+  Kind kind_;
+  union {
+    bool boolean_value_;
+    char character_value_;
+    struct {
+      bool signed_;  // Integer or Float is signed.
+      ACE_UINT64 integer_value_; // Integer or Float.
+      bool exponent_signed_; // Exponent is signed for Float.
+      ACE_UINT64 exponent_value_; // Exponent value for Float.
+    };
+  };
+  std::string string_value_;
+  std::string identifier_value_;
+};
+
+class OpenDDS_Dcps_Export IdlScanner {
+public:
+  IdlScanner(CharacterScanner& scanner)
+    : scanner_(scanner)
+  {}
+
+  IdlToken scan_token()
+  {
+    if (scanner_.eoi()) {
+      return IdlToken::make_eoi();
+    }
+
+    const char c = scanner_.peek();
+    if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+      return scan_identifier();
+    }
+
+    switch (c) {
+    case '\'':
+      if (scan_character_literal()) {
+        return IdlToken::make_character(character_literal_);
+      } else {
+        return IdlToken::make_error();
+      }
+    case '"':
+      if (scan_string_literal()) {
+        return IdlToken::make_string(string_literal_);
+      } else {
+        return IdlToken::make_error();
+      }
+    case '-':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case '.':
+      return scan_numeric_literal();
+    default:
+      return IdlToken::make_error();
+    }
+  }
+
+  // Method for scanning default_values.
+  IdlToken scan_token(DDS::DynamicType_ptr type);
+
+  bool eoi() const
+  {
+    return scanner_.eoi();
+  }
+
+private:
+
+  IdlToken scan_identifier()
+  {
+    identifier_.clear();
+
+    if (scan_identifier_alpha() && scan_identifier_optional_characters()) {
+      return IdlToken::make_identifier(identifier_);
+    }
+
+    return IdlToken::make_error();
+  }
+
+  bool scan_identifier_alpha()
+  {
+    if (scanner_.eoi()) {
+      return false;
+    }
+
+    const char c = scanner_.peek();
+    if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+      return scanner_.match(c) && append_to_identifier(c);
+    }
+
+    return false;
+  }
+
+  bool scan_identifier_optional_characters()
+  {
+    if (scanner_.eoi()) {
+      return true;
+    }
+
+    const char c = scanner_.peek();
+    if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') {
+      return scanner_.match(c) && append_to_identifier(c) && scan_identifier_optional_characters();
+    }
+
+    return true;
+  }
+
+  bool append_to_identifier(char c)
+  {
+    identifier_ += c;
+    return true;
+  }
+
+  bool scan_character_literal()
+  {
+    return scanner_.match('\'') && scan_character_value(true) && scanner_.match('\'');
+  }
+
+  bool scan_character_value(bool allow_null)
+  {
+    character_literal_ = 0;
+
+    if (scanner_.eoi()) {
+      return false;
+    }
+
+    const char c = scanner_.peek();
+    if (c == '\\') {
+      return scanner_.match(c) && scan_character_escape() && character_literal_okay(allow_null);
+    } else {
+      character_literal_ = c;
+      return scanner_.match(c) && character_literal_okay(allow_null);
+    }
+  }
+
+  bool character_literal_okay(bool allow_null) {
+    return allow_null || character_literal_ != 0;
+  }
+
+  bool scan_character_escape()
+  {
+    if (scanner_.eoi()) {
+      return false;
+    }
+
+    const char c = scanner_.peek();
+    switch (c) {
+    case 'n':
+      character_literal_ = '\n';
+      return scanner_.match(c);
+    case 't':
+      character_literal_ = '\t';
+      return scanner_.match(c);
+    case 'v':
+      character_literal_ = '\v';
+      return scanner_.match(c);
+    case 'b':
+      character_literal_ = '\b';
+      return scanner_.match(c);
+    case 'r':
+      character_literal_ = '\r';
+      return scanner_.match(c);
+    case 'f':
+      character_literal_ = '\f';
+      return scanner_.match(c);
+    case 'a':
+      character_literal_ = '\a';
+      return scanner_.match(c);
+    case '\\':
+      character_literal_ = '\\';
+      return scanner_.match(c);
+    case '?':
+      character_literal_ = '\?';
+      return scanner_.match(c);
+    case '\'':
+      character_literal_ = '\'';
+      return scanner_.match(c);
+    case '"':
+      character_literal_ = '\"';
+      return scanner_.match(c);
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+      return scan_character_octal_escape();
+    case 'x':
+      return scanner_.match(c) && scan_character_hex_escape();
+    default:
+      return false;
+    }
+  }
+
+  bool scan_character_octal_escape()
+  {
+    return scan_character_octal_digit() && scan_character_octal_optional_digit() && scan_character_octal_optional_digit();
+  }
+
+  bool scan_character_octal_digit()
+  {
+    if (scanner_.eoi()) {
+      return false;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '7') {
+      character_literal_ = (character_literal_ << 3) | ((c - '0') & 0x7);
+      return scanner_.match(c);
+    } else {
+      return false;
+    }
+  }
+
+  bool scan_character_octal_optional_digit()
+  {
+    if (scanner_.eoi()) {
+      return true;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '7') {
+      character_literal_ = (character_literal_ << 3) | ((c - '0') & 0x7);
+      return scanner_.match(c);
+    } else {
+      return true;
+    }
+  }
+
+  bool scan_character_hex_escape()
+  {
+    return scan_character_hex_digit() && scan_character_hex_optional_digit();
+  }
+
+  bool scan_character_hex_digit()
+  {
+    if (scanner_.eoi()) {
+      return false;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '9') {
+      character_literal_ = (character_literal_ << 4) | ((c - '0') & 0xF);
+      return scanner_.match(c);
+    } else if (c >= 'A' && c <= 'F') {
+      character_literal_ = (character_literal_ << 4) | ((c - 'A' + 10) & 0xF);
+      return scanner_.match(c);
+    } else if (c >= 'a' && c <= 'f') {
+      character_literal_ = (character_literal_ << 4) | ((c - 'a' + 10) & 0xF);
+      return scanner_.match(c);
+    } else {
+      return false;
+    }
+  }
+
+  bool scan_character_hex_optional_digit()
+  {
+    if (scanner_.eoi()) {
+      return true;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '9') {
+      character_literal_ = (character_literal_ << 4) | ((c - '0') & 0xF);
+      return scanner_.match(c);
+    } else if (c >= 'A' && c <= 'F') {
+      character_literal_ = (character_literal_ << 4) | ((c - 'A' + 10) & 0xF);
+      return scanner_.match(c);
+    } else if (c >= 'a' && c <= 'f') {
+      character_literal_ = (character_literal_ << 4) | ((c - 'a' + 10) & 0xF);
+      return scanner_.match(c);
+    } else {
+      return true;
+    }
+  }
+
+  bool scan_string_literal()
+  {
+    return scanner_.match('"') && scan_string_value(true) && scanner_.match('"');
+  }
+
+  bool scan_string_value(bool expect_quote)
+  {
+    string_literal_.clear();
+    return scan_string_optional_characters(expect_quote);
+  }
+
+  bool scan_string_optional_characters(bool expect_quote)
+  {
+    if (scanner_.eoi()) {
+      // Expecting ending quote.
+      return !expect_quote;
+    }
+
+    const char c = scanner_.peek();
+    if (c == '"') {
+      return true;
+    }
+
+    return scan_character_value(false) && append_character_to_string() && scan_string_optional_characters(expect_quote);
+  }
+
+  bool append_character_to_string()
+  {
+    string_literal_ += character_literal_;
+    return true;
+  }
+
+  IdlToken scan_numeric_literal()
+  {
+    signed_ = false;
+    integer_value_ = 0;
+    digits_after_decimal_ = 0;
+    exponent_signed_ = false;
+    exponent_value_ = 0;
+
+    if (scanner_.eoi()) {
+      return IdlToken::make_error();
+    }
+
+    const char c = scanner_.peek();
+    if (c == '-') {
+      scanner_.match(c);
+      signed_ = true;
+    }
+
+    if (scanner_.eoi()) {
+      return IdlToken::make_error();
+    }
+
+    const char d = scanner_.peek();
+    if (d == '0') {
+      scanner_.match(d);
+      if (scanner_.eoi()) {
+        // A single zero.
+        return IdlToken::make_integer(false, 0);
+      }
+
+      const char e = scanner_.peek();
+      if (e >= '0' && e <= '7') {
+        // Octal
+        if (scan_numeric_octal()) {
+          return IdlToken::make_integer(signed_, integer_value_);
+        } else {
+          return IdlToken::make_error();
+        }
+      } else if (e == 'x') {
+        // Hex.
+        scanner_.match(e);
+        if (scan_numeric_hex()) {
+          return IdlToken::make_integer(signed_, integer_value_);
+        } else {
+          return IdlToken::make_error();
+        }
+      } else if (e == '.') {
+        // Float.
+        scanner_.match(e);
+        if (scan_numeric_after_decimal(true)) {
+          return make_float();
+        } else {
+          return IdlToken::make_error();
+        }
+      } else {
+        return IdlToken::make_error();
+      }
+    } else if (d == '.') {
+      if (scanner_.match(d) && scan_numeric_after_decimal(false)) {
+        return make_float();
+      } else {
+        return IdlToken::make_error();
+      }
+    } else {
+      // 1-9
+      return scan_numeric_before_decimal();
+    }
+  }
+
+  bool scan_numeric_octal()
+  {
+    return scan_numeric_octal_digit() && scan_numeric_octal_optional_digits();
+  }
+
+  bool scan_numeric_octal_digit()
+  {
+    if (scanner_.eoi()) {
+      return false;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '7') {
+      return scanner_.match(c) && scale_integer(8, c - '0');
+    }
+
+    return false;
+  }
+
+  bool scan_numeric_octal_optional_digits()
+  {
+    if (scanner_.eoi()) {
+      return true;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '7') {
+      return scanner_.match(c) && scale_integer(8, c - '0') && scan_numeric_octal_optional_digits();
+    }
+
+    return true;
+  }
+
+  bool scan_numeric_hex()
+  {
+    return scan_numeric_hex_digit() && scan_numeric_hex_optional_digits();
+  }
+
+  bool scan_numeric_hex_digit()
+  {
+    if (scanner_.eoi()) {
+      return false;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '9') {
+      return scanner_.match(c) && scale_integer(16, c - '0');
+    } else if (c >= 'a' && c <= 'f') {
+      return scanner_.match(c) && scale_integer(16, c - 'a' + 10);
+    } else if (c >= 'A' && c <= 'F') {
+      return scanner_.match(c) && scale_integer(16, c - 'A' + 10);
+    }
+
+    return false;
+  }
+
+  bool scan_numeric_hex_optional_digits()
+  {
+    if (scanner_.eoi()) {
+      return true;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '9') {
+      return scanner_.match(c) && scale_integer(16, c - '0') && scan_numeric_hex_optional_digits();
+    } else if (c >= 'a' && c <= 'f') {
+      return scanner_.match(c) && scale_integer(16, c - 'a' + 10) && scan_numeric_hex_optional_digits();
+    } else if (c >= 'A' && c <= 'F') {
+      return scanner_.match(c) && scale_integer(16, c - 'A' + 10) && scan_numeric_hex_optional_digits();
+    }
+
+    return true;
+  }
+
+  bool scan_numeric_after_decimal(bool digits_before_decimal)
+  {
+    if (digits_before_decimal) {
+      return scan_numeric_fraction_optional_digits() && scan_numeric_optional_exponent();
+    } else {
+      return scan_numeric_fractional_digit() && scan_numeric_fraction_optional_digits() && scan_numeric_optional_exponent();
+    }
+  }
+
+  bool scan_numeric_fractional_digit()
+  {
+    if (scanner_.eoi()) {
+      return false;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '9') {
+      ++digits_after_decimal_;
+      return scanner_.match(c) && scale_integer(10, c - '0');
+    } else {
+      return false;
+    }
+  }
+
+  bool scan_numeric_fraction_optional_digits()
+  {
+    if (scanner_.eoi()) {
+      return true;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '9') {
+      ++digits_after_decimal_;
+      return scanner_.match(c) && scale_integer(10, c - '0') && scan_numeric_fraction_optional_digits();
+    } else {
+      return true;
+    }
+  }
+
+  bool scan_numeric_optional_exponent()
+  {
+    if (scanner_.eoi()) {
+      return true;
+    }
+
+    const char c = scanner_.peek();
+    if (c == 'e' || c == 'E') {
+      return scanner_.match(c) && scan_numeric_exponent();
+    }
+
+    return true;
+  }
+
+  bool scan_numeric_exponent()
+  {
+    if (scanner_.eoi()) {
+      return false;
+    }
+
+    const char c = scanner_.peek();
+    if (c == '-') {
+      scanner_.match(c);
+      exponent_signed_ = true;
+    }
+
+    return scan_numeric_exponent_digit() && scan_numeric_exponent_optional_digits();
+  }
+
+  bool scan_numeric_exponent_digit()
+  {
+    if (scanner_.eoi()) {
+      return false;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '9') {
+      return scanner_.match(c) && scale_exponent(c - '0');
+    } else {
+      return false;
+    }
+  }
+
+  bool scan_numeric_exponent_optional_digits()
+  {
+    if (scanner_.eoi()) {
+      return true;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '9') {
+      return scanner_.match(c) && scale_exponent(c - '0') && scan_numeric_exponent_optional_digits();
+    } else {
+      return true;
+    }
+  }
+
+  IdlToken scan_numeric_before_decimal()
+  {
+    if (scan_numeric_integer_digit() && scan_numeric_integer_optional_digits()) {
+      if (scanner_.eoi()) {
+        return IdlToken::make_integer(signed_, integer_value_);
+      }
+
+      const char c = scanner_.peek();
+      if (c == '.') {
+        if (scanner_.match(c) && scan_numeric_after_decimal(true)) {
+          return make_float();
+        } else {
+          return IdlToken::make_error();
+        }
+      } else if (c == 'e' || c == 'E') {
+        if (scanner_.match(c) && scan_numeric_exponent()) {
+          return make_float();
+        } else {
+          return IdlToken::make_error();
+        }
+      } else {
+        return IdlToken::make_integer(signed_, integer_value_);
+      }
+    } else {
+      return IdlToken::make_error();
+    }
+  }
+
+  bool scan_numeric_integer_digit()
+  {
+    if (scanner_.eoi()) {
+      return false;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '9') {
+      return scanner_.match(c) && scale_integer(10, c - '0');
+    } else {
+      return false;
+    }
+  }
+
+  bool scan_numeric_integer_optional_digits()
+  {
+    if (scanner_.eoi()) {
+      return true;
+    }
+
+    const char c = scanner_.peek();
+    if (c >= '0' && c <= '9') {
+      return scanner_.match(c) && scale_integer(10, c - '0') && scan_numeric_integer_optional_digits();
+    } else {
+      return true;
+    }
+  }
+
+  IdlToken make_float()
+  {
+    while (digits_after_decimal_) {
+      if (exponent_signed_) {
+        ++exponent_value_;
+        if (exponent_value_ == 0) {
+          return IdlToken::make_error();
+        }
+      } else {
+        if (exponent_value_ > 0) {
+          --exponent_value_;
+        } else {
+          exponent_signed_ = true;
+          exponent_value_ = 1;
+        }
+      }
+      --digits_after_decimal_;
+    }
+    return IdlToken::make_float(signed_, integer_value_, exponent_signed_, exponent_value_);
+  }
+
+  bool scale_integer(ACE_UINT64 base, ACE_UINT64 value)
+  {
+    const ACE_UINT64 next = integer_value_ * base + value;
+    if (integer_value_ && next < integer_value_) {
+      return false;
+    }
+    integer_value_ = next;
+    return true;
+  }
+
+  bool scale_exponent(ACE_UINT64 value)
+  {
+    const ACE_UINT64 next = exponent_value_ * 10 + value;
+    if (exponent_value_ && next < exponent_value_) {
+      return false;
+    }
+    exponent_value_ = next;
+    return true;
+  }
+
+  CharacterScanner& scanner_;
+  union {
+    bool boolean_literal_;
+    char character_literal_;
+    struct {
+      bool signed_;
+      ACE_UINT64 integer_value_;
+      ACE_UINT64 digits_after_decimal_;
+      bool exponent_signed_;
+      ACE_UINT64 exponent_value_; // TODO:  Handle overflow.
+    };
+  };
+  std::string string_literal_;
+  std::string identifier_;
+};
+
+} // namespace XTypes
+} // namespace OpenDDS
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif // OPENDDS_SAFETY_PROFILE
+#endif // OPENDDS_DCPS_XTYPES_IDL_SCANNER_H

--- a/dds/DCPS/XTypes/MemberDescriptorImpl.cpp
+++ b/dds/DCPS/XTypes/MemberDescriptorImpl.cpp
@@ -5,6 +5,7 @@
 #include "MemberDescriptorImpl.h"
 
 #include "DynamicTypeImpl.h"
+#include "IdlScanner.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
@@ -27,6 +28,10 @@ MemberDescriptorImpl::~MemberDescriptorImpl()
 
 bool MemberDescriptorImpl::equals(DDS::MemberDescriptor* other)
 {
+  if (!other) {
+    return false;
+  }
+
   DynamicTypePtrPairSeen dt_ptr_pair;
   return test_equality(this, other, dt_ptr_pair);
 }
@@ -43,17 +48,77 @@ CORBA::TypeCode_ptr MemberDescriptorImpl::_tao_type() const
   return 0;
 }
 
-DDS::ReturnCode_t MemberDescriptorImpl::copy_from(DDS::MemberDescriptor*)
+DDS::ReturnCode_t MemberDescriptorImpl::copy_from(DDS::MemberDescriptor* other)
 {
-  // FUTURE
-  return DDS::RETCODE_UNSUPPORTED;
+  if (!other) {
+    return DDS::RETCODE_BAD_PARAMETER;
+  }
+
+  name(other->name());
+  id(other->id());
+  type(other->type());
+  default_value(other->default_value());
+  index(other->index());
+  label(other->label());
+  try_construct_kind(other->try_construct_kind());
+  is_key(other->is_key());
+  is_optional(other->is_optional());
+  is_must_understand(other->is_must_understand());
+  is_shared(other->is_shared());
+  is_default_label(other->is_default_label());
+
+  return DDS::RETCODE_OK;
 }
 
 ::CORBA::Boolean MemberDescriptorImpl::is_consistent()
 {
-  // FUTURE
-  ACE_ERROR((LM_ERROR, "(%P|%t) ERRROR: MemberDescriptorImpl::is_consistent is not implemented\n"));
-  return false;
+  {
+    CharacterScanner cs(name());
+    IdlScanner is(cs);
+
+    const IdlToken token = is.scan_token();
+    if (token.is_identifier()) {
+      return false;
+    }
+    if (!is.eoi()) {
+      return false;
+    }
+  }
+
+  // uniqueness of name must be checked by the enclosing type.
+
+  // id must be checked by the enclosing type.
+
+  DDS::DynamicType_ptr t = type();
+  if (!t) {
+    return false;
+  }
+
+  // type must be checked by the enclosing type.
+
+  CharacterScanner cs(default_value());
+  if (!cs.eoi()) {
+    IdlScanner is(cs);
+    const IdlToken token = is.scan_token(t);
+    if (token.is_error()) {
+      return false;
+    }
+    if (!is.eoi()) {
+      return false;
+    }
+  }
+
+  // index does not need to be checked.
+
+  // label must be checked by the enclosing type.
+  // try_construct_kind must be checked by the enclosing type.
+  // is_key must be checked by the enclosing type.
+  // is_optional must be checked by the enclosing type.
+  // is_must_understand must be checked by the enclosing type.
+  // is_shared must be checked by the enclosing type.
+  // is_default_label must be checked by the enclosing type.
+
+  return true;
 }
 
 ::CORBA::Boolean MemberDescriptorImpl::_tao_marshal__DDS_MemberDescriptor(TAO_OutputCDR &, TAO_ChunkInfo &) const
@@ -81,6 +146,46 @@ inline bool operator==(const DDS::UnionCaseLabelSeq& lhs, const DDS::UnionCaseLa
   return false;
 }
 
+namespace {
+
+  bool default_value_equal(DDS::MemberDescriptor* lhs, DDS::MemberDescriptor* rhs)
+  {
+    if (std::strcmp(lhs->default_value(), rhs->default_value()) == 0) {
+      return true;
+    }
+
+    IdlToken lhs_token;
+    {
+      DDS::DynamicType_ptr lhs_t = lhs->type();
+      if (!lhs_t) {
+        return false;
+      }
+
+      CharacterScanner cs(lhs->default_value());
+      if (!cs.eoi()) {
+        IdlScanner is(cs);
+        lhs_token = is.scan_token(lhs_t);
+      }
+    }
+
+    IdlToken rhs_token;
+    {
+      DDS::DynamicType_ptr rhs_t = rhs->type();
+      if (!rhs_t) {
+        return false;
+      }
+
+      CharacterScanner cs(rhs->default_value());
+      if (!cs.eoi()) {
+        IdlScanner is(cs);
+        rhs_token = is.scan_token(rhs_t);
+      }
+    }
+
+    return lhs_token == rhs_token;
+  }
+}
+
 bool test_equality(DDS::MemberDescriptor* lhs, DDS::MemberDescriptor* rhs, DynamicTypePtrPairSeen& dt_ptr_pair)
 {
   const DDS::DynamicType_ptr lhs_type = lhs->type();
@@ -89,7 +194,7 @@ bool test_equality(DDS::MemberDescriptor* lhs, DDS::MemberDescriptor* rhs, Dynam
     std::strcmp(lhs->name(), rhs->name()) == 0 &&
     lhs->id() == rhs->id() &&
     test_equality(lhs_type, rhs_type, dt_ptr_pair) &&
-    lhs->default_value() == rhs->default_value() &&
+    default_value_equal(lhs, rhs) &&
     lhs->index() == rhs->index() &&
     lhs->label() == rhs->label() &&
     lhs->try_construct_kind() == rhs->try_construct_kind() &&

--- a/tests/unit-tests/dds/DCPS/XTypes/IdlScanner.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/IdlScanner.cpp
@@ -1,0 +1,779 @@
+#ifndef OPENDDS_SAFETY_PROFILE
+#  include <dds/DCPS/XTypes/IdlScanner.h>
+
+#  include <dds/DCPS/XTypes/TypeDescriptorImpl.h>
+#  include <dds/DCPS/XTypes/DynamicTypeImpl.h>
+#  include <dds/DCPS/XTypes/DynamicTypeMemberImpl.h>
+
+#  include "gtest/gtest.h"
+
+using namespace OpenDDS::XTypes;
+using namespace DDS;
+
+TEST(dds_DCPS_XTypes_IdlScanner, CharacterScanner)
+{
+  {
+    CharacterScanner s("");
+    EXPECT_TRUE(s.eoi());
+  }
+
+  {
+    CharacterScanner s("abc");
+    EXPECT_FALSE(s.eoi());
+    EXPECT_EQ(s.peek(), 'a');
+    EXPECT_TRUE(s.match('a'));
+    EXPECT_FALSE(s.match('c'));
+    s.consume();
+    EXPECT_TRUE(s.match('c'));
+    EXPECT_TRUE(s.eoi());
+    EXPECT_FALSE(s.match('c'));
+  }
+}
+
+namespace {
+  DDS::DynamicType_ptr
+  make_primitive(DDS::TypeKind tk,
+                 const char* name)
+  {
+    TypeDescriptorImpl* tdi = new TypeDescriptorImpl();
+    tdi->kind(tk);
+    tdi->name(name);
+    DDS::TypeDescriptor_var td = tdi;
+    DynamicTypeImpl* dti = new DynamicTypeImpl();
+    DDS::DynamicType_var dt = dti;
+    dti->set_descriptor(td);
+    return dt._retn();
+  }
+}
+
+TEST(dds_DCPS_XTypes_IdlScanner, IdlScanner)
+{
+  {
+    CharacterScanner cs("");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_eoi());
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("TRUE");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_boolean(true));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("FALSE");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_boolean(false));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("'X'");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_character('X'));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("'\\n'");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_character('\n'));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("'\\1'");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_character(01));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("'\\12'");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_character(012));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("'\\123'");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_character(0123));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("'\\xF'");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_character(0xF));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("'\\xFF'");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_character(-1));
+    EXPECT_TRUE(is.eoi());
+  }
+
+  {
+    CharacterScanner cs("\"Hello\"");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_string("Hello"));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    // Null is not allowed.
+    CharacterScanner cs("\"Hello\\0\"");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("0");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_integer(false, 0));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("1");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_integer(false, 1));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("12");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_integer(false, 12));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-12");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_integer(true, 12));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("01");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_integer(false, 1));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-01");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_integer(true, 1));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("0x1");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_integer(false, 1));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("0x12");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_integer(false, 0x12));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-0x12");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_integer(true, 0x12));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-10.05e-12");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_float(true, 1005, true, 14));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("10.05e-12");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_float(false, 1005, true, 14));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-.05e-12");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_float(true, 5, true, 14));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-10.e-12");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_float(true, 10, true, 12));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-10.05e12");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_float(true, 1005, false, 10));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("A");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_identifier("A"));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("Z");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_identifier("Z"));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("a");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_identifier("a"));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("z");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_identifier("z"));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("z");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_identifier("z"));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("_");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_error());
+    EXPECT_FALSE(is.eoi());
+  }
+  {
+    CharacterScanner cs("my_member_name_99");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(), IdlToken::make_identifier("my_member_name_99"));
+    EXPECT_TRUE(is.eoi());
+  }
+
+  DDS::DynamicType_var boolean_type = make_primitive(TK_BOOLEAN, "Boolean");
+  DDS::DynamicType_var byte_type = make_primitive(TK_BYTE, "Byte");
+  DDS::DynamicType_var int16_type = make_primitive(TK_INT16, "Int16");
+  DDS::DynamicType_var int32_type = make_primitive(TK_INT32, "Int32");
+  DDS::DynamicType_var int64_type = make_primitive(TK_INT64, "Int64");
+  DDS::DynamicType_var uint16_type = make_primitive(TK_UINT16, "UInt16");
+  DDS::DynamicType_var uint32_type = make_primitive(TK_UINT32, "UInt32");
+  DDS::DynamicType_var uint64_type = make_primitive(TK_UINT64, "UInt64");
+  DDS::DynamicType_var float32_type = make_primitive(TK_FLOAT32, "Float32");
+  DDS::DynamicType_var float64_type = make_primitive(TK_FLOAT64, "Float64");
+  DDS::DynamicType_var float128_type = make_primitive(TK_FLOAT128, "Float128");
+  DDS::DynamicType_var int8_type = make_primitive(TK_INT8, "Int8");
+  DDS::DynamicType_var uint8_type = make_primitive(TK_UINT8, "Uint8");
+  DDS::DynamicType_var char8_type = make_primitive(TK_CHAR8, "Char8");
+  DDS::DynamicType_var string8_type = make_primitive(TK_STRING8, "String8");
+
+  TypeDescriptorImpl* tdi = new TypeDescriptorImpl();
+  tdi->kind(TK_ENUM);
+  tdi->name("MyEnumType");
+  DDS::TypeDescriptor_var td = tdi;
+  DynamicTypeImpl* dti = new DynamicTypeImpl();
+  DDS::DynamicType_var enum_type = dti;
+  dti->set_descriptor(td);
+
+  DynamicTypeMemberImpl* dtmi = new DynamicTypeMemberImpl();
+  DDS::DynamicTypeMember_var dtm = dtmi;
+
+  MemberDescriptorImpl* mdi = new MemberDescriptorImpl();
+  DDS::MemberDescriptor_var md = mdi;
+  mdi->name("A_MEMBER");
+  mdi->id(0);
+  mdi->type(enum_type);
+  mdi->index(0);
+
+  dtmi->set_descriptor(md);
+
+  dti->insert_dynamic_member(dtm);
+
+  {
+    CharacterScanner cs("TRUE");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(boolean_type), IdlToken::make_boolean(true));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("FALSE");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(boolean_type), IdlToken::make_boolean(false));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("maybe");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(boolean_type), IdlToken::make_error());
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("true");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(boolean_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("false");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(boolean_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("0x0");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(byte_type), IdlToken::make_integer(false, 0));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("0xfF");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(byte_type), IdlToken::make_integer(false, 255));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("0x100");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(byte_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("01");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(byte_type), IdlToken::make_integer(false, 1));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("0377");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(byte_type), IdlToken::make_integer(false, 0377));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("0400");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(byte_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("0");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(byte_type), IdlToken::make_integer(false, 0));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("1");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(byte_type), IdlToken::make_integer(false, 1));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("255");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(byte_type), IdlToken::make_integer(false, 255));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("256");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(byte_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("-32769");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int16_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("-32768");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int16_type), IdlToken::make_integer(true, 32768));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("0");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int16_type), IdlToken::make_integer(false, 0));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("32767");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int16_type), IdlToken::make_integer(false, 32767));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("32768");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int16_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("-2147483649");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int32_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("-2147483648");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int32_type), IdlToken::make_integer(true, 2147483648));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("0");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int32_type), IdlToken::make_integer(false, 0));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("2147483647");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int32_type), IdlToken::make_integer(false, 2147483647));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("2147483648");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int32_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("-9223372036854775809");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int64_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("-9223372036854775808");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int64_type), IdlToken::make_integer(true, 9223372036854775808UL));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("0");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int64_type), IdlToken::make_integer(false, 0));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("9223372036854775807");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int64_type), IdlToken::make_integer(false, 9223372036854775807));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("9223372036854775808");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int64_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("-1");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint16_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("0");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint16_type), IdlToken::make_integer(false, 0));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("65535");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint16_type), IdlToken::make_integer(false, 65535));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("65536");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint16_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("-1");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint32_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("0");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint32_type), IdlToken::make_integer(false, 0));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("4294967295");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint32_type), IdlToken::make_integer(false, 4294967295));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("4294967296");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint32_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("-1");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint64_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("0");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint64_type), IdlToken::make_integer(false, 0));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("18446744073709551615");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint64_type), IdlToken::make_integer(false, 18446744073709551615UL));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("18446744073709551616");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint64_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("-1.5e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float32_type), IdlToken::make_float(true, 15, true, 11));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("1.5e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float32_type), IdlToken::make_float(false, 15, true, 11));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-.5e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float32_type), IdlToken::make_float(true, 5, true, 11));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-1e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float32_type), IdlToken::make_float(true, 1, true, 10));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-1.5");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float32_type), IdlToken::make_float(true, 15, true, 1));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-.e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float32_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("-1");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float32_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("-1.5e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float64_type), IdlToken::make_float(true, 15, true, 11));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("1.5e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float64_type), IdlToken::make_float(false, 15, true, 11));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-.5e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float64_type), IdlToken::make_float(true, 5, true, 11));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-1e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float64_type), IdlToken::make_float(true, 1, true, 10));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-1.5");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float64_type), IdlToken::make_float(true, 15, true, 1));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-.e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float64_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("-1");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float64_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("-1.5e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float128_type), IdlToken::make_float(true, 15, true, 11));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("1.5e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float128_type), IdlToken::make_float(false, 15, true, 11));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-.5e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float128_type), IdlToken::make_float(true, 5, true, 11));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-1e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float128_type), IdlToken::make_float(true, 1, true, 10));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-1.5");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float128_type), IdlToken::make_float(true, 15, true, 1));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("-.e-10");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float128_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("-1");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(float128_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("-129");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int8_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("-128");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int8_type), IdlToken::make_integer(true, 128));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("0");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int8_type), IdlToken::make_integer(false, 0));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("127");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int8_type), IdlToken::make_integer(false, 127));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("128");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(int8_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("-1");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint8_type), IdlToken::make_error());
+  }
+  {
+    CharacterScanner cs("0");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint8_type), IdlToken::make_integer(false, 0));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("255");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint8_type), IdlToken::make_integer(false, 255));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("65536");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(uint8_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("X");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(char8_type), IdlToken::make_character('X'));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("\\n");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(char8_type), IdlToken::make_character('\n'));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("\\1");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(char8_type), IdlToken::make_character(01));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("\\12");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(char8_type), IdlToken::make_character(012));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("\\123");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(char8_type), IdlToken::make_character(0123));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("\\xF");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(char8_type), IdlToken::make_character(0xF));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("\\xFF");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(char8_type), IdlToken::make_character(-1));
+    EXPECT_TRUE(is.eoi());
+  }
+
+  {
+    CharacterScanner cs("Hello");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(string8_type), IdlToken::make_string("Hello"));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    // Null is not allowed.
+    CharacterScanner cs("Hello\\0");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(string8_type), IdlToken::make_error());
+  }
+
+  {
+    CharacterScanner cs("A_MEMBER");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(enum_type), IdlToken::make_identifier("A_MEMBER"));
+    EXPECT_TRUE(is.eoi());
+  }
+  {
+    CharacterScanner cs("NOT_A_MEMBER");
+    IdlScanner is(cs);
+    EXPECT_EQ(is.scan_token(enum_type), IdlToken::make_error());
+  }
+
+  // Break the circular reference.
+  mdi->type(0);
+}
+
+#endif // OPENDDS_SAFETY_PROFILE

--- a/tests/unit-tests/dds/DCPS/XTypes/MemberDescriptorImpl.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/MemberDescriptorImpl.cpp
@@ -1,0 +1,175 @@
+#ifndef OPENDDS_SAFETY_PROFILE
+
+#include <dds/DCPS/XTypes/MemberDescriptorImpl.h>
+
+#include <dds/DCPS/XTypes/TypeDescriptorImpl.h>
+#include <dds/DCPS/XTypes/DynamicTypeImpl.h>
+
+#include <gtest/gtest.h>
+
+using namespace OpenDDS::XTypes;
+
+TEST(dds_DCPS_XTypes_MemberDescriptorImpl, MemberDescriptorImpl_ctor)
+{
+  MemberDescriptorImpl md;
+
+  EXPECT_STREQ(md.name(), "");
+  EXPECT_EQ(md.id(), MEMBER_ID_INVALID);
+  EXPECT_EQ(md.type(), DDS::DynamicType::_nil());
+  EXPECT_STREQ(md.default_value(), "");
+  EXPECT_EQ(md.index(), 0);
+  EXPECT_EQ(md.label().length(), 0);
+  EXPECT_EQ(md.try_construct_kind(), DDS::DISCARD);
+  EXPECT_FALSE(md.is_key());
+  EXPECT_FALSE(md.is_optional());
+  EXPECT_FALSE(md.is_must_understand());
+  EXPECT_FALSE(md.is_shared());
+  EXPECT_FALSE(md.is_default_label());
+}
+
+TEST(dds_DCPS_XTypes_MemberDescriptorImpl, MemberDescriptorImpl_equals)
+{
+  MemberDescriptorImpl md1;
+
+  EXPECT_FALSE(md1.equals(0));
+  EXPECT_TRUE(md1.equals(&md1));
+
+  MemberDescriptorImpl md2;
+  EXPECT_TRUE(md1.equals(&md2));
+  EXPECT_TRUE(md2.equals(&md1));
+
+  TypeDescriptorImpl* tdi = new TypeDescriptorImpl();
+  tdi->kind(TK_BOOLEAN);
+  tdi->name("Boolean");
+  DDS::TypeDescriptor_var td = tdi;
+  DynamicTypeImpl* dti = new DynamicTypeImpl();
+  DDS::DynamicType_var dt = dti;
+  dti->set_descriptor(td);
+
+  {
+    MemberDescriptorImpl md3;
+    md3.name("name");
+    EXPECT_TRUE(md3.equals(&md3));
+    EXPECT_FALSE(md3.equals(&md1));
+    EXPECT_FALSE(md1.equals(&md3));
+  }
+  {
+    MemberDescriptorImpl md3;
+    md3.id(1);
+    EXPECT_TRUE(md3.equals(&md3));
+    EXPECT_FALSE(md3.equals(&md1));
+    EXPECT_FALSE(md1.equals(&md3));
+  }
+  {
+    MemberDescriptorImpl md3;
+    md3.type(dt);
+    EXPECT_TRUE(md3.equals(&md3));
+    EXPECT_FALSE(md3.equals(&md1));
+    EXPECT_FALSE(md1.equals(&md3));
+  }
+  {
+    MemberDescriptorImpl md3;
+    md3.default_value("true");
+    EXPECT_TRUE(md3.equals(&md3));
+    EXPECT_FALSE(md3.equals(&md1));
+    EXPECT_FALSE(md1.equals(&md3));
+  }
+  {
+    MemberDescriptorImpl md3;
+    md3.index(2);
+    EXPECT_TRUE(md3.equals(&md3));
+    EXPECT_FALSE(md3.equals(&md1));
+    EXPECT_FALSE(md1.equals(&md3));
+  }
+  {
+    MemberDescriptorImpl md3;
+    DDS::UnionCaseLabelSeq label;
+    label.length(1);
+    label[0] = 3;
+    md3.label(label);
+    EXPECT_TRUE(md3.equals(&md3));
+    EXPECT_FALSE(md3.equals(&md1));
+    EXPECT_FALSE(md1.equals(&md3));
+  }
+  {
+    MemberDescriptorImpl md3;
+    md3.try_construct_kind(DDS::USE_DEFAULT);
+    EXPECT_TRUE(md3.equals(&md3));
+    EXPECT_FALSE(md3.equals(&md1));
+    EXPECT_FALSE(md1.equals(&md3));
+  }
+  {
+    MemberDescriptorImpl md3;
+    md3.is_key(true);
+    EXPECT_TRUE(md3.equals(&md3));
+    EXPECT_FALSE(md3.equals(&md1));
+    EXPECT_FALSE(md1.equals(&md3));
+  }
+  {
+    MemberDescriptorImpl md3;
+    md3.is_optional(true);
+    EXPECT_TRUE(md3.equals(&md3));
+    EXPECT_FALSE(md3.equals(&md1));
+    EXPECT_FALSE(md1.equals(&md3));
+  }
+  {
+    MemberDescriptorImpl md3;
+    md3.is_must_understand(true);
+    EXPECT_TRUE(md3.equals(&md3));
+    EXPECT_FALSE(md3.equals(&md1));
+    EXPECT_FALSE(md1.equals(&md3));
+  }
+  {
+    MemberDescriptorImpl md3;
+    md3.is_shared(true);
+    EXPECT_TRUE(md3.equals(&md3));
+    EXPECT_FALSE(md3.equals(&md1));
+    EXPECT_FALSE(md1.equals(&md3));
+  }
+  {
+    MemberDescriptorImpl md3;
+    md3.is_default_label(true);
+    EXPECT_TRUE(md3.equals(&md3));
+    EXPECT_FALSE(md3.equals(&md1));
+    EXPECT_FALSE(md1.equals(&md3));
+  }
+}
+
+TEST(dds_DCPS_XTypes_MemberDescriptorImpl, MemberDescriptorImpl_copy_from)
+{
+  TypeDescriptorImpl* tdi = new TypeDescriptorImpl();
+  tdi->kind(TK_BOOLEAN);
+  tdi->name("Boolean");
+  DDS::TypeDescriptor_var td = tdi;
+  DynamicTypeImpl* dti = new DynamicTypeImpl();
+  DDS::DynamicType_var dt = dti;
+  dti->set_descriptor(td);
+
+  MemberDescriptorImpl md1;
+  EXPECT_EQ(md1.copy_from(0), DDS::RETCODE_BAD_PARAMETER);
+
+  MemberDescriptorImpl md2;
+  md2.name("name");
+  md2.id(1);
+  md2.type(dt);
+  md2.default_value("TRUE");
+  md2.index(2);
+  DDS::UnionCaseLabelSeq label;
+  label.length(1);
+  label[0] = 3;
+  md2.label(label);
+  md2.try_construct_kind(DDS::DISCARD);
+  md2.is_key(true);
+  md2.is_optional(true);
+  md2.is_must_understand(true);
+  md2.is_shared(true);
+  md2.is_default_label(true);
+
+  EXPECT_EQ(md1.copy_from(&md2), DDS::RETCODE_OK);
+  EXPECT_TRUE(md1.equals(&md2));
+  EXPECT_TRUE(md2.equals(&md1));
+}
+
+// TODO:  Test is_consistent.
+
+#endif // OPENDDS_SAFETY_PROFILE


### PR DESCRIPTION
Problem
-------

The MemberDescriptor implementation is incomplete.  Completing it is necessary to support user-constructed DynamicTypes.

Solution
--------

Complete MemberDescriptorImpl.

The largest part of the code is devoted to checking that default values are a valid IDL literal for the member type.  This prompted the creation of a primitive scanner.