### PR TITLE
Improve SpdpSendAddrs parsing

### DIFF
--- a/tests/DCPS/ConfigFile/ConfigFile.cpp
+++ b/tests/DCPS/ConfigFile/ConfigFile.cpp
@@ -221,12 +221,22 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       OpenDDS::RTPS::RtpsDiscovery_rch rd =
         dynamic_rchandle_cast<OpenDDS::RTPS::RtpsDiscovery>(discovery);
       TEST_CHECK(!rd.is_nil());
-      TEST_CHECK(rd->spdp_send_addrs().size() == 5);
+      TEST_CHECK(rd->spdp_send_addrs().size() == 10);
       TEST_CHECK(rd->spdp_send_addrs().count(NetworkAddress("10.1.1.1:10001")) == 1);
       TEST_CHECK(rd->spdp_send_addrs().count(NetworkAddress("10.2.2.2:10002")) == 1);
       TEST_CHECK(rd->spdp_send_addrs().count(NetworkAddress("10.3.3.3:10003")) == 1);
       TEST_CHECK(rd->spdp_send_addrs().count(NetworkAddress("10.4.4.4:10004")) == 1);
+      
+      // Specifying 10.5.5.5:10005:2 gives us two ports, with default interval of 2
       TEST_CHECK(rd->spdp_send_addrs().count(NetworkAddress("10.5.5.5:10005")) == 1);
+      TEST_CHECK(rd->spdp_send_addrs().count(NetworkAddress("10.5.5.5:10007")) == 1);
+      
+      TEST_CHECK(rd->spdp_send_addrs().count(NetworkAddress("10.6.6.6:10006")) == 1);
+      
+      // Specifying 10.7.7.7:10007:3:3 gives three ports, with interval of three       
+      TEST_CHECK(rd->spdp_send_addrs().count(NetworkAddress("10.7.7.7:10007")) == 1);      
+      TEST_CHECK(rd->spdp_send_addrs().count(NetworkAddress("10.7.7.7:10010")) == 1);      
+      TEST_CHECK(rd->spdp_send_addrs().count(NetworkAddress("10.7.7.7:10013")) == 1);
     }
     {
       DDS::DomainId_t domain = 97;

--- a/tests/DCPS/ConfigFile/test1.ini
+++ b/tests/DCPS/ConfigFile/test1.ini
@@ -114,7 +114,7 @@ DefaultTransportConfig=$file
 RepositoryIor=file://repo3.ior
 
 [rtps_discovery/MultiSendAddr]
-SpdpSendAddrs=10.1.1.1:10001,10.2.2.2:10002, 10.3.3.3:10003 ,10.4.4.4:10004 ,   10.5.5.5:10005
+SpdpSendAddrs=10.1.1.1:10001,10.2.2.2:10002, 10.3.3.3:10003 ,10.4.4.4:10004 ,   10.5.5.5:10005:2, 10.6.6.6:10006:1:1, 10.7.7.7:10007:3:3
 
 # Test Static Discovery.
 


### PR DESCRIPTION
For large deployments with no multicast discovery, the current SpdpSendAddrs syntax in the ini file is cumbersome. Allow multiple ports per host to be easily specified.

Each SpdpSendAddrs entry can now be:
<addr>:<port>

or
<addr>:<base_port>:<num>  (defaults to interval = 2)

or
<addr>:<base_port>:<num>:<port_interval>

Example:
SpdpSendAddrs=100.11.13.15:13910:16:2
This will specify 16 endpoints on 100.11.13.15, starting from port 13910, counting up two at a time