### PR TITLE
Init Union Branch in `DynamicData` `copy`

### DIFF
--- a/dds/DCPS/XTypes/DynamicDataAdapter.h
+++ b/dds/DCPS/XTypes/DynamicDataAdapter.h
@@ -58,10 +58,9 @@ class DynamicDataAdapterImpl;
  *   - Part of this is accessing all types as complex value.
  * - Implement equals, clear_value, clear_all_values, and clear_nonkey_values
  * - Respect bounds of strings and sequences.
- * - Implement way for unions branch to initialized with a default value so
- *   get_complex_value works like DynamicDataImpl if there is no selected
- *   branch. This might be able to be done in either code generation of
- *   DynamicDataAdapterImpl or maybe purely in terms of DynamicDataAdapter.
+ * - Add a way to check if using get_complex_value on a complex member of a
+ *   union that isn't selected. Doing this will cause a segfault. It should
+ *   return DDS::PRECONDITION_NOT_MET.
  */
 class OpenDDS_Dcps_Export DynamicDataAdapter : public DynamicDataBase {
 public:

--- a/dds/DCPS/XTypes/DynamicDataImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataImpl.cpp
@@ -2120,7 +2120,7 @@ bool DynamicDataImpl::set_complex_to_union(DDS::MemberId id, DDS::DynamicData_va
     return false;
   }
   const DDS::DynamicType_var value_type = value->type();
-  if (get_base_type(md->type())->equals(value_type)) {
+  if (!get_base_type(md->type())->equals(value_type)) {
     return false;
   }
 

--- a/dds/DCPS/XTypes/Utils.cpp
+++ b/dds/DCPS/XTypes/Utils.cpp
@@ -1382,7 +1382,7 @@ DDS::ReturnCode_t copy_member(
       get_rc = src->get_complex_value(subsrc, src_id);
       if (get_rc == DDS::RETCODE_OK) {
         DDS::DynamicType_var parent_dest_type = get_base_type(dest_type);
-        if (parent_dest_type->get_kind() == TK_UNION && dest_id != DISCRIMINATOR_ID) {
+        if (parent_dest_type->get_kind() == TK_UNION) {
           DDS::DynamicData_var temp = new DynamicDataImpl(use_dest_type);
           set_rc = dest->set_complex_value(dest_id, temp);
         }

--- a/dds/DCPS/XTypes/Utils.cpp
+++ b/dds/DCPS/XTypes/Utils.cpp
@@ -1381,10 +1381,17 @@ DDS::ReturnCode_t copy_member(
       DDS::DynamicData_var subsrc;
       get_rc = src->get_complex_value(subsrc, src_id);
       if (get_rc == DDS::RETCODE_OK) {
-        DDS::DynamicData_var subdest;
-        get_rc = dest->get_complex_value(subdest, dest_id);
-        if (get_rc == DDS::RETCODE_OK) {
-          set_rc = copy(subdest, subsrc);
+        DDS::DynamicType_var parent_dest_type = get_base_type(dest_type);
+        if (parent_dest_type->get_kind() == TK_UNION && dest_id != DISCRIMINATOR_ID) {
+          DDS::DynamicData_var temp = new DynamicDataImpl(use_dest_type);
+          set_rc = dest->set_complex_value(dest_id, temp);
+        }
+        if (set_rc == DDS::RETCODE_OK) {
+          DDS::DynamicData_var subdest;
+          get_rc = dest->get_complex_value(subdest, dest_id);
+          if (get_rc == DDS::RETCODE_OK) {
+            set_rc = copy(subdest, subsrc);
+          }
         }
       }
     }

--- a/tests/unit-tests/dds/DCPS/XTypes/DynamicDataAdapter.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/DynamicDataAdapter.cpp
@@ -341,14 +341,13 @@ TEST_F(dds_DCPS_XTypes_DynamicDataAdapter, test_union)
       ASSERT_EQ(tu.simple_struct().value, 1u);
     }
   }
-  /* TODO: TestUnion::simple_union in IDL
   {
     DDS::DynamicData_var ddi = DDS::DynamicDataFactory::get_instance()->create_data(dt);
     {
       SimpleUnion su;
       su.value(1);
       TestUnion tu;
-      tu.simple_struct(su);
+      tu.simple_union(su);
       DDS::DynamicData_var dda = get_dynamic_data_adapter(dt, tu);
       ASSERT_RC_OK(copy(ddi, dda));
     }
@@ -359,7 +358,6 @@ TEST_F(dds_DCPS_XTypes_DynamicDataAdapter, test_union)
       ASSERT_EQ(tu.simple_union().value(), 1u);
     }
   }
-  */
 }
 
 #  else // (No DynamicDataAdapter)

--- a/tests/unit-tests/dds/DCPS/XTypes/DynamicDataAdapter.idl
+++ b/tests/unit-tests/dds/DCPS/XTypes/DynamicDataAdapter.idl
@@ -295,11 +295,8 @@ case TypeEnum:
   EnumType enum_type;
 case TypeStruct:
   SimpleStruct simple_struct;
-/* TODO: This casues a segfault. DynamicDataAdapter needs a way to intialize
- branchs with default values.
 case TypeUnion:
   SimpleUnion simple_union;
-*/
 };
 
 @topic


### PR DESCRIPTION
This was made in response to upcoming changes to make `DynamicDataImpl` unions work more like C++ unions in https://github.com/OpenDDS/OpenDDS/pull/4278. This also works around a problem in `DynamicDataAdaptor` when using `get_complex_value` on union branches that haven't been initialized.