### PR TITLE
Sync 3.26.1 News and Release Script Updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ Released 2023-11-14
 
 Download [this release on GitHub](https://github.com/OpenDDS/OpenDDS/releases/tag/DDS-3.26.1).
 
-Read [the documenation for this release on Read the Docs](https://opendds.readthedocs.io/en/dds-3.26.1).
+Read [the documentation for this release on Read the Docs](https://opendds.readthedocs.io/en/dds-3.26.1).
 
 ### Fixes
 
@@ -22,7 +22,7 @@ Released 2023-10-23
 
 Download [this release on GitHub](https://github.com/OpenDDS/OpenDDS/releases/tag/DDS-3.26).
 
-Read [the documenation for this release on Read the Docs](https://opendds.readthedocs.io/en/dds-3.26).
+Read [the documentation for this release on Read the Docs](https://opendds.readthedocs.io/en/dds-3.26).
 
 ### Additions
 
@@ -82,7 +82,7 @@ Released 2023-07-20
 
 Download [this release on GitHub](https://github.com/OpenDDS/OpenDDS/releases/tag/DDS-3.25).
 
-Read [the documenation for this release on Read the Docs](https://opendds.readthedocs.io/en/dds-3.25).
+Read [the documentation for this release on Read the Docs](https://opendds.readthedocs.io/en/dds-3.25).
 
 ### Additions
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # OpenDDS Releases
 
+## Version 3.26.1 of OpenDDS
+
+Released 2023-11-14
+
+Download [this release on GitHub](https://github.com/OpenDDS/OpenDDS/releases/tag/DDS-3.26.1).
+
+Read [the documenation for this release on Read the Docs](https://opendds.readthedocs.io/en/dds-3.26.1).
+
+### Fixes
+
+* Building with CMake
+    * Fixed [Issue #4328](https://github.com/OpenDDS/OpenDDS/issues/4328), where each run of CMake effectively always appended the MPC features to `default.features` in ACE. ([PR #4330](https://github.com/OpenDDS/OpenDDS/pull/4330))
+
+* Fixed a corner case in RTPS ParameterList parsing ([PR #4336](https://github.com/OpenDDS/OpenDDS/pull/4336))
+* Reject some types of invalid RTPS DataFrag submessages ([PR #4348](https://github.com/OpenDDS/OpenDDS/pull/4348))
+
 ## Version 3.26.0 of OpenDDS
 
 Released 2023-10-23

--- a/docs/news.d/_releases/v3.24.0.rst
+++ b/docs/news.d/_releases/v3.24.0.rst
@@ -2,7 +2,7 @@ Released 2023-04-11
 
 Download :ghrelease:`this release on GitHub <DDS-3.24>`.
 
-Read `the documenation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.24>`__.
+Read `the documentation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.24>`__.
 
 Additions
 =========

--- a/docs/news.d/_releases/v3.24.1.rst
+++ b/docs/news.d/_releases/v3.24.1.rst
@@ -2,7 +2,7 @@ Released 2023-04-22
 
 Download :ghrelease:`this release on GitHub <DDS-3.24.1>`.
 
-Read `the documenation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.24.1>`__.
+Read `the documentation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.24.1>`__.
 
 Fixes
 =====

--- a/docs/news.d/_releases/v3.24.2.rst
+++ b/docs/news.d/_releases/v3.24.2.rst
@@ -2,7 +2,7 @@ Released 2023-06-30
 
 Download :ghrelease:`this release on GitHub <DDS-3.24.2>`.
 
-Read `the documenation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.24.2>`__.
+Read `the documentation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.24.2>`__.
 
 Security
 ========

--- a/docs/news.d/_releases/v3.25.0.rst
+++ b/docs/news.d/_releases/v3.25.0.rst
@@ -2,7 +2,7 @@ Released 2023-07-20
 
 Download :ghrelease:`this release on GitHub <DDS-3.25>`.
 
-Read `the documenation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.25>`__.
+Read `the documentation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.25>`__.
 
 Additions
 =========

--- a/docs/news.d/_releases/v3.26.0.rst
+++ b/docs/news.d/_releases/v3.26.0.rst
@@ -2,7 +2,7 @@ Released 2023-10-23
 
 Download :ghrelease:`this release on GitHub <DDS-3.26>`.
 
-Read `the documenation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.26>`__.
+Read `the documentation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.26>`__.
 
 Additions
 =========

--- a/docs/news.d/_releases/v3.26.1.rst
+++ b/docs/news.d/_releases/v3.26.1.rst
@@ -1,0 +1,17 @@
+Released 2023-11-14
+
+Download :ghrelease:`this release on GitHub <DDS-3.26.1>`.
+
+Read `the documenation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.26.1>`__.
+
+Fixes
+=====
+
+- Building with CMake
+
+  - Fixed :ghissue:`4328`, where each run of CMake effectively always appended the MPC features to ``default.features`` in ACE. (:ghpr:`4330`)
+
+- Fixed a corner case in RTPS ParameterList parsing (:ghpr:`4336`)
+
+- Reject some types of invalid RTPS DataFrag submessages (:ghpr:`4348`)
+

--- a/docs/news.d/_releases/v3.26.1.rst
+++ b/docs/news.d/_releases/v3.26.1.rst
@@ -2,7 +2,7 @@ Released 2023-11-14
 
 Download :ghrelease:`this release on GitHub <DDS-3.26.1>`.
 
-Read `the documenation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.26.1>`__.
+Read `the documentation for this release on Read the Docs <https://opendds.readthedocs.io/en/dds-3.26.1>`__.
 
 Fixes
 =====

--- a/docs/news.d/cmake-features.rst
+++ b/docs/news.d/cmake-features.rst
@@ -1,7 +1,0 @@
-.. news-prs: 4330
-
-.. news-start-section: Fixes
-.. news-start-section: Building with CMake
-- Fixed :ghissue:`4328`, where each run of CMake effectively always appended the MPC features to ``default.features`` in ACE.
-.. news-end-section
-.. news-end-section

--- a/docs/news.d/rtps-badmsg.rst
+++ b/docs/news.d/rtps-badmsg.rst
@@ -1,6 +1,0 @@
-.. news-prs: 4348
-
-.. news-start-section: Fixes
-- Reject some types of invalid RTPS DataFrag submessages
-
-.. news-end-section

--- a/docs/news.d/rtps-parameterlist.rst
+++ b/docs/news.d/rtps-parameterlist.rst
@@ -1,6 +1,0 @@
-.. news-prs: 4336
-
-.. news-start-section: Fixes
-- Fixed a corner case in RTPS ParameterList parsing
-
-.. news-end-section

--- a/docs/sphinx_extensions/newsd.py
+++ b/docs/sphinx_extensions/newsd.py
@@ -62,7 +62,7 @@ class PrintHelper:
             print(line, file=self.file, **kw)
             self.printed_blank_line = blank
 
-    def put_level_seperator(self):
+    def put_level_separator(self):
         if not self.printed_blank_line:
             print(file=self.file)
             self.printed_blank_line = True
@@ -181,7 +181,7 @@ class Section(Node):
     def print(self, h):
         if self.empty():
             return
-        h.put_level_seperator()
+        h.put_level_separator()
         if self.level:
             if self.level == 1:
                 h.put(0, self.name)
@@ -189,11 +189,11 @@ class Section(Node):
                 h.put(0, self.rank_str(h))
             elif self.level > 1:
                 h.put(self.level - 1, '-', self.name, decorate=self.rank_str(h))
-            h.put_level_seperator()
+            h.put_level_separator()
         for child in sorted(self.children):
             child.print(h)
         if self.level:
-            h.put_level_seperator()
+            h.put_level_separator()
 
     def print_all(self, file=sys.stdout):
         version_info = VersionInfo()
@@ -202,7 +202,7 @@ class Section(Node):
             print((
                 'Released {}\n\n' +
                 'Download :ghrelease:`this release on GitHub <{}>`.\n\n' +
-                'Read `the documenation for this release on Read the Docs <https://opendds.readthedocs.io/en/{}>`__.'
+                'Read `the documentation for this release on Read the Docs <https://opendds.readthedocs.io/en/{}>`__.'
             ).format(today.isoformat(), version_info.tag, version_info.tag.lower()), file=file)
         else:
             print('This version is currently still in development, so this list might change.', file=file)
@@ -218,7 +218,7 @@ class Section(Node):
 def test_section():
     root = Section()
     a = root.get_section('Section A')
-    a.add_text(set([0]), ['- This is some text\n', '- This is a seperate item\n'])
+    a.add_text(set([0]), ['- This is some text\n', '- This is a separate item\n'])
     aa = a.get_section('Section AA')
     aa.add_text(set([3]), ['- This is some text\n  - This is some more\n'])
     aa.add_text(set([1]), ['- This is some text  \n  - This is some more\n'])
@@ -249,7 +249,7 @@ Section A
 [Rank 0]
 
 - This is some text (:ghpr:`0`) [Rank 0]
-- This is a seperate item (:ghpr:`0`) [Rank 0]
+- This is a separate item (:ghpr:`0`) [Rank 0]
 
 - Section AA [Rank 0]
 
@@ -321,7 +321,7 @@ def parse(root, path):
                             prs = set([int(pr) for pr in arg.split(' ')])
                     except ValueError:
                         raise ParseError(loc,
-                            'news-prs must be space seperated PR numbers or just "none"')
+                            'news-prs must be space-separated PR numbers or just "none"')
                     seen_prs = True
                 elif name == 'start-section':
                     if not seen_prs:


### PR DESCRIPTION
Added a small utility to cherry pick GitHub PRs to help prepare micro releases and fixed updating links in README for micro releases.