### PR TITLE
`TransportInst::load` is unnecessary

### DIFF
--- a/dds/DCPS/transport/framework/TransportInst.cpp
+++ b/dds/DCPS/transport/framework/TransportInst.cpp
@@ -41,30 +41,6 @@ TransportInst::~TransportInst()
   DBG_ENTRY_LVL("TransportInst","~TransportInst",6);
 }
 
-int
-TransportInst::load(ACE_Configuration_Heap& cf,
-                    ACE_Configuration_Section_Key& sect)
-{
-  process_section(*TheServiceParticipant->config_store(),
-                  ConfigReader_rch(),
-                  ConfigReaderListener_rch(),
-                  config_prefix_,
-                  cf,
-                  sect,
-                  "",
-                  false);
-
-  ACE_TString stringvalue;
-  if (cf.get_string_value (sect, ACE_TEXT("passive_connect_duration"), stringvalue) == 0) {
-    ACE_DEBUG ((LM_WARNING,
-                ACE_TEXT ("(%P|%t) WARNING: passive_connect_duration option ")
-                ACE_TEXT ("is deprecated in the transport inst, must be ")
-                ACE_TEXT ("defined in transport config.\n")));
-  }
-
-  return 0;
-}
-
 void
 TransportInst::dump(DDS::DomainId_t domain) const
 {

--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -31,11 +31,6 @@
 
 #include <ace/Synch_Traits.h>
 
-ACE_BEGIN_VERSIONED_NAMESPACE_DECL
-class ACE_Configuration_Heap;
-class ACE_Configuration_Section_Key;
-ACE_END_VERSIONED_NAMESPACE_DECL
-
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
@@ -78,11 +73,6 @@ public:
   }
 
   bool is_template() const { return is_template_; }
-
-  /// Overwrite the default configurations with the configuration from the
-  /// given section in the ACE_Configuration_Heap object.
-  virtual int load(ACE_Configuration_Heap& cf,
-                   ACE_Configuration_Section_Key& sect);
 
   /// Diagnostic aid.
   void dump(DDS::DomainId_t domain) const;

--- a/dds/DCPS/transport/framework/TransportRegistry.cpp
+++ b/dds/DCPS/transport/framework/TransportRegistry.cpp
@@ -175,7 +175,6 @@ TransportRegistry::load_transport_configuration(const OPENDDS_STRING& file_name,
             }
 
             instances.push_back(inst);
-            inst->load(cf, inst_sect);
 
             // store the transport info
             TransportEntry entry;

--- a/dds/DCPS/transport/multicast/MulticastInst.cpp
+++ b/dds/DCPS/transport/multicast/MulticastInst.cpp
@@ -63,15 +63,6 @@ MulticastInst::MulticastInst(const std::string& name)
   , async_send_(*this, &MulticastInst::async_send, &MulticastInst::async_send)
 {}
 
-int
-MulticastInst::load(ACE_Configuration_Heap& cf,
-                    ACE_Configuration_Section_Key& sect)
-{
-  TransportInst::load(cf, sect); // delegate to parent
-
-  return 0;
-}
-
 TransportImpl_rch
 MulticastInst::new_impl(DDS::DomainId_t domain)
 {

--- a/dds/DCPS/transport/multicast/MulticastInst.h
+++ b/dds/DCPS/transport/multicast/MulticastInst.h
@@ -144,9 +144,6 @@ public:
   void async_send(bool as);
   bool async_send() const;
 
-  virtual int load(ACE_Configuration_Heap& cf,
-                   ACE_Configuration_Section_Key& sect);
-
   /// Diagnostic aid.
   virtual OPENDDS_STRING dump_to_str(DDS::DomainId_t) const;
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -495,14 +495,6 @@ RtpsUdpInst::new_impl(DDS::DomainId_t domain)
   return make_rch<RtpsUdpTransport>(rchandle_from(this), domain);
 }
 
-int
-RtpsUdpInst::load(ACE_Configuration_Heap& cf,
-                  ACE_Configuration_Section_Key& sect)
-{
-  TransportInst::load(cf, sect); // delegate to parent
-  return 0;
-}
-
 OPENDDS_STRING
 RtpsUdpInst::dump_to_str(DDS::DomainId_t domain) const
 {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -86,9 +86,6 @@ public:
   void send_delay(const TimeDuration& sd);
   TimeDuration send_delay() const;
 
-  virtual int load(ACE_Configuration_Heap& cf,
-                   ACE_Configuration_Section_Key& sect);
-
   /// Diagnostic aid.
   virtual OPENDDS_STRING dump_to_str(DDS::DomainId_t domain) const;
 

--- a/dds/DCPS/transport/shmem/ShmemInst.cpp
+++ b/dds/DCPS/transport/shmem/ShmemInst.cpp
@@ -37,14 +37,6 @@ ShmemInst::new_impl(DDS::DomainId_t domain)
   return make_rch<ShmemTransport>(rchandle_from(this), domain);
 }
 
-int
-ShmemInst::load(ACE_Configuration_Heap& cf,
-                ACE_Configuration_Section_Key& sect)
-{
-  TransportInst::load(cf, sect);
-  return 0;
-}
-
 OPENDDS_STRING
 ShmemInst::dump_to_str(DDS::DomainId_t domain) const
 {

--- a/dds/DCPS/transport/shmem/ShmemInst.h
+++ b/dds/DCPS/transport/shmem/ShmemInst.h
@@ -21,9 +21,6 @@ class OpenDDS_Shmem_Export ShmemInst : public TransportInst {
 public:
   static const TimeDuration default_association_resend_period;
 
-  virtual int load(ACE_Configuration_Heap& cf,
-                   ACE_Configuration_Section_Key& sect);
-
   virtual OPENDDS_STRING dump_to_str(DDS::DomainId_t domain) const;
 
   /// Size (in bytes) of the single shared-memory pool allocated by this

--- a/dds/DCPS/transport/tcp/TcpInst.cpp
+++ b/dds/DCPS/transport/tcp/TcpInst.cpp
@@ -31,14 +31,6 @@ OpenDDS::DCPS::TcpInst::new_impl(DDS::DomainId_t domain)
   return make_rch<TcpTransport>(rchandle_from(this), domain);
 }
 
-int
-OpenDDS::DCPS::TcpInst::load(ACE_Configuration_Heap& cf,
-                             ACE_Configuration_Section_Key& trans_sect)
-{
-  TransportInst::load(cf, trans_sect);
-  return 0;
-}
-
 OPENDDS_STRING
 OpenDDS::DCPS::TcpInst::dump_to_str(DDS::DomainId_t domain) const
 {

--- a/dds/DCPS/transport/tcp/TcpInst.h
+++ b/dds/DCPS/transport/tcp/TcpInst.h
@@ -36,9 +36,6 @@ public:
   static const int DEFAULT_PASSIVE_RECONNECT_DURATION = 2000;
   static const int DEFAULT_ACTIVE_CONN_TIMEOUT_PERIOD = 5000;
 
-  virtual int load(ACE_Configuration_Heap& cf,
-                   ACE_Configuration_Section_Key& sect);
-
   /// Diagnostic aid.
   virtual OPENDDS_STRING dump_to_str(DDS::DomainId_t domain) const;
 

--- a/dds/DCPS/transport/udp/UdpInst.cpp
+++ b/dds/DCPS/transport/udp/UdpInst.cpp
@@ -35,14 +35,6 @@ UdpInst::new_impl(DDS::DomainId_t domain)
   return make_rch<UdpTransport>(rchandle_from(this), domain);
 }
 
-int
-UdpInst::load(ACE_Configuration_Heap& cf,
-              ACE_Configuration_Section_Key& sect)
-{
-  TransportInst::load(cf, sect); // delegate to parent
-  return 0;
-}
-
 OPENDDS_STRING
 UdpInst::dump_to_str(DDS::DomainId_t domain) const
 {

--- a/dds/DCPS/transport/udp/UdpInst.h
+++ b/dds/DCPS/transport/udp/UdpInst.h
@@ -30,9 +30,6 @@ public:
   void rcv_buffer_size(ACE_INT32 rbs);
   ACE_INT32 rcv_buffer_size() const;
 
-  virtual int load(ACE_Configuration_Heap& cf,
-                   ACE_Configuration_Section_Key& sect);
-
   /// Diagnostic aid.
   virtual OPENDDS_STRING dump_to_str(DDS::DomainId_t) const;
 

--- a/tests/DCPS/Thrasher/Publisher.cpp
+++ b/tests/DCPS/Thrasher/Publisher.cpp
@@ -12,6 +12,8 @@
 #include <dds/DCPS/transport/framework/TransportRegistry.h>
 #include <dds/DCPS/transport/framework/TransportConfig.h>
 #include <dds/DCPS/transport/framework/TransportInst.h>
+#include <dds/DCPS/transport/rtps_udp/RtpsUdpInst_rch.h>
+#include <dds/DCPS/transport/rtps_udp/RtpsUdpInst.h>
 
 #include <string>
 #include <stdexcept>
@@ -167,23 +169,16 @@ void Publisher::configure_transport()
   OpenDDS::RTPS::RtpsDiscovery_rch rd = OpenDDS::DCPS::dynamic_rchandle_cast<OpenDDS::RTPS::RtpsDiscovery>(disc);
   if (!rd.is_nil()) {
     char config_name[64], inst_name[64];
-    ACE_TCHAR nak_depth[8];
     ACE_OS::snprintf(config_name, 64, "cfg_%d", thread_index_);
     ACE_OS::snprintf(inst_name, 64, "rtps_%d", thread_index_);
-    // The 2 is a safety factor to allow for control messages.
-    ACE_OS::snprintf(nak_depth, 8, ACE_SIZE_T_FORMAT_SPECIFIER, 2 * samples_per_thread_);
     ACE_DEBUG((LM_INFO, (pfx_ + "->transport %C\n").c_str(), config_name));
     OpenDDS::DCPS::TransportConfig_rch config = TheTransportRegistry->create_config(config_name);
     OpenDDS::DCPS::TransportInst_rch inst = TheTransportRegistry->create_inst(inst_name, "rtps_udp");
-    ACE_Configuration_Heap ach;
-    ACE_Configuration_Section_Key sect_key;
-    ach.open();
-    ach.open_section(ach.root_section(), ACE_TEXT("not_root"), 1, sect_key);
-    ach.set_string_value(sect_key, ACE_TEXT("use_multicast"), ACE_TEXT("0"));
-    ach.set_string_value(sect_key, ACE_TEXT("nak_depth"), nak_depth);
-    ach.set_string_value(sect_key, ACE_TEXT("heartbeat_period"), ACE_TEXT("200"));
-    ach.set_string_value(sect_key, ACE_TEXT("heartbeat_response_delay"), ACE_TEXT("100"));
-    inst->load(ach, sect_key);
+    OpenDDS::DCPS::RtpsUdpInst_rch rtps_inst = OpenDDS::DCPS::static_rchandle_cast<OpenDDS::DCPS::RtpsUdpInst>(inst);
+    rtps_inst->use_multicast(false);
+    // The 2 is a safety factor to allow for control messages.
+    rtps_inst->nak_depth(2 * samples_per_thread_);
+    rtps_inst->heartbeat_period(OpenDDS::DCPS::TimeDuration::from_msec(200));
     config->passive_connect_duration_ = 600000;
     config->instances_.push_back(inst);
     TheTransportRegistry->bind_config(config_name, dp_);


### PR DESCRIPTION
Problem
-------

`TransportInst::load` is no longer necessary and can be removed.

Solution
--------

Remove `TransportInst::load`.