### PR TITLE
index is not generated for GHA builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -326,7 +326,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -825,7 +825,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config SAFETY_EXTENDED -Config OPENDDS_SAFETY_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config DDS_NO_MULTI_TOPIC -Config DDS_NO_QUERY_CONDITION -Config DDS_NO_OWNERSHIP_KIND_EXCLUSIVE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS_OPENDDS_SAFETY_PROFILE -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/build/target/${{ github.job }}_autobuild_workspace/config.xml"
@@ -1157,7 +1157,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config SAFETY_BASE -Config OPENDDS_SAFETY_PROFILE -Config NO_BUILT_IN_TOPICS -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_CONTENT_FILTERED_TOPIC -Config DDS_NO_MULTI_TOPIC -Config DDS_NO_QUERY_CONDITION -Config DDS_NO_OWNERSHIP_KIND_EXCLUSIVE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config GH_ACTIONS_OPENDDS_SAFETY_PROFILE -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/build/target/${{ github.job }}_autobuild_workspace/config.xml"
@@ -1440,7 +1440,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config XERCES3 -Config WCHAR -Config CXX11 -Config OPENDDS_SECURITY -Config NO_BUILT_IN_TOPICS -Config DDS_NO_CONTENT_SUBSCRIPTION -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config NO_UNIT_TESTS --security --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -1743,7 +1743,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -2044,7 +2044,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake -Config OPENDDS_TESTING_FEATURES"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -2342,7 +2342,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -2634,7 +2634,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -2916,7 +2916,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -3424,7 +3424,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config WIRESHARK --java --modeling --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -3728,7 +3728,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON --security -Config GH_ACTIONS_ASAN --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -4022,7 +4022,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON --no-dcps tests/tsan_tests.lst"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -4327,7 +4327,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON --no-dcps tests/ubsan_tests.lst"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -4648,7 +4648,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON --security --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -4787,7 +4787,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON --no-dcps tests/valgrind_tests.lst"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -5013,7 +5013,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config IPV6 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS --modeling --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -5301,7 +5301,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config WCHAR -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_UNIT_TESTS --security --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -5527,7 +5527,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config WCHAR -Config CXX11 -Config RAPIDJSON -Config DDS_NO_CONTENT_SUBSCRIPTION -Config NO_UNIT_TESTS --java --modeling --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -5827,7 +5827,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -6008,7 +6008,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/core_ci_tests.lst -Config STATIC_MESSENGER -Config STATIC -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -6175,7 +6175,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/core_ci_tests.lst -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -6342,7 +6342,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/core_ci_tests.lst -Config STATIC_UNIT_TESTS -Config STATIC -Config XERCES3 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -6499,7 +6499,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS tests/core_ci_tests.lst -Config STATIC_SECURITY"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -6802,7 +6802,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config RAPIDJSON -Config DDS_NO_CONTENT_FILTERED_TOPIC --modeling --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -7120,7 +7120,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS --no-dcps --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -7300,7 +7300,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_MESSENGER -Config IPV6 -Config XERCES3 -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -7469,7 +7469,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_COMPILER -Config IPV6 -Config XERCES3 -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -7640,7 +7640,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_COMPILER2 -Config IPV6 -Config XERCES3 -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -7806,7 +7806,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Static_Debug -Config STATIC_UNIT_TESTS -Config IPV6 -Config XERCES3 -Config CXX11"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -8131,7 +8131,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS --no-dcps --cmake --cmake-build-cfg Release"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -8311,7 +8311,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Static_Release -Config STATIC -Config STATIC_MESSENGER -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config CXX11 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -8479,7 +8479,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Static_Release -Config STATIC_COMPILER -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -8649,7 +8649,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Static_Release -Config STATIC_COMPILER2 -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11 -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -8815,7 +8815,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Static_Release -Config STATIC_UNIT_TESTS -Config STATIC -Config NO_BUILT_IN_TOPICS -Config DDS_NO_OBJECT_MODEL_PROFILE -Config DDS_NO_OWNERSHIP_PROFILE -Config DDS_NO_PERSISTENCE_PROFILE -Config DDS_NO_CONTENT_SUBSCRIPTION -Config IPV6 -Config OPENDDS_SECURITY -Config RAPIDJSON -Config CXX11"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -9190,7 +9190,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS --no-dcps --cmake --cmake-build-cfg Release"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -9379,7 +9379,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Release -Config STATIC_MESSENGER -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -9545,7 +9545,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Release -Config STATIC_COMPILER -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -9720,7 +9720,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Release -Config STATIC_UNIT_TESTS -Config IPV6 -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -10126,7 +10126,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS --no-dcps --cmake --cmake-build-cfg Release"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -10306,7 +10306,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Release -Config STATIC_MESSENGER -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -10472,7 +10472,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Release -Config STATIC_COMPILER -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -10645,7 +10645,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Release -Config STATIC_UNIT_TESTS -Config XERCES3 -Config CXX11 -Config RAPIDJSON -Config NO_BUILT_IN_TOPICS"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -10984,7 +10984,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=C:/OpenDDS --no-dcps --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
     - name: run OpenDDS CMake tests
@@ -11139,7 +11139,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=C:/OpenDDS -Config DCPS_MIN"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
     - name: run OpenDDS tests
@@ -11379,7 +11379,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS --no-dcps --cmake --cmake-build-dir=c:/tests/cmake/build -Config OPENDDS_TESTING_FEATURES"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -11704,7 +11704,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS --no-dcps --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -11873,7 +11873,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Debug -Config STATIC_MESSENGER -Config IPV6 -Config XERCES3 -Config CXX11 -Config NO_UNIT_TESTS -Config RAPIDJSON"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -12039,7 +12039,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Debug -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config IPV6 -Config XERCES3 -Config CXX11 -Config NO_UNIT_TESTS -Config RAPIDJSON"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -12205,7 +12205,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$FS_GHW/OpenDDS tests\core_ci_tests.lst -ExeSubDir Debug -Config STATIC_UNIT_TESTS -Config IPV6 -Config XERCES3 -Config CXX11 -Config RAPIDJSON"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         cat config.xml
@@ -12493,7 +12493,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS --no-dcps tests/core_ci_tests.lst"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -12617,7 +12617,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -12831,7 +12831,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS --no-dcps tests/core_ci_tests.lst"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -12955,7 +12955,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS --java --cmake --modeling"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -13236,7 +13236,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config XERCES3 -Config OPENDDS_SECURITY -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config GH_ACTIONS_M12 --no-dcps tests/core_ci_tests.lst"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -13363,7 +13363,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -13662,7 +13662,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS -Config STATIC_MESSENGER -Config STATIC_COMPILER -Config STATIC_COMPILER2 -Config STATIC_UNIT_TESTS -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS -Config GH_ACTIONS_M12 --no-dcps tests/core_ci_tests.lst"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"
@@ -13789,7 +13789,7 @@ jobs:
         <command name="print_autobuild_config"/>
         <command name="auto_run_tests" options="script_path=tests dir=$GITHUB_WORKSPACE/OpenDDS --no-dcps -Config CXX11 -Config RAPIDJSON -Config NO_SHMEM -Config DDS_NO_ORBSVCS -Config NO_BUILT_IN_TOPICS -Config NO_UNIT_TESTS -Config GH_ACTIONS_M12 --modeling --cmake"/>
         <command name="log" options="off"/>
-        <command name="process_logs" options="prettify"/>
+        <command name="process_logs" options="prettify index"/>
         </autobuild>
         EOF
         $GITHUB_WORKSPACE/autobuild/autobuild.pl "$GITHUB_WORKSPACE/OpenDDS/${{ github.job }}_autobuild_workspace/config.xml"


### PR DESCRIPTION
Problem
-------

The index.html is not generated for the GHA builds.  This is preventing the scoreboard from showing these builds.

Solution
--------

Generate the index.

Notes
-----

Generating the index this way will only allow the most recent build to appear on the scoreboard.  Adding previous builds to the index will be addressed later.