### PR TITLE
Fix Broken PDF Scraping in Sphinx

### DIFF
--- a/docs/sphinx_extensions/links.py
+++ b/docs/sphinx_extensions/links.py
@@ -258,7 +258,10 @@ def add_omg_spec(app, slug, version, our_name=None, display_name=None):
             if kind == fitz.LINK_GOTO:
                 loc = 'page={}&view=FitH,{}'.format(page, dest['to'].y)
             elif kind == fitz.LINK_NAMED:
-                loc = dest['name']
+                if 'name' in dest:
+                    loc = dest['name']
+                else:
+                    loc = dest['nameddest']
             else:
                 continue
 


### PR DESCRIPTION
This might be caused by a refactor that PyMuPDF is currently doing. This library is used to read the OMG spec table of contents to get the links. I could look into this further to see if this was intentional or a bug, but the fix seems to be trivial.