### PR TITLE
Discovery templates are not reused

### DIFF
--- a/dds/DCPS/Discovery.h
+++ b/dds/DCPS/Discovery.h
@@ -28,10 +28,6 @@
 #  pragma once
 #endif
 
-ACE_BEGIN_VERSIONED_NAMESPACE_DECL
-class ACE_Configuration_Heap;
-ACE_END_VERSIONED_NAMESPACE_DECL
-
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
@@ -98,7 +94,7 @@ public:
     , public EnableContainerSupportedUniquePtr<Config> {
   public:
     virtual ~Config();
-    virtual int discovery_config(ACE_Configuration_Heap& cf) = 0;
+    virtual int discovery_config() = 0;
   };
 
   virtual bool attach_participant(

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.cpp
@@ -946,7 +946,7 @@ InfoRepoDiscovery::removeDataWriterRemote(const GUID_t& publicationId)
 }
 
 int
-InfoRepoDiscovery::Config::discovery_config(ACE_Configuration_Heap&)
+InfoRepoDiscovery::Config::discovery_config()
 {
   const Service_Participant::RepoKeyDiscoveryMap& discoveryMap = TheServiceParticipant->discoveryMap();
 

--- a/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h
+++ b/dds/DCPS/InfoRepoDiscovery/InfoRepoDiscovery.h
@@ -270,7 +270,7 @@ private:
 public:
   class Config : public Discovery::Config {
   public:
-    int discovery_config(ACE_Configuration_Heap& cf);
+    int discovery_config();
   };
 
   class OpenDDS_InfoRepoDiscovery_Export StaticInitializer {

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -41,125 +41,102 @@ RtpsDiscovery::~RtpsDiscovery()
 {
 }
 
-namespace {
-  const ACE_TCHAR RTPS_SECTION_NAME[] = ACE_TEXT("rtps_discovery");
-}
-
 int
-RtpsDiscovery::Config::discovery_config(ACE_Configuration_Heap& cf)
+RtpsDiscovery::Config::discovery_config()
 {
-  const ACE_Configuration_Section_Key &root = cf.root_section();
-  ACE_Configuration_Section_Key rtps_sect;
+  RcHandle<DCPS::ConfigStoreImpl> config_store = TheServiceParticipant->config_store();
 
-  if (cf.open_section(root, RTPS_SECTION_NAME, 0, rtps_sect) == 0) {
+  const DCPS::ConfigStoreImpl::StringList sections = config_store->get_section_names("OPENDDS_RTPS_DISCOVERY");
 
-    RcHandle<DCPS::ConfigStoreImpl> config_store = TheServiceParticipant->config_store();
+  // Loop through the [rtps_discovery/*] sections
+  for (DCPS::ConfigStoreImpl::StringList::const_iterator pos = sections.begin(), limit = sections.end();
+       pos != limit; ++pos) {
+    const String& rtps_name = *pos;
 
-    // Reprocess for templates.
-    process_section(*config_store,
-                    DCPS::ConfigReader_rch(),
-                    DCPS::ConfigReaderListener_rch(),
-                    "OPENDDS_RTPS_DISCOVERY",
-                    cf,
-                    rtps_sect,
-                    "",
-                    false);
-
-    const DCPS::ConfigStoreImpl::StringList sections = config_store->get_section_names("OPENDDS_RTPS_DISCOVERY");
-
-    // Loop through the [rtps_discovery/*] sections
-    for (DCPS::ConfigStoreImpl::StringList::const_iterator pos = sections.begin(), limit = sections.end();
-         pos != limit; ++pos) {
-      const String& rtps_name = *pos;
-
-      RtpsDiscovery_rch discovery = OpenDDS::DCPS::make_rch<RtpsDiscovery>(rtps_name);
-      RtpsDiscoveryConfig_rch config = discovery->config();
+    RtpsDiscovery_rch discovery = OpenDDS::DCPS::make_rch<RtpsDiscovery>(rtps_name);
+    RtpsDiscoveryConfig_rch config = discovery->config();
 
 #if defined(OPENDDS_SECURITY)
-      if (config_store->has(config->config_key("IceTa").c_str())) {
-        if (log_level >= DCPS::LogLevel::Warning) {
-          ACE_ERROR((LM_WARNING,
-                     "(%P|%t) RtpsDiscovery::Config::discovery_config: "
-                     "IceTa is deprecated.  Use Ta in [ice]\n"));
-        }
-        config_store->set("OPENDDS_IceTa", config_store->get(config->config_key("IceTa").c_str(), ""));
+    if (config_store->has(config->config_key("IceTa").c_str())) {
+      if (log_level >= DCPS::LogLevel::Warning) {
+        ACE_ERROR((LM_WARNING,
+                   "(%P|%t) RtpsDiscovery::Config::discovery_config: "
+                   "IceTa is deprecated.  Use Ta in [ice]\n"));
       }
-      if (config_store->has(config->config_key("IceConnectivityCheckTTL").c_str())) {
-        if (log_level >= DCPS::LogLevel::Warning) {
-          ACE_ERROR((LM_WARNING,
-                     "(%P|%t) RtpsDiscovery::Config::discovery_config: "
-                     "IceConnectivityCheckTTL is deprecated.  Use ConnectivityCheckTTL in [ice]\n"));
-        }
-        config_store->set("OPENDDS_IceConnectivityCheckTTL", config_store->get(config->config_key("IceConnectivityCheckTTL").c_str(), ""));
+      config_store->set("OPENDDS_IceTa", config_store->get(config->config_key("IceTa").c_str(), ""));
+    }
+    if (config_store->has(config->config_key("IceConnectivityCheckTTL").c_str())) {
+      if (log_level >= DCPS::LogLevel::Warning) {
+        ACE_ERROR((LM_WARNING,
+                   "(%P|%t) RtpsDiscovery::Config::discovery_config: "
+                   "IceConnectivityCheckTTL is deprecated.  Use ConnectivityCheckTTL in [ice]\n"));
       }
-      if (config_store->has(config->config_key("IceChecklistPeriod").c_str())) {
-        if (log_level >= DCPS::LogLevel::Warning) {
-          ACE_ERROR((LM_WARNING,
-                     "(%P|%t) RtpsDiscovery::Config::discovery_config: "
-                     "IceChecklistPeriod is deprecated.  Use ChecklistPeriod in [ice]\n"));
-        }
-        config_store->set("OPENDDS_IceChecklistPeriod", config_store->get(config->config_key("IceChecklistPeriod").c_str(), ""));
+      config_store->set("OPENDDS_IceConnectivityCheckTTL", config_store->get(config->config_key("IceConnectivityCheckTTL").c_str(), ""));
+    }
+    if (config_store->has(config->config_key("IceChecklistPeriod").c_str())) {
+      if (log_level >= DCPS::LogLevel::Warning) {
+        ACE_ERROR((LM_WARNING,
+                   "(%P|%t) RtpsDiscovery::Config::discovery_config: "
+                   "IceChecklistPeriod is deprecated.  Use ChecklistPeriod in [ice]\n"));
       }
-      if (config_store->has(config->config_key("IceIndicationPeriod").c_str())) {
-        if (log_level >= DCPS::LogLevel::Warning) {
-          ACE_ERROR((LM_WARNING,
-                     "(%P|%t) RtpsDiscovery::Config::discovery_config: "
-                     "IceIndicationPeriod is deprecated.  Use IndicationPeriod in [ice]\n"));
-        }
-        config_store->set("OPENDDS_IceIndicationPeriod", config_store->get(config->config_key("IceIndicationPeriod").c_str(), ""));
+      config_store->set("OPENDDS_IceChecklistPeriod", config_store->get(config->config_key("IceChecklistPeriod").c_str(), ""));
+    }
+    if (config_store->has(config->config_key("IceIndicationPeriod").c_str())) {
+      if (log_level >= DCPS::LogLevel::Warning) {
+        ACE_ERROR((LM_WARNING,
+                   "(%P|%t) RtpsDiscovery::Config::discovery_config: "
+                   "IceIndicationPeriod is deprecated.  Use IndicationPeriod in [ice]\n"));
       }
-      if (config_store->has(config->config_key("IceNominatedTTL").c_str())) {
-        if (log_level >= DCPS::LogLevel::Warning) {
-          ACE_ERROR((LM_WARNING,
-                     "(%P|%t) RtpsDiscovery::Config::discovery_config: "
-                     "IceNominatedTTL is deprecated.  Use NominatedTTL in [ice]\n"));
-        }
-        config_store->set("OPENDDS_IceNominatedTTL", config_store->get(config->config_key("IceNominatedTTL").c_str(), ""));
+      config_store->set("OPENDDS_IceIndicationPeriod", config_store->get(config->config_key("IceIndicationPeriod").c_str(), ""));
+    }
+    if (config_store->has(config->config_key("IceNominatedTTL").c_str())) {
+      if (log_level >= DCPS::LogLevel::Warning) {
+        ACE_ERROR((LM_WARNING,
+                   "(%P|%t) RtpsDiscovery::Config::discovery_config: "
+                   "IceNominatedTTL is deprecated.  Use NominatedTTL in [ice]\n"));
       }
-      if (config_store->has(config->config_key("IceServerReflexiveAddressPeriod").c_str())) {
-        if (log_level >= DCPS::LogLevel::Warning) {
-          ACE_ERROR((LM_WARNING,
-                     "(%P|%t) RtpsDiscovery::Config::discovery_config: "
-                     "IceServerReflexiveAddressPeriod is deprecated.  Use ServerReflexiveAddressPeriod in [ice]\n"));
-        }
-        config_store->set("OPENDDS_IceServerReflexiveAddressPeriod", config_store->get(config->config_key("IceServerReflexiveAddressPeriod").c_str(), ""));
+      config_store->set("OPENDDS_IceNominatedTTL", config_store->get(config->config_key("IceNominatedTTL").c_str(), ""));
+    }
+    if (config_store->has(config->config_key("IceServerReflexiveAddressPeriod").c_str())) {
+      if (log_level >= DCPS::LogLevel::Warning) {
+        ACE_ERROR((LM_WARNING,
+                   "(%P|%t) RtpsDiscovery::Config::discovery_config: "
+                   "IceServerReflexiveAddressPeriod is deprecated.  Use ServerReflexiveAddressPeriod in [ice]\n"));
       }
-      if (config_store->has(config->config_key("IceServerReflexiveIndicationCount").c_str())) {
-        if (log_level >= DCPS::LogLevel::Warning) {
-          ACE_ERROR((LM_WARNING,
-                     "(%P|%t) RtpsDiscovery::Config::discovery_config: "
-                     "IceServerReflexiveIndicationCount is deprecated.  Use ServerReflexiveIndicationCount in [ice]\n"));
-        }
-        config_store->set("OPENDDS_IceServerReflexiveIndicationCount", config_store->get(config->config_key("IceServerReflexiveIndicationCount").c_str(), ""));
+      config_store->set("OPENDDS_IceServerReflexiveAddressPeriod", config_store->get(config->config_key("IceServerReflexiveAddressPeriod").c_str(), ""));
+    }
+    if (config_store->has(config->config_key("IceServerReflexiveIndicationCount").c_str())) {
+      if (log_level >= DCPS::LogLevel::Warning) {
+        ACE_ERROR((LM_WARNING,
+                   "(%P|%t) RtpsDiscovery::Config::discovery_config: "
+                   "IceServerReflexiveIndicationCount is deprecated.  Use ServerReflexiveIndicationCount in [ice]\n"));
       }
-      if (config_store->has(config->config_key("IceDeferredTriggeredCheckTTL").c_str())) {
-        if (log_level >= DCPS::LogLevel::Warning) {
-          ACE_ERROR((LM_WARNING,
-                     "(%P|%t) RtpsDiscovery::Config::discovery_config: "
-                     "IceDeferredTriggeredCheckTTL is deprecated.  Use DeferredTriggeredCheckTTL in [ice]\n"));
-        }
-        config_store->set("OPENDDS_IceDeferredTriggeredCheckTTL", config_store->get(config->config_key("IceDeferredTriggeredCheckTTL").c_str(), ""));
+      config_store->set("OPENDDS_IceServerReflexiveIndicationCount", config_store->get(config->config_key("IceServerReflexiveIndicationCount").c_str(), ""));
+    }
+    if (config_store->has(config->config_key("IceDeferredTriggeredCheckTTL").c_str())) {
+      if (log_level >= DCPS::LogLevel::Warning) {
+        ACE_ERROR((LM_WARNING,
+                   "(%P|%t) RtpsDiscovery::Config::discovery_config: "
+                   "IceDeferredTriggeredCheckTTL is deprecated.  Use DeferredTriggeredCheckTTL in [ice]\n"));
       }
-      if (config_store->has(config->config_key("IceChangePasswordPeriod").c_str())) {
-        if (log_level >= DCPS::LogLevel::Warning) {
-          ACE_ERROR((LM_WARNING,
-                     "(%P|%t) RtpsDiscovery::Config::discovery_config: "
-                     "IceChangePasswordPeriod is deprecated.  Use ChangePasswordPeriod in [ice]\n"));
-        }
-        config_store->set("OPENDDS_IceChangePasswordPeriod", config_store->get(config->config_key("IceChangePasswordPeriod").c_str(), ""));
+      config_store->set("OPENDDS_IceDeferredTriggeredCheckTTL", config_store->get(config->config_key("IceDeferredTriggeredCheckTTL").c_str(), ""));
+    }
+    if (config_store->has(config->config_key("IceChangePasswordPeriod").c_str())) {
+      if (log_level >= DCPS::LogLevel::Warning) {
+        ACE_ERROR((LM_WARNING,
+                   "(%P|%t) RtpsDiscovery::Config::discovery_config: "
+                   "IceChangePasswordPeriod is deprecated.  Use ChangePasswordPeriod in [ice]\n"));
       }
+      config_store->set("OPENDDS_IceChangePasswordPeriod", config_store->get(config->config_key("IceChangePasswordPeriod").c_str(), ""));
+    }
 #endif /* OPENDDS_SECURITY */
 
-      TheServiceParticipant->add_discovery(discovery);
-    }
+    TheServiceParticipant->add_discovery(discovery);
   }
 
   // If the default RTPS discovery object has not been configured,
   // instantiate it now.
-  const DCPS::Service_Participant::RepoKeyDiscoveryMap& discoveryMap = TheServiceParticipant->discoveryMap();
-  if (discoveryMap.find(Discovery::DEFAULT_RTPS) == discoveryMap.end()) {
-    TheServiceParticipant->add_discovery(OpenDDS::DCPS::make_rch<RtpsDiscovery>(Discovery::DEFAULT_RTPS));
-  }
+  TheServiceParticipant->add_discovery(OpenDDS::DCPS::make_rch<RtpsDiscovery>(Discovery::DEFAULT_RTPS));
 
   return 0;
 }

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -134,7 +134,7 @@ public:
   OPENDDS_STRING multicast_interface() const { return config_->multicast_interface(); }
   void multicast_interface(const OPENDDS_STRING& mi) { config_->multicast_interface(mi); }
 
-  DCPS::NetworkAddress default_multicast_group() const { return config_->default_multicast_group(); }
+  DCPS::NetworkAddress default_multicast_group(DDS::DomainId_t domain) const { return config_->default_multicast_group(domain); }
   void default_multicast_group(const DCPS::NetworkAddress& group) { config_->default_multicast_group(group); }
 
   DCPS::NetworkAddressSet spdp_send_addrs() const { return config_->spdp_send_addrs(); }
@@ -354,7 +354,7 @@ private:
 public:
   class Config : public Discovery::Config {
   public:
-    int discovery_config(ACE_Configuration_Heap& cf);
+    int discovery_config();
   };
 
   class OpenDDS_Rtps_Export StaticInitializer {

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
@@ -101,12 +101,13 @@ public:
   OPENDDS_STRING multicast_interface() const;
   void multicast_interface(const OPENDDS_STRING& mi);
 
-  DCPS::NetworkAddress default_multicast_group() const;
+  DCPS::NetworkAddress default_multicast_group(DDS::DomainId_t domain) const;
   void default_multicast_group(const DCPS::NetworkAddress& group);
 
   u_short port_common(DDS::DomainId_t domain) const;
 
-  DCPS::NetworkAddress multicast_address(u_short port_common) const;
+  DCPS::NetworkAddress multicast_address(u_short port_common,
+                                         DDS::DomainId_t domain) const;
 
 #ifdef ACE_HAS_IPV6
   DCPS::NetworkAddress ipv6_spdp_local_address() const;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -440,7 +440,7 @@ Sedp::init(const GUID_t& guid,
     // Bind to a specific multicast group
     const u_short mc_port = disco.pb() + disco.dg() * domainId + disco.dx();
 
-    DCPS::NetworkAddress mc_addr = disco.default_multicast_group();
+    DCPS::NetworkAddress mc_addr = disco.default_multicast_group(domainId);
     mc_addr.set_port_number(mc_port);
     config_store_->set(transport_inst_->config_key("MULTICAST_GROUP_ADDRESS").c_str(),
                        NetworkAddress(mc_addr),

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2357,7 +2357,7 @@ Spdp::SpdpTransport::SpdpTransport(DCPS::RcHandle<Spdp> outer)
   multicast_interface_ = outer->disco_->multicast_interface();
 
   const u_short port_common = outer->config_->port_common(outer->domain_);
-  multicast_address_ = outer->config_->multicast_address(port_common);
+  multicast_address_ = outer->config_->multicast_address(port_common, outer->domain_);
 
 #ifdef ACE_HAS_IPV6
   multicast_ipv6_address_ = outer->config_->ipv6_multicast_address(port_common);

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -841,8 +841,7 @@ Service_Participant::set_repo_ior(const char* ior,
   }
 
   if (discovery_types_.count(repo_type)) {
-    ACE_Configuration_Heap cf;
-    discovery_types_[repo_type]->discovery_config(cf);
+    discovery_types_[repo_type]->discovery_config();
     this->remap_domains(key, key, attach_participant);
     return true;
   }
@@ -1104,47 +1103,34 @@ Service_Participant::get_default_discovery()
 Discovery_rch
 Service_Participant::get_discovery(const DDS::DomainId_t domain)
 {
-  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, this->maps_lock_, Discovery_rch());
+  ACE_GUARD_RETURN(ACE_Recursive_Thread_Mutex, guard, maps_lock_, Discovery_rch());
 
-  // Default to the Default InfoRepo-based discovery unless the user has
-  // changed defaultDiscovery_ using the API or config file
+  // Start with the default discovery.
   Discovery::RepoKey repo = get_default_discovery();
-  bool in_range = false;
-  const Discovery::RepoKey instance_name = get_discovery_template_instance_name(domain);
+
+  // Override with the discovery for the domain range.
   DomainRange dr_inst("");
-
-  RepoKeyDiscoveryMap::const_iterator location;
-
-  // Find if this domain has a repo key (really a discovery key)
-  // mapped to it.
-  DomainRepoMap::const_iterator where = this->domainRepoMap_.find(domain);
-  if (where != this->domainRepoMap_.end()) {
-    repo = where->second;
-  } else {
-    // Is domain part of a DomainRange template?
-    in_range = get_domain_range_info(domain, dr_inst);
+  bool in_range = false;
+  if (get_domain_range_info(domain, dr_inst)) {
+    repo = dr_inst.discovery_template_name(config_store_, repo);
+    in_range = true;
   }
 
-  // check to see if this domain has a discovery template
-  // and if the template instance has already been loaded.
-  if (!in_range && is_discovery_template(repo)) {
-    location = this->discoveryMap_.find(instance_name);
-    if (location == this->discoveryMap_.end()) {
-      if (configure_discovery_template(domain, repo)) {
-        repo = instance_name;
-      }
-    }
+  // Override with the discovery for the domain.
+  DomainRepoMap::const_iterator pos = domainRepoMap_.find(domain);
+  if (pos != domainRepoMap_.end()) {
+    repo = pos->second;
   }
 
-  location = this->discoveryMap_.find(repo);
+  RepoKeyDiscoveryMap::const_iterator location = discoveryMap_.find(repo);
 
-  if (location == this->discoveryMap_.end()) {
+  if (location == discoveryMap_.end()) {
     if (in_range) {
-      const int ret = configure_domain_range_instance(domain);
+      const int ret = configure_domain_range_instance(domain, repo);
 
       // return the newly configured domain and return it
       if (!ret) {
-        return this->discoveryMap_[instance_name];
+        return discoveryMap_[repo];
       } else {
         if (DCPS_debug_level > 0) {
           ACE_DEBUG((LM_DEBUG,
@@ -1159,7 +1145,7 @@ Service_Participant::get_discovery(const DDS::DomainId_t domain)
         (repo == "-1")) {
       // Set the default repository IOR if it hasn't already happened
       // by this point.  This is why this can't be const.
-      bool ok = this->set_repo_ior(DEFAULT_REPO_IOR, Discovery::DEFAULT_REPO, true, false);
+      bool ok = set_repo_ior(DEFAULT_REPO_IOR, Discovery::DEFAULT_REPO, true, false);
 
       if (!ok) {
         if (DCPS_debug_level > 0) {
@@ -1179,7 +1165,7 @@ Service_Participant::get_discovery(const DDS::DomainId_t domain)
         }
 
       }
-      return this->discoveryMap_[Discovery::DEFAULT_REPO];
+      return discoveryMap_[Discovery::DEFAULT_REPO];
 
     } else if (repo == Discovery::DEFAULT_RTPS) {
 
@@ -1200,9 +1186,9 @@ Service_Participant::get_discovery(const DDS::DomainId_t domain)
       }
 
       // Try to find it again
-      location = this->discoveryMap_.find(Discovery::DEFAULT_RTPS);
+      location = discoveryMap_.find(Discovery::DEFAULT_RTPS);
 
-      if (location == this->discoveryMap_.end()) {
+      if (location == discoveryMap_.end()) {
         // Unable to load DEFAULT_RTPS
         if (DCPS_debug_level > 0) {
           ACE_DEBUG((LM_DEBUG,
@@ -1542,17 +1528,6 @@ Service_Participant::load_configuration(
   // could be a domain_range that specifies the DiscoveryTemplate, check
   // for config templates before loading any config information.
 
-  // load any rtps_discovery templates
-  status = load_discovery_templates();
-
-  if (status != 0) {
-    ACE_ERROR_RETURN((LM_ERROR,
-                      ACE_TEXT("(%P|%t) ERROR: Service_Participant::load_configuration ")
-                      ACE_TEXT("load_domain_range_configuration() returned %d\n"),
-                      status),
-                     -1);
-  }
-
   status = this->load_discovery_configuration(config, RTPS_SECTION_NAME);
 
   if (status != 0) {
@@ -1633,7 +1608,7 @@ Service_Participant::load_configuration(
 
   // Needs to be loaded after transport configs and instances and domains.
   try {
-    status = StaticDiscovery::instance()->load_configuration(config);
+    status = StaticDiscovery::instance()->load_configuration();
 
     if (status != 0) {
       ACE_ERROR_RETURN((LM_ERROR,
@@ -1817,10 +1792,9 @@ Service_Participant::load_domain_ranges()
   return 0;
 }
 
-int Service_Participant::configure_domain_range_instance(DDS::DomainId_t domainId)
+int Service_Participant::configure_domain_range_instance(DDS::DomainId_t domainId,
+                                                         const Discovery::RepoKey& name)
 {
-  Discovery::RepoKey name = get_discovery_template_instance_name(domainId);
-
   if (discoveryMap_.find(name) == discoveryMap_.end()) {
     // create a cf that has [rtps_discovery/name+domainId]
     // copy sections adding customization
@@ -1879,32 +1853,8 @@ int Service_Participant::configure_domain_range_instance(DDS::DomainId_t domainI
                          -1);
       }
 
-      //create matching discovery instance
-      ACE_Configuration_Section_Key sect;
-      dcf.open_section(root, RTPS_SECTION_NAME, true /* create */, sect);
-      ACE_Configuration_Section_Key sub_sect;
-      dcf.open_section(sect, ACE_TEXT_CHAR_TO_TCHAR(name.c_str()), true, sub_sect);
-
-      ValueMap discovery_settings;
-      if (process_customizations(domainId, dr_inst.discovery_template_name(config_store_), discovery_settings)) {
-        for (ValueMap::const_iterator ds_it = discovery_settings.begin(); ds_it != discovery_settings.end(); ++ds_it) {
-          dcf.set_string_value(sub_sect, ACE_TEXT_CHAR_TO_TCHAR(ds_it->first.c_str()), ACE_TEXT_CHAR_TO_TCHAR(ds_it->second.c_str()));
-        }
-      }
-
-      // load discovery
-      int status = this->load_discovery_configuration(dcf, RTPS_SECTION_NAME);
-
-      if (status != 0) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("(%P|%t) ERROR: Service_Participant::configure_domain_range_instance(): ")
-                          ACE_TEXT("load_discovery_configuration() returned %d\n"),
-                          status),
-                         -1);
-      }
-
       // load domain config
-      status = this->load_domain_configuration(dcf, 0);
+      int status = this->load_domain_configuration(dcf, 0);
 
       if (status != 0) {
         ACE_ERROR_RETURN((LM_ERROR,
@@ -1984,7 +1934,7 @@ Service_Participant::load_discovery_configuration(ACE_Configuration_Heap& cf,
 
     if (iter != this->discovery_types_.end()) {
       // discovery code is loaded, process options
-      return iter->second->discovery_config(cf);
+      return iter->second->discovery_config();
     } else {
       // No discovery code can be loaded, report an error
       ACE_ERROR_RETURN((LM_ERROR,
@@ -1995,79 +1945,6 @@ Service_Participant::load_discovery_configuration(ACE_Configuration_Heap& cf,
                        -1);
     }
   }
-  return 0;
-}
-
-int
-Service_Participant::configure_discovery_template(DDS::DomainId_t domainId, const OPENDDS_STRING& discovery_name)
-{
-  ValueMap discovery_settings;
-  if (process_customizations(domainId, discovery_name, discovery_settings)) {
-    Discovery::RepoKey name = get_discovery_template_instance_name(domainId);
-
-    if (discoveryMap_.find(name) == discoveryMap_.end()) {
-      ACE_Configuration_Heap dcf;
-      dcf.open();
-      const ACE_Configuration_Section_Key& root = dcf.root_section();
-
-      //create discovery instance
-      ACE_Configuration_Section_Key sect;
-      dcf.open_section(root, RTPS_SECTION_NAME, true /* create */, sect);
-      ACE_Configuration_Section_Key sub_sect;
-      dcf.open_section(sect, ACE_TEXT_CHAR_TO_TCHAR(name.c_str()), true, sub_sect);
-
-      for (ValueMap::const_iterator ds_it = discovery_settings.begin(); ds_it != discovery_settings.end(); ++ds_it) {
-        dcf.set_string_value(sub_sect, ACE_TEXT_CHAR_TO_TCHAR(ds_it->first.c_str()), ACE_TEXT_CHAR_TO_TCHAR(ds_it->second.c_str()));
-        if (DCPS_debug_level > 0) {
-          ACE_DEBUG((LM_DEBUG,
-                     ACE_TEXT("(%P|%t) Service_Participant::configure_discovery_template(): ")
-                     ACE_TEXT("setting %C = %C\n"),
-                     ds_it->first.c_str(), ds_it->second.c_str()));
-        }
-      }
-
-      // load discovery
-      int status = this->load_discovery_configuration(dcf, RTPS_SECTION_NAME);
-
-      if (status != 0) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("(%P|%t) ERROR: Service_Participant::configure_discovery_template(): ")
-                          ACE_TEXT("load_discovery_configuration() returned %d\n"),
-                          status),
-                         -1);
-      }
-    } else {
-      // already configured. not necessarily an error
-      if (DCPS_debug_level > 0) {
-          ACE_DEBUG((LM_DEBUG,
-                     ACE_TEXT("(%P|%t) Discovery config %C already exists\n"),
-                     name.c_str()));
-        }
-
-    }
-  } else {
-    ACE_ERROR_RETURN((LM_ERROR,
-                      ACE_TEXT("(%P|%t) ERROR: Service_Participant::configure_discovery_template(): ")
-                      ACE_TEXT("process_customizations() returned false\n")),
-                     -1);
-  }
-
-  return 0;
-}
-
-
-int
-Service_Participant::load_discovery_templates()
-{
-  const DCPS::ConfigStoreImpl::StringList sections = config_store_->get_section_names("OPENDDS_RTPS_DISCOVERY");
-
-  // Loop through the [rtps_discovery/*] sections
-  for (DCPS::ConfigStoreImpl::StringList::const_iterator pos = sections.begin(), limit = sections.end();
-       pos != limit; ++pos) {
-    discovery_infos_.push_back(DiscoveryInfo(*pos));
-  }
-
-  // return 0 even if no templates were loaded
   return 0;
 }
 
@@ -2141,9 +2018,10 @@ int Service_Participant::DomainRange::parse_domain_range()
 }
 
 String
-Service_Participant::DomainRange::discovery_template_name(RcHandle<ConfigStoreImpl> config_store) const
+Service_Participant::DomainRange::discovery_template_name(RcHandle<ConfigStoreImpl> config_store,
+                                                          const String& default_name) const
 {
-  return config_store->get(config_key("DiscoveryTemplate").c_str(), "");
+  return config_store->get(config_key("DiscoveryTemplate").c_str(), default_name);
 }
 
 String
@@ -2156,25 +2034,6 @@ Service_Participant::DomainRange::transport_config_name(RcHandle<ConfigStoreImpl
 
 DCPS::ConfigStoreImpl::StringMap
 Service_Participant::DomainRange::domain_info(RcHandle<ConfigStoreImpl> config_store) const
-{
-  return config_store->get_section_values(config_prefix_);
-}
-
-DCPS::ConfigStoreImpl::StringMap
-Service_Participant::DiscoveryInfo::customizations(RcHandle<ConfigStoreImpl> config_store) const
-{
-  if (config_store->has(config_key("Customization").c_str())) {
-    const String c = config_store->get(config_key("Customization").c_str(), "");
-    if (!c.empty()) {
-      return config_store->get_section_values("OPENDDS_CUSTOMIZATION_" + c);
-    }
-  }
-
-  return DCPS::ConfigStoreImpl::StringMap();
-}
-
-DCPS::ConfigStoreImpl::StringMap
-Service_Participant::DiscoveryInfo::disc_info(RcHandle<ConfigStoreImpl> config_store) const
 {
   return config_store->get_section_values(config_prefix_);
 }
@@ -2208,100 +2067,14 @@ Service_Participant::get_domain_range_info(const DDS::DomainId_t id, DomainRange
   return false;
 }
 
-bool
-Service_Participant::process_customizations(DDS::DomainId_t id, const OPENDDS_STRING& discovery_name, ValueMap& customs)
-{
-  // get the discovery info
-  OPENDDS_VECTOR(DiscoveryInfo)::const_iterator dit;
-  for (dit = discovery_infos_.begin(); dit != discovery_infos_.end(); ++dit) {
-    if (discovery_name == dit->discovery_name()) {
-      break;
-    }
-  }
-
-  if (dit != discovery_infos_.end()) {
-    // add discovery info to customs
-    const DCPS::ConfigStoreImpl::StringMap disc_info = dit->disc_info(config_store_);
-    for (DCPS::ConfigStoreImpl::StringMap::const_iterator i = disc_info.begin(); i != disc_info.end(); ++i) {
-      customs[i->first] = i->second;
-      if (DCPS_debug_level > 0) {
-        ACE_DEBUG((LM_DEBUG,
-                   ACE_TEXT("(%P|%t) Service_Participant::")
-                   ACE_TEXT("process_customizations(): adding config %C=%C\n"),
-                   i->first.c_str(), i->second.c_str()));
-      }
-    }
-
-    // update customs valuemap with any customizations
-    const DCPS::ConfigStoreImpl::StringMap customizations = dit->customizations(config_store_);
-    for (ValueMap::const_iterator i = customizations.begin(); i != customizations.end(); ++i) {
-      if (i->first == "INTEROP_MULTICAST_OVERRIDE" && i->second == "AddDomainId") {
-        DCPS::ConfigStoreImpl::StringMap::const_iterator pos2 = customs.find("INTEROP_MULTICAST_OVERRIDE");
-        if (pos2 == customs.end()) {
-          pos2 = customs.find("InteropMulticastOverride");
-        }
-        OPENDDS_STRING addr = pos2 != customs.end() ? pos2->second : "";
-        size_t pos = addr.find_last_of(".");
-        if (pos != OPENDDS_STRING::npos) {
-          OPENDDS_STRING custom = addr.substr(pos + 1);
-          int val = 0;
-          if (!convertToInteger(custom, val)) {
-            ACE_ERROR_RETURN((LM_ERROR,
-                              ACE_TEXT("(%P|%t) ERROR: Service_Participant::")
-                              ACE_TEXT("process_customizations(): ")
-                              ACE_TEXT("could not convert %C to integer\n"),
-                              custom.c_str()),
-                             false);
-          }
-          val += id;
-          addr = addr.substr(0, pos);
-          addr += "." + to_dds_string(val);
-        } else {
-          ACE_ERROR_RETURN((LM_ERROR,
-                            ACE_TEXT("(%P|%t) ERROR: Service_Participant::")
-                            ACE_TEXT("process_customizations(): ")
-                            ACE_TEXT("could not AddDomainId for %s\n"),
-                            customs["InteropMulticastOverride"].c_str()),
-                           false);
-        }
-
-        customs["InteropMulticastOverride"] = addr;
-      }
-    }
-  }
-
-  return true;
-}
-
-Discovery::RepoKey
-Service_Participant::get_discovery_template_instance_name(const DDS::DomainId_t id)
-{
-  OpenDDS::DCPS::Discovery::RepoKey configured_name = "rtps_template_instance_";
-  configured_name += to_dds_string(id);
-  return configured_name;
-}
-
-bool
-Service_Participant::is_discovery_template(const OPENDDS_STRING& name)
-{
-  OPENDDS_VECTOR(DiscoveryInfo)::const_iterator i;
-  for (i = discovery_infos_.begin(); i != discovery_infos_.end(); ++i) {
-    if (i->discovery_name() == name && !i->customizations(config_store_).empty()) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 #if OPENDDS_POOL_ALLOCATOR
 void
 Service_Participant::configure_pool()
 {
   const size_t pool_size = config_store_->get_uint32(OPENDDS_COMMON_POOL_SIZE,
-                                                    OPENDDS_COMMON_POOL_SIZE_default);
+                                                     OPENDDS_COMMON_POOL_SIZE_default);
   const size_t pool_granularity = config_store_->get_uint32(OPENDDS_COMMON_POOL_GRANULARITY,
-                                                          OPENDDS_COMMON_POOL_GRANULARITY_default);
+                                                            OPENDDS_COMMON_POOL_GRANULARITY_default);
   if (pool_size) {
     SafetyProfilePool::instance()->configure_pool(pool_size, pool_granularity);
     SafetyProfilePool::instance()->install();
@@ -2365,8 +2138,10 @@ void
 Service_Participant::add_discovery(Discovery_rch discovery)
 {
   if (discovery) {
-    ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->maps_lock_);
-    this->discoveryMap_[discovery->key()] = discovery;
+    ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, maps_lock_);
+    if (discoveryMap_.count(discovery->key()) == 0) {
+      discoveryMap_[discovery->key()] = discovery;
+    }
   }
 }
 

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -645,15 +645,11 @@ private:
   int load_domain_ranges();
 
   /**
-   * Load the discovery template information
-   */
-  int load_discovery_templates();
-
-  /**
    * Process the domain range template and activate the
    * domain for the given domain ID
    */
-  int configure_domain_range_instance(DDS::DomainId_t domainId);
+  int configure_domain_range_instance(DDS::DomainId_t domainId,
+                                      const Discovery::RepoKey& name);
 
   /**
    * Load the discovery configuration to the Service_Participant
@@ -661,12 +657,6 @@ private:
    */
   int load_discovery_configuration(ACE_Configuration_Heap& cf,
                                    const ACE_TCHAR* section_name);
-
-  /**
-   * Create and load a discovery config from a discovery template
-   */
-  int configure_discovery_template(DDS::DomainId_t domainId,
-                                   const OPENDDS_STRING& discovery_name);
 
   typedef OPENDDS_MAP(OPENDDS_STRING, container_supported_unique_ptr<Discovery::Config>) DiscoveryTypes;
   DiscoveryTypes discovery_types_;
@@ -740,7 +730,8 @@ private:
 
     const String& name() const { return name_; }
     const String& config_prefix() const { return config_prefix_; }
-    String discovery_template_name(RcHandle<ConfigStoreImpl> config_store) const;
+    String discovery_template_name(RcHandle<ConfigStoreImpl> config_store,
+                                   const String& default_name) const;
     String transport_config_name(RcHandle<ConfigStoreImpl> config_store) const;
     DCPS::ConfigStoreImpl::StringMap domain_info(RcHandle<ConfigStoreImpl> config_store) const;
 
@@ -761,42 +752,13 @@ private:
     DDS::DomainId_t range_end_;
   };
 
-  class DiscoveryInfo {
-  public:
-    DiscoveryInfo(const String& name)
-      : discovery_name_(name)
-      , config_prefix_(ConfigPair::canonicalize(String("OPENDDS_RTPS_DISCOVERY_") + name))
-    {}
-
-    const String& discovery_name() const { return discovery_name_; }
-    DCPS::ConfigStoreImpl::StringMap customizations(RcHandle<ConfigStoreImpl> config_store) const;
-    DCPS::ConfigStoreImpl::StringMap disc_info(RcHandle<ConfigStoreImpl> config_store) const;
-
-  private:
-    String config_key(const String& key) const
-    {
-      return ConfigPair::canonicalize(config_prefix_ + "_" + key);
-    }
-
-    String discovery_name_;
-    String config_prefix_;
-  };
-
   OPENDDS_MAP(DDS::DomainId_t, OPENDDS_STRING) domain_to_transport_name_map_;
 
   OPENDDS_VECTOR(DomainRange) domain_ranges_;
 
-  OPENDDS_VECTOR(DiscoveryInfo) discovery_infos_;
-
   bool has_domain_range() const;
 
   bool get_domain_range_info(DDS::DomainId_t id, DomainRange& inst);
-
-  bool process_customizations(DDS::DomainId_t id, const OPENDDS_STRING& discovery_name, ValueMap& customs);
-
-  OpenDDS::DCPS::Discovery::RepoKey get_discovery_template_instance_name(DDS::DomainId_t id);
-
-  bool is_discovery_template(const OPENDDS_STRING& name);
 
 public:
   /// getter for lock that protects the static initialization of XTypes related data structures

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -1724,7 +1724,7 @@ namespace {
 }
 
 int
-StaticDiscovery::load_configuration(ACE_Configuration_Heap&)
+StaticDiscovery::load_configuration()
 {
   if (parse_topics() ||
       parse_datawriterqos() ||

--- a/dds/DCPS/StaticDiscovery.h
+++ b/dds/DCPS/StaticDiscovery.h
@@ -865,7 +865,7 @@ public:
 
   RepoKey key() const { return key_; }
 
-  int load_configuration(ACE_Configuration_Heap& config);
+  int load_configuration();
 
   virtual GUID_t generate_participant_guid();
 

--- a/tests/security/ConcurrentAuthLimit/ConcurrentAuthLimit.cpp
+++ b/tests/security/ConcurrentAuthLimit/ConcurrentAuthLimit.cpp
@@ -265,7 +265,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   }
 
   const u_short port_common = disc->config()->port_common(domain);
-  const NetworkAddress multicast_address = disc->config()->multicast_address(port_common);
+  const NetworkAddress multicast_address = disc->config()->multicast_address(port_common, domain);
   ACE_DEBUG((LM_DEBUG, "multicast_address = %C\n", LogAddr(multicast_address).c_str()));
   ACE_SOCK_Dgram_Mcast multicast_socket;
 #ifdef ACE_HAS_MAC_OSX


### PR DESCRIPTION
Problem
-------

One of the goals of using the ConfigStore (#4134) is to minimize the number of entries in the ConfigStore that are generated by the framework itself.  Such entries are basically leaked.

The main culprit here is template support which
instatiates new `[domain]`, `[rtps_discovery]`, `[config]`, and `[transport]` sections.  This commit removes the need to instantiate `[rtps_discovery]` sections.

Solution
--------

Parameterize `RtpsDiscoveryConfig::default_multicast_group` on the domain so that it can be customized on the fly.