### PR TITLE
`TheParticipantFactory*` should return `NULL` for Missing Config File

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -404,10 +404,10 @@ Service_Participant::get_domain_participant_factory(int &argc,
       }
 
       if (config_fname.empty()) {
-        if (DCPS_debug_level) {
-          ACE_DEBUG((LM_NOTICE,
-                     ACE_TEXT("(%P|%t) NOTICE: not using file configuration - no configuration ")
-                     ACE_TEXT("file specified.\n")));
+        if (log_level >= LogLevel::Info) {
+          ACE_DEBUG((LM_INFO,
+                     "(%P|%t) INFO: Service_Participant::get_domain_participant_factory: "
+                     "no configuration file specified.\n"));
         }
 
       } else {
@@ -420,31 +420,33 @@ Service_Participant::get_domain_participant_factory(int &argc,
           config_fname = new_path;
         }
 
-        // Load configuration only if the configuration
-        // file exists.
-        FILE* in = ACE_OS::fopen(config_fname.c_str(),
-                                 ACE_TEXT("r"));
-
+        // Load configuration only if the configuration file exists.
+        FILE* const in = ACE_OS::fopen(config_fname.c_str(), ACE_TEXT("r"));
         if (!in) {
-          ACE_DEBUG((LM_WARNING,
-                     ACE_TEXT("(%P|%t) WARNING: not using file configuration - ")
-                     ACE_TEXT("can not open \"%s\" for reading. %p\n"),
-                     config_fname.c_str(), ACE_TEXT("fopen")));
+          if (log_level >= LogLevel::Error) {
+            ACE_ERROR((LM_ERROR,
+                       "(%P|%t) ERROR: Service_Participant::get_domain_participant_factory: "
+                       "could not find config file \"%s\": %p\n",
+                       config_fname.c_str(), ACE_TEXT("fopen")));
+          }
+          return DDS::DomainParticipantFactory::_nil();
 
         } else {
           ACE_OS::fclose(in);
 
-          if (DCPS_debug_level > 1) {
-            ACE_DEBUG((LM_NOTICE,
-                        ACE_TEXT("(%P|%t) NOTICE: Service_Participant::get_domain_participant_factory ")
-                        ACE_TEXT("Going to load configuration from <%s>\n"),
-                        config_fname.c_str()));
+          if (log_level >= LogLevel::Info) {
+            ACE_DEBUG((LM_INFO,
+                       "(%P|%t) INFO: Service_Participant::get_domain_participant_factory: "
+                       "Going to load configuration from <%s>\n",
+                       config_fname.c_str()));
           }
 
           if (this->load_configuration(config_fname) != 0) {
-            ACE_ERROR((LM_ERROR,
-                       ACE_TEXT("(%P|%t) ERROR: Service_Participant::get_domain_participant_factory: ")
-                       ACE_TEXT("load_configuration() failed.\n")));
+            if (log_level >= LogLevel::Error) {
+              ACE_ERROR((LM_ERROR,
+                         "(%P|%t) ERROR: Service_Participant::get_domain_participant_factory: "
+                         "load_configuration() failed.\n"));
+            }
             return DDS::DomainParticipantFactory::_nil();
           }
         }

--- a/docs/news.d/partfactnull.rst
+++ b/docs/news.d/partfactnull.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4372
+
+.. news-start-section: Notes
+- ``TheParticipantFactory*`` will now return a null pointer when ``DCPSConfigFile`` doesn't exist.
+.. news-end-section

--- a/tests/DCPS/SampleLost/run_test.pl
+++ b/tests/DCPS/SampleLost/run_test.pl
@@ -17,7 +17,7 @@ PerlDDS::add_lib_path('../ConsolidatedMessengerIdl');
 my $test = new PerlDDS::TestFramework();
 $test->setup_discovery();
 
-my $pubsub_opts = "-DCPSConfigFile pub.ini";
+my $pubsub_opts = "-DCPSConfigFile pubsub.ini";
 
 while (scalar @ARGV) {
   if ($ARGV[0] =~ /^-d/i) {


### PR DESCRIPTION
Right now it issues a warning and uses a default configuration. With this it logs an error and returns `NULL`. Also corrected other logging to match guidelines.