### PR TITLE
Post 3.27.0 Release Script Improvements

### DIFF
--- a/docs/devguide/shapes.rst
+++ b/docs/devguide/shapes.rst
@@ -1,3 +1,5 @@
+.. _shapes-demo:
+
 ###########
 Shapes Demo
 ###########

--- a/docs/internal/release.rst
+++ b/docs/internal/release.rst
@@ -376,7 +376,7 @@ Upload Artifacts from Release Workflows
 
     This should only be done for the :ref:`latest release <release-latest-release>`.
 
-During the release script there are steps that trigger :ref:`release workflows <release-workflows>` on GitHub Actions and print out links to the runs.
+The release script has steps that trigger :ref:`release workflows <release-workflows>` on GitHub Actions and print out links to the runs.
 After they have finished successfully, run the release script with the version and workspace arguments and the ``--upload-artifacts`` option.
 If the workflows are still in progress it will say so and give the links again.
 If the workflows were successful, it will download the artifacts, package them, and upload them to GitHub.

--- a/docs/internal/release.rst
+++ b/docs/internal/release.rst
@@ -161,6 +161,8 @@ To do this follow these steps:
 
 The release script will merge ``website-next-release`` into ``gh-pages`` on the ``OpenDDS/OpenDDS`` repository during the release process.
 
+.. _release-workflows:
+
 Check if GHA Workflows need Updating
 ====================================
 
@@ -176,14 +178,14 @@ Then manually trigger them to make sure they work.
 
 The workflows are:
 
-- Shapes Demo:
+- :ref:`shapes-demo`:
   :ghfile:`(file) <.github/workflows/ishapes.yml>`,
   `(runs) <https://github.com/OpenDDS/OpenDDS/actions/workflows/ishapes.yml>`__,
-  :ref:`(instructions) <release-shapes-postrelease>`,
-- RTPS Interop Test:
+- `OMG RTPS interoperability test <https://github.com/omg-dds/dds-rtps>`__:
   :ghfile:`(file) <.github/workflows/dds-rtps.yml>`,
   `(runs) <https://github.com/OpenDDS/OpenDDS/actions/workflows/dds-rtps.yml>`__,
-  :ref:`(instructions) <release-rtps-postrelease>`,
+
+These will be triggered by the release script, then must be :ref:`uploaded after release <release-upload-artifacts>`.
 
 ****************
 Making a Release
@@ -208,8 +210,10 @@ Before Running the Release Script
     - Git version 2.5 or later
     - :ref:`Python 3 for News Generation <docs-requirements>`
 
-  - Your GitHub account has been added as a member of the `OpenDDS organization <https://github.com/OpenDDS>`__ with the appropriate permissions.
+  - Your GitHub account meets the following requirements:
 
+    - It has been added as a member of the `OpenDDS organization <https://github.com/OpenDDS>`__ with the appropriate permissions.
+    - It has permissions to update the release artifacts for the `OMG RTPS Interop repo <https://github.com/omg-dds/dds-rtps>`__ for :ref:`release-upload-artifacts`.
     - `You have uploaded your SSH public key to your GitHub account <https://help.github.com/articles/generating-an-ssh-key>`__
     - `You have created a Personal Access Token for your GitHub account <https://help.github.com/articles/creating-an-access-token-for-command-line-use/>`__
 
@@ -363,36 +367,19 @@ Updating the news consists of:
 - Copy the micro release file in :ghfile:`docs/news.d/_releases`.
 - Remove the :ref:`news fragments <docs-news>` in :ghfile:`docs/news.d` for the PRs that were backported.
 
-.. _release-shapes-postrelease:
+.. _release-upload-artifacts:
 
-Upload the Shapes Demo Binaries
--------------------------------
-
-.. note::
-
-    This should only be done for the :ref:`latest release <release-latest-release>`.
-
-During the release script there’s a step called "Trigger Shapes Demo Build" that triggers a workflow on GitHub to build the shapes demo for the new release.
-If it was successful it will print out the link to the run so it can be monitored.
-
-After it has finished successfully, run the release script with the version and workspace arguments and the ``--upload-shapes-demo`` option.
-If the workflow is still in progress it will say so and give the link again.
-If the workflow is successful it will download the shapes demo binaries, package them, and upload them to GitHub.
-
-.. _release-rtps-postrelease:
-
-Upload the RTPS Interop Test
-----------------------------
+Upload Artifacts from Release Workflows
+---------------------------------------
 
 .. note::
 
     This should only be done for the :ref:`latest release <release-latest-release>`.
 
-During the release script there’s a step called "Trigger RTPS Interop Test Build" that triggers a workflow on GitHub to build the `OMG RTPS interoperability test <https://github.com/omg-dds/dds-rtps>`__ for the new release.
-If it was successful it will print out the link to the run so it can be monitored.
-
-After it has finished successfully, take the Linux executable from it and `upload it as a release artifact on the OMG repo <https://github.com/omg-dds/dds-rtps#upload-executable>`__.
-Request access to upload a release artifact if needed.
+During the release script there are steps that trigger :ref:`release workflows <release-workflows>` on GitHub Actions and print out links to the runs.
+After they have finished successfully, run the release script with the version and workspace arguments and the ``--upload-artifacts`` option.
+If the workflows are still in progress it will say so and give the links again.
+If the workflows were successful, it will download the artifacts, package them, and upload them to GitHub.
 
 Remove Files Used for Release
 -----------------------------

--- a/tools/scripts/gitrelease.pl
+++ b/tools/scripts/gitrelease.pl
@@ -507,7 +507,7 @@ sub download {
   }
 
   my @redirects = $response->redirects();
-  if (!$response->is_success() && scalar(@redirects) && $args{redirect_retry_no_auth}) {
+  if ($response->code() == 403 && scalar(@redirects) && $args{redirect_retry_no_auth}) {
     # Workaround redirect to real artifact URL failing because of authorization:
     # https://github.com/orgs/community/discussions/88698
     $request->remove_header('Authorization');

--- a/tools/scripts/modules/ini.pm
+++ b/tools/scripts/modules/ini.pm
@@ -14,15 +14,9 @@ our @EXPORT_OK = qw(
   get_ini_value
 );
 
-sub die_with_stack_trace {
-  my $i = 1;
-  print STDERR ("ERROR: ", @_, " STACK TRACE:\n");
-  while (my @call_details = (caller($i++)) ){
-      print STDERR ("ERROR: STACK TRACE[", $i - 2, "] " .
-        "$call_details[1]:$call_details[2] in function $call_details[3]\n");
-  }
-  die();
-}
+use FindBin;
+use lib "$FindBin::RealBin";
+use misc_utils qw/trace/;
 
 sub print_usage {
   my $fh = shift() // *STDERR;
@@ -46,7 +40,7 @@ sub read_ini_file {
   my @section_names;
   my %sections;
   my $section;
-  open(my $fh, $path) or die_with_stack_trace("Couldn't open \"$path\": $!\nStopped");
+  open(my $fh, $path) or trace("Couldn't open \"$path\": $!");
   while (my $line = <$fh>) {
     $line =~ s/\s$//;
     if ($line =~ /\[(\w+)\]/) {

--- a/tools/scripts/modules/misc_utils.pm
+++ b/tools/scripts/modules/misc_utils.pm
@@ -1,0 +1,23 @@
+package misc_utils;
+
+use strict;
+use warnings;
+
+require Exporter;
+our @ISA = qw(Exporter);
+our @EXPORT_OK = qw(
+  trace
+);
+
+sub trace {
+  my $i = 0;
+  my $msg = "ERROR: " . join('', @_) . "\n";
+  while (my @call = (caller($i++))) {
+    my @next = caller($i);
+    my $from = @next ? $next[3] : 'main';
+    $msg .= "ERROR: STACK TRACE[" . ($i - 1) . "] $call[1]:$call[2] in $from\n";
+  }
+  die($msg);
+}
+
+1;


### PR DESCRIPTION
- Replace `--upload-shapes-demo` with `--upload-artifacts`, which will now upload the RTPS interop test in addition to the shapes demo.
- `--upload-shapes-demo`, now `--upload-artifacts` was unable to download artifacts from workflows. [This GitHub discussion answer](https://github.com/orgs/community/discussions/88698#discussioncomment-8252538) provided an overview of the issue. The artifact download URL was being redirected to an internal Microsoft one which rejects GitHub authentication. The solution was to use the `download` function instead of PitHub and make a special case where it detects the failed redirect and retries it without authentication.
- Replace the multiple `die_with_stack_trace` functions with a single implementation called `trace`. Also fixed the confusing off-by-one error in the output.
- Replaced invalid usage of `$?` with `$!`.