### PR TITLE
Equality operator not in namespace for `-Lc++11 -Gequality`

### DIFF
--- a/dds/idl/langmap_generator.cpp
+++ b/dds/idl/langmap_generator.cpp
@@ -1762,6 +1762,7 @@ struct Cxx11Generator : GeneratorBase
                  const std::vector<AST_UnionBranch*>& branches, AST_Type* discriminator)
   {
     const ScopedNamespaceGuard namespaces(name, be_global->lang_header_);
+    const ScopedNamespaceGuard namespacesCpp(name, be_global->impl_);
     const char* const nm = name->last_component()->get_string();
     const std::string d_type = generator_->map_type(discriminator);
     const std::string defVal = generateDefaultValue(u);
@@ -1818,7 +1819,6 @@ struct Cxx11Generator : GeneratorBase
     gen_common_strunion_post(nm);
     gen_union_pragma_post();
 
-    const ScopedNamespaceGuard namespacesCpp(name, be_global->impl_);
     be_global->impl_ <<
       nm << "::" << nm << "(const " << nm << "& rhs)\n"
       "{\n"

--- a/tests/DCPS/Compiler/idl_test_nested_types_lib/NestedTypesTest.idl
+++ b/tests/DCPS/Compiler/idl_test_nested_types_lib/NestedTypesTest.idl
@@ -47,4 +47,22 @@ module NestedTypesTest {
   struct TypedefStructKeyStruct {
     MyStructTypedef my_struct_typedef_key;
   };
+
+  enum msgType_t {
+    val1,
+    val2
+  };
+
+  union msgUnion_t switch (msgType_t) {
+    case val1:
+      string someString;
+    case val2:
+      float someFloat;
+  };
+
+  @topic
+  struct Message {
+    @key long subject_id;
+    msgUnion_t msgUnion;
+  };
 };


### PR DESCRIPTION
Problem
-------

When using `-Lc++11 -Gequality`, the generated equality operator for a union is not in the appropriate namespace.  This leads to code that can't be compiled.  See #4447.

Solution
--------

Move the namespace scoping guard ahead of the operator generation and extend a test.