### PR TITLE
`create_datawriter/datareader` do not check topic participant

### DIFF
--- a/dds/DCPS/PublisherImpl.cpp
+++ b/dds/DCPS/PublisherImpl.cpp
@@ -99,6 +99,27 @@ PublisherImpl::create_datawriter(
     DDS::DataWriterListener_ptr a_listener,
     DDS::StatusMask             mask)
 {
+  if (!a_topic) {
+    if (log_level >= LogLevel::Notice) {
+      ACE_ERROR((LM_NOTICE,
+                 "(%P|%t) NOTICE: PublisherImpl::create_datawriter: "
+                 "topic is nil\n"));
+    }
+    return 0;
+  }
+
+  DDS::DomainParticipant_var my_participant = get_participant();
+  DDS::DomainParticipant_var topic_participant = a_topic->get_participant();
+
+  if (my_participant != topic_participant) {
+    if (log_level >= LogLevel::Notice) {
+      ACE_ERROR((LM_NOTICE,
+                 "(%P|%t) NOTICE: PublisherImpl::create_datawriter: "
+                 "topic does not belong to same participant\n"));
+    }
+    return 0;
+  }
+
   DDS::DataWriterQos dw_qos;
 
   if (!validate_datawriter_qos(qos, default_datawriter_qos_, a_topic, dw_qos)) {

--- a/dds/DCPS/SubscriberImpl.cpp
+++ b/dds/DCPS/SubscriberImpl.cpp
@@ -108,14 +108,25 @@ SubscriberImpl::create_datareader(
   DDS::DataReaderListener_ptr a_listener,
   DDS::StatusMask             mask)
 {
-  if (CORBA::is_nil(a_topic_desc)) {
-    if (DCPS_debug_level > 0) {
-      ACE_ERROR((LM_ERROR,
-                ACE_TEXT("(%P|%t) ERROR: ")
-                ACE_TEXT("SubscriberImpl::create_datareader, ")
-                ACE_TEXT("topic desc is nil.\n")));
+  if (!a_topic_desc) {
+    if (log_level >= LogLevel::Notice) {
+      ACE_ERROR((LM_NOTICE,
+                 "(%P|%t) NOTICE: SubscriberImpl::create_datareader: "
+                 "topic is nil\n"));
     }
-    return DDS::DataReader::_nil();
+    return 0;
+  }
+
+  DDS::DomainParticipant_var my_participant = get_participant();
+  DDS::DomainParticipant_var topic_participant = a_topic_desc->get_participant();
+
+  if (my_participant != topic_participant) {
+    if (log_level >= LogLevel::Notice) {
+      ACE_ERROR((LM_NOTICE,
+                 "(%P|%t) NOTICE: SubscriberImpl::create_datareader: "
+                 "topic does not belong to same participant\n"));
+    }
+    return 0;
   }
 
   DDS::DataReaderQos dr_qos;

--- a/docs/news.d/create-writer-reader-topic.rst
+++ b/docs/news.d/create-writer-reader-topic.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4398
+
+.. news-start-section: Fixes
+- ``create_datawriter`` and ``create_datareader`` check if the topic belongs to the same participant as the publisher/subscriber.
+.. news-end-section

--- a/tests/DCPS/TopicReuse/README.rst
+++ b/tests/DCPS/TopicReuse/README.rst
@@ -1,0 +1,14 @@
+###############
+TopicReuse Test
+###############
+
+This test checks that
+* `delete_topic` fails when the topic is still in use (2.2.2.2.1.6)
+* `delete_topic` fails if called for a participant that didn't create the topic (2.2.2.2.1.6)
+* `find_topic` increments the number of times `delete_topic` must be called (2.2.2.2.1.11)
+* `create_datawriter` fails if the topic does not belong to the same participant (2.2.2.4.1.5)
+* `create_datareader` fails if the topic does not belong to the same particpant (2.2.2.5.2.5)
+
+This test creates a single process.
+
+To run the tests with RTPS: `./run_test.pl`

--- a/tests/DCPS/TopicReuse/tpreuse.cpp
+++ b/tests/DCPS/TopicReuse/tpreuse.cpp
@@ -27,172 +27,150 @@
 
 using namespace std;
 
-int ACE_TMAIN (int argc, ACE_TCHAR *argv[]){
-  try
-    {
-      DDS::DomainParticipantFactory_var dpf =
-        TheParticipantFactoryWithArgs(argc, argv);
-      DDS::DomainParticipant_var participant =
-        dpf->create_participant(11,
-                                PARTICIPANT_QOS_DEFAULT,
-                                DDS::DomainParticipantListener::_nil(),
-                                ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-      if (CORBA::is_nil (participant.in ())) {
-        cerr << "create_participant failed." << endl;
-        return 1;
-      }
-      else
-      {
-        ACE_DEBUG ((LM_DEBUG, "Created participant 1 with instance handle %d\n",
-                    participant->get_instance_handle ()));
-      }
+int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
+{
+  DDS::DomainParticipantFactory_var dpf =
+    TheParticipantFactoryWithArgs(argc, argv);
+  DDS::DomainParticipant_var participant =
+    dpf->create_participant(11,
+                            PARTICIPANT_QOS_DEFAULT,
+                            0,
+                            ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-      DDS::DomainParticipant_var participant2 =
-        dpf->create_participant(11,
-                                PARTICIPANT_QOS_DEFAULT,
-                                DDS::DomainParticipantListener::_nil(),
-                                ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-      if (CORBA::is_nil (participant2.in ())) {
-        cerr << "create_participant2 failed." << endl;
-        return 1;
-      }
-      else
-      {
-        ACE_DEBUG ((LM_DEBUG, "Created participant 2 with instance handle %d\n",
-                    participant2->get_instance_handle ()));
-      }
+  DDS::DomainParticipant_var participant2 =
+    dpf->create_participant(11,
+                            PARTICIPANT_QOS_DEFAULT,
+                            0,
+                            ::OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-      // Register TypeSupport (Messenger::Message)
-      Messenger::MessageTypeSupport_var mts =
-        new Messenger::MessageTypeSupportImpl();
+  // Register TypeSupport (Messenger::Message)
+  Messenger::MessageTypeSupport_var mts =
+    new Messenger::MessageTypeSupportImpl();
 
-      if (mts->register_type(participant.in(), "") != DDS::RETCODE_OK) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: register_type failed!\n")),
-                        -1);
-      }
+  mts->register_type(participant, "");
 
-      // Create Topic
-      CORBA::String_var type_name = mts->get_type_name();
-      DDS::Topic_var topic =
-        participant->create_topic("Movie Discussion List",
-                                  type_name.in(),
-                                  TOPIC_QOS_DEFAULT,
-                                  DDS::TopicListener::_nil(),
-                                  OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-      if (CORBA::is_nil(topic.in())) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: create_topic failed!\n")),
-                        -1);
-      }
-
-      // Create Publisher
-      DDS::Publisher_var pub =
-        participant->create_publisher(PUBLISHER_QOS_DEFAULT,
-                                      DDS::PublisherListener::_nil(),
-                                      OpenDDS::DCPS::DEFAULT_STATUS_MASK);
-
-      if (CORBA::is_nil(pub.in())) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: create_publisher failed!\n")),
-                        -1);
-      }
-
-      // Create DataWriter
-      DDS::DataWriter_var dw =
-        pub->create_datawriter(topic.in(),
-                              DATAWRITER_QOS_DEFAULT,
-                              DDS::DataWriterListener::_nil(),
+  // Create Topic
+  CORBA::String_var type_name = mts->get_type_name();
+  DDS::Topic_var topic =
+    participant->create_topic("Movie Discussion List",
+                              type_name,
+                              TOPIC_QOS_DEFAULT,
+                              0,
                               OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-      if (CORBA::is_nil(dw.in())) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: create_datawriter failed!\n")),
-                        -1);
-      }
+  // Create Publisher
+  DDS::Publisher_var pub =
+    participant->create_publisher(PUBLISHER_QOS_DEFAULT,
+                                  0,
+                                  OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-      DDS::ReturnCode_t retcode = participant2->delete_topic (topic.in ());
-      if (retcode != DDS::RETCODE_PRECONDITION_NOT_MET) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: should not be able to delete topic, not part of this participant!\n")),
-                        -1);
-      }
+  // Create DataWriter
+  DDS::DataWriter_var dw =
+    pub->create_datawriter(topic,
+                           DATAWRITER_QOS_DEFAULT,
+                           0,
+                           OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-      DDS::ReturnCode_t retcode5 = participant->delete_topic (topic.in ());
-      if (retcode5 != DDS::RETCODE_PRECONDITION_NOT_MET) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: should not be able to delete topic, still referenced by datawriter!\n")),
-                        -1);
-      }
-
-      DDS::ReturnCode_t retcode2 = pub->delete_datawriter (dw.in ());
-      if (retcode2 != DDS::RETCODE_OK) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: should be able to delete datawriter\n")),
-                        -1);
-      }
-      dw = DDS::DataWriter::_nil ();
-
-      DDS::Duration_t timeout;
-      timeout.sec = 0;
-      timeout.nanosec = 0;
-      // Doing a find_topic will require us to call delete topic twice, see
-      // 7.1.2.2.1.11 from the dds spec
-      DDS::Topic_var topic2 = participant->find_topic ("Movie Discussion List", timeout);
-      if (CORBA::is_nil (topic2.in ())) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: Not able to find topic\n")),
-                        -1);
-      }
-
-      const DDS::ReturnCode_t retcode4 = participant->delete_topic (topic.in ());
-      if (retcode4 != DDS::RETCODE_OK) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: should be able to delete topic\n")),
-                        -1);
-      }
-      topic = DDS::Topic::_nil ();
-
-      const DDS::ReturnCode_t retcode6 = participant->delete_topic (topic2.in ());
-      if (retcode6 != DDS::RETCODE_OK) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: should be able to delete topic\n")),
-                        -1);
-      }
-      topic2 = DDS::Topic::_nil ();
-
-      DDS::ReturnCode_t retcode8 = participant->delete_publisher (pub.in ());
-      if (retcode8 != DDS::RETCODE_OK) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%N:%l: main()")
-                          ACE_TEXT(" ERROR: should be able to delete publisher\n")),
-                        -1);
-      }
-      pub = DDS::Publisher::_nil ();
-
-      dpf->delete_participant(participant.in ());
-      participant = DDS::DomainParticipant::_nil ();
-      dpf->delete_participant(participant2.in ());
-      participant2 = DDS::DomainParticipant::_nil ();
-      TheServiceParticipant->shutdown ();
+  const DDS::ReturnCode_t retcode = participant2->delete_topic(topic);
+  if (retcode != DDS::RETCODE_PRECONDITION_NOT_MET) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      ACE_TEXT("%N:%l: main()")
+                      ACE_TEXT(" ERROR: should not be able to delete topic, not part of this participant!\n")),
+                     -1);
   }
-  catch (CORBA::Exception& e)
-  {
-    cerr << "dp: Exception caught in main.cpp:" << endl
-         << e << endl;
-    exit(1);
+
+  const DDS::ReturnCode_t retcode5 = participant->delete_topic(topic);
+  if (retcode5 != DDS::RETCODE_PRECONDITION_NOT_MET) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      ACE_TEXT("%N:%l: main()")
+                      ACE_TEXT(" ERROR: should not be able to delete topic, still referenced by datawriter!\n")),
+                     -1);
   }
+
+  const DDS::ReturnCode_t retcode2 = pub->delete_datawriter(dw);
+  if (retcode2 != DDS::RETCODE_OK) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      ACE_TEXT("%N:%l: main()")
+                      ACE_TEXT(" ERROR: should be able to delete datawriter\n")),
+                     -1);
+  }
+
+  DDS::Publisher_var pub2 =
+    participant2->create_publisher(PUBLISHER_QOS_DEFAULT,
+                                   0,
+                                   OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  DDS::DataWriter_var dw2 =
+    pub2->create_datawriter(topic,
+                            DATAWRITER_QOS_DEFAULT,
+                            0,
+                            OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  if (dw2) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      ACE_TEXT("%N:%l: main()")
+                      ACE_TEXT(" ERROR: should not be able to create_datawriter with a topic from another participant\n")),
+                     -1);
+  }
+
+  DDS::Subscriber_var sub2 =
+    participant2->create_subscriber(SUBSCRIBER_QOS_DEFAULT,
+                                    0,
+                                    OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+
+  DDS::DataReader_var dr2 =
+    sub2->create_datareader(topic,
+                            DATAREADER_QOS_DEFAULT,
+                            0,
+                            OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  if (dr2) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      ACE_TEXT("%N:%l: main()")
+                      ACE_TEXT(" ERROR: should not be able to create_datareader with a topic from another participant\n")),
+                     -1);
+  }
+
+  DDS::Duration_t timeout;
+  timeout.sec = 0;
+  timeout.nanosec = 0;
+  // Doing a find_topic will require us to call delete topic twice, see
+  // 2.2.2.2.1.11 from the dds spec
+  DDS::Topic_var topic2 = participant->find_topic("Movie Discussion List", timeout);
+  if (!topic2) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      ACE_TEXT("%N:%l: main()")
+                      ACE_TEXT(" ERROR: Not able to find topic\n")),
+                     -1);
+  }
+
+  const DDS::ReturnCode_t retcode4 = participant->delete_topic(topic);
+  if (retcode4 != DDS::RETCODE_OK) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      ACE_TEXT("%N:%l: main()")
+                      ACE_TEXT(" ERROR: should be able to delete topic\n")),
+                     -1);
+  }
+
+  const DDS::ReturnCode_t retcode6 = participant->delete_topic(topic2);
+  if (retcode6 != DDS::RETCODE_OK) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      ACE_TEXT("%N:%l: main()")
+                      ACE_TEXT(" ERROR: should be able to delete topic\n")),
+                     -1);
+  }
+
+  const DDS::ReturnCode_t retcode8 = participant->delete_publisher(pub);
+  if (retcode8 != DDS::RETCODE_OK) {
+    ACE_ERROR_RETURN((LM_ERROR,
+                      ACE_TEXT("%N:%l: main()")
+                      ACE_TEXT(" ERROR: should be able to delete publisher\n")),
+                     -1);
+  }
+
+  participant->delete_contained_entities();
+  participant2->delete_contained_entities();
+  dpf->delete_participant(participant);
+  dpf->delete_participant(participant2);
+  TheServiceParticipant->shutdown();
 
   return 0;
 }


### PR DESCRIPTION
Problem
-------

Sections 2.2.2.4.1.5 and 2.2.2.5.2.5 of the DDS Specification say that `create_datawriter` and `create_datareader` should fail if the topic does not belong to the same participant as the publisher/subscriber.

Solution
--------

Add the necessary checks to `create_datawriter` and `create_datareader`.