### PR TITLE
`load_transport_configuration` uses `ACE_Configuration_Heap`

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -496,8 +496,7 @@ Sedp::init(const GUID_t& guid,
                             domainStr;
   transport_cfg_ = TheTransportRegistry->create_config(config_name.c_str());
   transport_cfg_->instances_.push_back(transport_inst_);
-  transport_cfg_->passive_connect_duration_ =
-    static_cast<unsigned long>(disco.config()->sedp_passive_connect_duration().value().get_msec());
+  transport_cfg_->passive_connect_duration_ = disco.config()->sedp_passive_connect_duration();
 
   // Use a static cast to avoid dependency on the RtpsUdp library
   DCPS::RtpsUdpInst_rch rtps_inst =

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -1542,7 +1542,7 @@ Service_Participant::load_configuration(
                      -1);
   }
 
-  status = TransportRegistry::instance()->load_transport_configuration(ACE_TEXT_ALWAYS_CHAR(filename), config);
+  status = TransportRegistry::instance()->load_transport_configuration(ACE_TEXT_ALWAYS_CHAR(filename));
   const String global_transport_config = config_store_->get(OPENDDS_COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG,
                                                             OPENDDS_COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG_default);
   if (!global_transport_config.empty()) {

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -129,9 +129,9 @@ TransportClient::enable_transport_using_config(bool reliable, bool durable,
   swap_bytes_ = tc->swap_bytes_;
   reliable_ = reliable;
   durable_ = durable;
-  unsigned long duration = tc->passive_connect_duration_;
-  if (duration == 0) {
-    duration = TransportConfig::DEFAULT_PASSIVE_CONNECT_DURATION;
+  passive_connect_duration_ = tc->passive_connect_duration_;
+  if (passive_connect_duration_ == 0) {
+    passive_connect_duration_ = TimeDuration::from_msec(TransportConfig::DEFAULT_PASSIVE_CONNECT_DURATION);
     if (DCPS_debug_level) {
       ACE_DEBUG((LM_WARNING,
         ACE_TEXT("(%P|%t) TransportClient::enable_transport_using_config ")
@@ -139,7 +139,6 @@ TransportClient::enable_transport_using_config(bool reliable, bool durable,
         ACE_TEXT("default value\n")));
     }
   }
-  passive_connect_duration_ = TimeDuration::from_msec(duration);
 
   populate_connection_info(dpi);
 

--- a/dds/DCPS/transport/framework/TransportConfig.cpp
+++ b/dds/DCPS/transport/framework/TransportConfig.cpp
@@ -19,13 +19,56 @@ const unsigned long TransportConfig::DEFAULT_PASSIVE_CONNECT_DURATION;
 #endif
 
 TransportConfig::TransportConfig(const OPENDDS_STRING& name)
-  : swap_bytes_(false)
-  , passive_connect_duration_(DEFAULT_PASSIVE_CONNECT_DURATION)
+  : swap_bytes_(*this, &TransportConfig::swap_bytes, &TransportConfig::swap_bytes)
+  , passive_connect_duration_(*this, &TransportConfig::passive_connect_duration, &TransportConfig::passive_connect_duration)
+  , transports_(*this, &TransportConfig::transports, &TransportConfig::transports)
   , name_(name)
+  , config_prefix_(ConfigPair::canonicalize("OPENDDS_CONFIG_" + name_))
 {}
 
 TransportConfig::~TransportConfig()
 {}
+
+void
+TransportConfig::swap_bytes(bool flag)
+{
+  TheServiceParticipant->config_store()->set_boolean(config_key("SWAP_BYTES").c_str(), flag);
+}
+
+bool
+TransportConfig::swap_bytes() const
+{
+  return TheServiceParticipant->config_store()->get_boolean(config_key("SWAP_BYTES").c_str(), false);
+}
+
+void
+TransportConfig::passive_connect_duration(const TimeDuration& pcd)
+{
+  TheServiceParticipant->config_store()->set(config_key("PASSIVE_CONNECT_DURATION").c_str(),
+                                             pcd,
+                                             ConfigStoreImpl::Format_IntegerMilliseconds);
+
+}
+
+TimeDuration
+TransportConfig::passive_connect_duration() const
+{
+  return TheServiceParticipant->config_store()->get(config_key("PASSIVE_CONNECT_DURATION").c_str(),
+                                                    TimeDuration::from_msec(DEFAULT_PASSIVE_CONNECT_DURATION),
+                                                    ConfigStoreImpl::Format_IntegerMilliseconds);
+}
+
+void
+TransportConfig::transports(const ConfigStoreImpl::StringList& t)
+{
+  TheServiceParticipant->config_store()->set(config_key("TRANSPORTS").c_str(), t);
+}
+
+ConfigStoreImpl::StringList
+TransportConfig::transports() const
+{
+  return TheServiceParticipant->config_store()->get(config_key("TRANSPORTS").c_str(), ConfigStoreImpl::StringList());
+}
 
 void
 TransportConfig::sorted_insert(const TransportInst_rch& inst)

--- a/dds/DCPS/transport/framework/TransportConfig.h
+++ b/dds/DCPS/transport/framework/TransportConfig.h
@@ -30,17 +30,30 @@ public:
 
   static const unsigned long DEFAULT_PASSIVE_CONNECT_DURATION = 60000;
 
-  OPENDDS_STRING name() const { return name_; }
+  const String& name() const { return name_; }
+  const String& config_prefix() const { return config_prefix_; }
+  String config_key(const String& key) const
+  {
+    return ConfigPair::canonicalize(config_prefix_ + "_" + key);
+  }
 
   typedef OPENDDS_VECTOR(TransportInst_rch) InstancesType;
   InstancesType instances_;
 
-  bool swap_bytes_;
+  ConfigValue<TransportConfig, bool> swap_bytes_;
+  void swap_bytes(bool flag);
+  bool swap_bytes() const;
 
   /// The time period in milliseconds for the acceptor side
   /// of a connection to wait for the connection.
   /// The default is 60 seconds
-  unsigned long passive_connect_duration_;
+  ConfigValueRef<TransportConfig, TimeDuration> passive_connect_duration_;
+  void passive_connect_duration(const TimeDuration& pcd);
+  TimeDuration passive_connect_duration() const;
+
+  ConfigValueRef<TransportConfig, ConfigStoreImpl::StringList> transports_;
+  void transports(const ConfigStoreImpl::StringList& t);
+  ConfigStoreImpl::StringList transports() const;
 
   /// Insert the TransportInst in sorted order (by name) in the instances_ list.
   /// Use when the names of the TransportInst objects are specifically assigned
@@ -56,10 +69,11 @@ private:
   friend class TransportRegistry;
   template <typename T, typename U>
   friend RcHandle<T> OpenDDS::DCPS::make_rch(U const&);
-  explicit TransportConfig(const OPENDDS_STRING& name);
+  explicit TransportConfig(const String& name);
   ~TransportConfig();
 
-  const OPENDDS_STRING name_;
+  const String name_;
+  const String config_prefix_;
 };
 
 }

--- a/dds/DCPS/transport/framework/TransportRegistry.cpp
+++ b/dds/DCPS/transport/framework/TransportRegistry.cpp
@@ -86,236 +86,122 @@ TransportRegistry::TransportRegistry()
   lib_directive_map_["repository"] = "dynamic OpenDDS_InfoRepoDiscovery Service_Object * OpenDDS_InfoRepoDiscovery:_make_IRDiscoveryLoader()";
 }
 
-int
-TransportRegistry::load_transport_configuration(const OPENDDS_STRING& file_name,
-                                                ACE_Configuration_Heap& cf)
+bool TransportRegistry::process_transport(const String& transport_id,
+                                          bool is_template,
+                                          OPENDDS_LIST(TransportInst_rch)& instances)
 {
-  const ACE_Configuration_Section_Key& root = cf.root_section();
+  // Get the factory_id for the transport.
+  const String transport_type =
+    TheServiceParticipant->config_store()->get(String((is_template ? "OPENDDS_TRANSPORT_TEMPLATE_" : "OPENDDS_TRANSPORT_") + transport_id + "_TRANSPORT_TYPE").c_str(), "");
 
-  // Create a vector to hold configuration information so we can populate
-  // them after the transports instances are created.
-  typedef std::pair<TransportConfig_rch, OPENDDS_VECTOR(OPENDDS_STRING) > ConfigInfo;
-  OPENDDS_VECTOR(ConfigInfo) configInfoVec;
+  if (transport_type.empty()) {
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR,
+                 "(%P|%t) TransportRegistry::process_transport: "
+                 "missing transport_type in [transport/%C] section.\n",
+                 transport_id.c_str()));
+    }
+    return false;
+  }
 
+  // Create the TransportInst object and load the transport
+  // configuration.
+  TransportInst_rch inst = create_inst(transport_id, transport_type, is_template);
+  if (!inst) {
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR,
+                 "(%P|%t) TransportRegistry::process_transport: "
+                 "Unable to create transport instance in [transport/%C] section.\n",
+                 transport_id.c_str()));
+    }
+    return false;
+  }
+
+  instances.push_back(inst);
+
+  return true;
+}
+
+bool TransportRegistry::process_config(const String& config_id)
+{
+  // Create a TransportConfig object.
+  TransportConfig_rch config = create_config(config_id);
+  if (!config) {
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR,
+                 "(%P|%t) TransportRegistry::process_config: "
+                 "Unable to create transport config in [config/%C] section.\n",
+                 config_id.c_str()));
+    }
+    return false;
+  }
+
+  if (config->transports().empty()) {
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR,
+                 "(%P|%t) TransportRegistry::process_config: "
+                 "No transport instances listed in [config/%C] section.\n",
+                 config_id.c_str()));
+    }
+    return false;
+  }
+
+  const ConfigStoreImpl::StringList transports = config->transports();
+  for (ConfigStoreImpl::StringList::const_iterator pos = transports.begin(), limit = transports.end();
+       pos != limit; ++pos) {
+    TransportInst_rch inst = get_inst(*pos);
+    if (!inst) {
+      if (log_level >= LogLevel::Error) {
+        ACE_ERROR((LM_ERROR,
+                   "(%P|%t) TransportRegistry::load_transport_configuration: "
+                   "The inst (%C) in [config/%C] section is undefined.\n",
+                   pos->c_str(), config->name().c_str()));
+      }
+      return -1;
+    }
+    config->instances_.push_back(inst);
+  }
+
+  return true;
+}
+
+int
+TransportRegistry::load_transport_configuration(const String& file_name)
+{
   // Record the transport instances created, so we can place them
   // in the implicit transport configuration for this file.
   OPENDDS_LIST(TransportInst_rch) instances;
 
-  ACE_TString sect_name;
-
-  for (int index = 0;
-       cf.enumerate_sections(root, index, sect_name) == 0;
-       ++index) {
-    const bool is_template = ACE_OS::strcmp(sect_name.c_str(), TRANSPORT_TEMPLATE_SECTION_NAME) == 0;
-    if (ACE_OS::strcmp(sect_name.c_str(), TRANSPORT_SECTION_NAME) == 0 ||
-        is_template) {
-      // found the [transport/*] or [transport_template/*] section,
-      // now iterate through subsections...
-      ACE_Configuration_Section_Key sect;
-      if (cf.open_section(root, sect_name.c_str(), false, sect) != 0) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                          ACE_TEXT("failed to open section %C\n"),
-                          sect_name.c_str()),
-                         -1);
-      } else {
-        // Ensure there are no properties in this section
-        ValueMap vm;
-        if (pullValues(cf, sect, vm) > 0) {
-          // There are values inside [transport]
-          ACE_ERROR_RETURN((LM_ERROR,
-                            ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                            ACE_TEXT("transport sections must have a section name\n"),
-                            sect_name.c_str()),
-                           -1);
-        }
-        // Process the subsections of this section (the individual transport
-        // impls).
-        KeyList keys;
-        if (processSections(cf, sect, keys) != 0) {
-          ACE_ERROR_RETURN((LM_ERROR,
-                            ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                            ACE_TEXT("too many nesting layers in [%C] section.\n"),
-                            sect_name.c_str()),
-                           -1);
-        }
-        for (KeyList::const_iterator it = keys.begin(); it != keys.end(); ++it) {
-          ACE_TString transport_id = ACE_TEXT_CHAR_TO_TCHAR(it->first.c_str());
-          ACE_Configuration_Section_Key inst_sect = it->second;
-
-          ValueMap values;
-          if (pullValues(cf, it->second, values) != 0) {
-            // Get the factory_id for the transport.
-            OPENDDS_STRING transport_type;
-            ValueMap::const_iterator vm_it = values.find("TRANSPORT_TYPE");
-            if (vm_it == values.end()) {
-              vm_it = values.find("transport_type");
-            }
-            if (vm_it != values.end()) {
-              transport_type = vm_it->second;
-            } else {
-              ACE_ERROR_RETURN((LM_ERROR,
-                                ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                                ACE_TEXT("missing transport_type in [transport/%C] section.\n"),
-                                transport_id.c_str()),
-                               -1);
-            }
-
-            // Create the TransportInst object and load the transport
-            // configuration in ACE_Configuration_Heap to the TransportInst
-            // object.
-            const OPENDDS_STRING tid_str = transport_id.c_str() ? ACE_TEXT_ALWAYS_CHAR(transport_id.c_str()) : "";
-            TransportInst_rch inst = create_inst(tid_str, transport_type, is_template);
-            if (!inst) {
-              ACE_ERROR_RETURN((LM_ERROR,
-                                ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                                ACE_TEXT("Unable to create transport instance in [transport/%C] section.\n"),
-                                transport_id.c_str()),
-                               -1);
-            }
-
-            instances.push_back(inst);
-
-            // store the transport info
-            TransportEntry entry;
-            entry.transport_name = transport_id;
-            entry.transport_info = values;
-            transports_.push_back(entry);
-          } else {
-            ACE_ERROR_RETURN((LM_ERROR,
-                              ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                              ACE_TEXT("missing transport_type in [transport/%C] section.\n"),
-                              transport_id.c_str()),
-                             -1);
-          }
-        }
-      }
-    } else if (ACE_OS::strcmp(sect_name.c_str(), CONFIG_SECTION_NAME) == 0) {
-      // found the [config/*] section, now iterate through subsections...
-      ACE_Configuration_Section_Key sect;
-      if (cf.open_section(root, sect_name.c_str(), false, sect) != 0) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                          ACE_TEXT("failed to open section [%C]\n"),
-                          sect_name.c_str()),
-                         -1);
-      } else {
-        // Ensure there are no properties in this section
-        ValueMap vm;
-        if (pullValues(cf, sect, vm) > 0) {
-          // There are values inside [config]
-          ACE_ERROR_RETURN((LM_ERROR,
-                            ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                            ACE_TEXT("config sections must have a section name\n"),
-                            sect_name.c_str()),
-                           -1);
-        }
-        // Process the subsections of this section (the individual config
-        // impls).
-        KeyList keys;
-        if (processSections(cf, sect, keys) != 0) {
-          // Don't allow multiple layers of nesting ([config/x/y]).
-          ACE_ERROR_RETURN((LM_ERROR,
-                            ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                            ACE_TEXT("too many nesting layers in [%C] section.\n"),
-                            sect_name.c_str()),
-                           -1);
-        }
-        for (KeyList::const_iterator it = keys.begin(); it != keys.end(); ++it) {
-          OPENDDS_STRING config_id = it->first;
-
-          // Create a TransportConfig object.
-          TransportConfig_rch config = create_config(config_id);
-          if (!config) {
-            ACE_ERROR_RETURN((LM_ERROR,
-                              ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                              ACE_TEXT("Unable to create transport config in [config/%C] section.\n"),
-                              config_id.c_str()),
-                             -1);
-          }
-
-          ValueMap values;
-          pullValues(cf, it->second, values);
-
-          ConfigInfo configInfo;
-          configInfo.first = config;
-          for (ValueMap::const_iterator it = values.begin(); it != values.end(); ++it) {
-            OPENDDS_STRING name = it->first;
-            OPENDDS_STRING value = it->second;
-            if (name == "transports") {
-              char delim = ',';
-              size_t pos = 0;
-              OPENDDS_STRING token;
-              while ((pos = value.find(delim)) != OPENDDS_STRING::npos) {
-                token = value.substr(0, pos);
-                configInfo.second.push_back(token);
-                value.erase(0, pos + 1);
-              }
-
-              // store the config name for the transport entry
-              for (OPENDDS_VECTOR(TransportEntry)::iterator it = transports_.begin(); it != transports_.end(); ++it) {
-                if (!ACE_OS::strcmp(ACE_TEXT_ALWAYS_CHAR(it->transport_name.c_str()), value.c_str())) {
-                  it->config_name = ACE_TEXT_CHAR_TO_TCHAR(config_id.c_str());
-                  break;
-                }
-              }
-
-              configInfo.second.push_back(value);
-
-              configInfoVec.push_back(configInfo);
-            } else if (name == "swap_bytes") {
-              if ((value == "1") || (value == "true")) {
-                config->swap_bytes_ = true;
-              } else if ((value != "0") && (value != "false")) {
-                ACE_ERROR_RETURN((LM_ERROR,
-                                  ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                                  ACE_TEXT("Illegal value for swap_bytes (%C) in [config/%C] section.\n"),
-                                  value.c_str(), config_id.c_str()),
-                                 -1);
-              }
-            } else if (name == "passive_connect_duration") {
-              if (!convertToInteger(value,
-                                    config->passive_connect_duration_)) {
-                ACE_ERROR_RETURN((LM_ERROR,
-                                  ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                                  ACE_TEXT("Illegal integer value for passive_connect_duration (%C) in [config/%C] section.\n"),
-                                  value.c_str(), config_id.c_str()),
-                                 -1);
-              }
-            } else {
-              ACE_ERROR_RETURN((LM_ERROR,
-                                ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                                ACE_TEXT("Unexpected entry (%C) in [config/%C] section.\n"),
-                                name.c_str(), config_id.c_str()),
-                               -1);
-            }
-          }
-          if (configInfo.second.empty()) {
-            ACE_ERROR_RETURN((LM_ERROR,
-                              ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                              ACE_TEXT("No transport instances listed in [config/%C] section.\n"),
-                              config_id.c_str()),
-                             -1);
-          }
-        }
+  {
+    const ConfigStoreImpl::StringList transports =
+      TheServiceParticipant->config_store()->get_section_names("OPENDDS_TRANSPORT");
+    for (ConfigStoreImpl::StringList::const_iterator pos = transports.begin(), limit = transports.end();
+         pos != limit; ++pos) {
+      if (!process_transport(*pos, false, instances)) {
+        return -1;
       }
     }
   }
 
-  // Populate the configurations with instances
-  for (unsigned int i = 0; i < configInfoVec.size(); ++i) {
-    TransportConfig_rch config = configInfoVec[i].first;
-    OPENDDS_VECTOR(OPENDDS_STRING)& insts = configInfoVec[i].second;
-    for (unsigned int j = 0; j < insts.size(); ++j) {
-      TransportInst_rch inst = get_inst(insts[j]);
-      if (!inst) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                          ACE_TEXT("The inst (%C) in [config/%C] section is undefined.\n"),
-                          insts[j].c_str(), config->name().c_str()),
-                         -1);
+  {
+    const ConfigStoreImpl::StringList transports =
+      TheServiceParticipant->config_store()->get_section_names("OPENDDS_TRANSPORT_TEMPLATE");
+    for (ConfigStoreImpl::StringList::const_iterator pos = transports.begin(), limit = transports.end();
+         pos != limit; ++pos) {
+      if (!process_transport(*pos, true, instances)) {
+        return -1;
       }
-      config->instances_.push_back(inst);
+    }
+  }
+
+  {
+    const ConfigStoreImpl::StringList configs =
+      TheServiceParticipant->config_store()->get_section_names("OPENDDS_CONFIG");
+    for (ConfigStoreImpl::StringList::const_iterator pos = configs.begin(), limit = configs.end();
+         pos != limit; ++pos) {
+      if (!process_config(*pos)) {
+        return -1;
+      }
     }
   }
 
@@ -324,11 +210,13 @@ TransportRegistry::load_transport_configuration(const OPENDDS_STRING& file_name,
   if (!instances.empty()) {
     TransportConfig_rch config = create_config(file_name);
     if (!config) {
-      ACE_ERROR_RETURN((LM_ERROR,
-                        ACE_TEXT("(%P|%t) TransportRegistry::load_transport_configuration: ")
-                        ACE_TEXT("Unable to create default transport config.\n"),
-                        file_name.c_str()),
-                       -1);
+      if (log_level >= LogLevel::Error) {
+        ACE_ERROR((LM_ERROR,
+                   "(%P|%t) TransportRegistry::load_transport_configuration: "
+                   "Unable to create default transport config.\n",
+                   file_name.c_str()));
+      }
+      return -1;
     }
     instances.sort(predicate);
     for (OPENDDS_LIST(TransportInst_rch)::const_iterator it = instances.begin();
@@ -532,7 +420,6 @@ TransportRegistry::release()
     }
   }
 
-  transports_.clear();
   type_map_.clear();
   config_map_.clear();
   domain_default_config_map_.clear();
@@ -544,38 +431,6 @@ TransportRegistry::released() const
 {
   GuardType guard(lock_);
   return released_;
-}
-
-bool
-TransportRegistry::get_transport_info(const ACE_TString& config_name, TransportEntry& inst)
-{
-  bool ret = false;
-  if (has_transports()) {
-    for (OPENDDS_VECTOR(TransportEntry)::const_iterator i = transports_.begin(); i != transports_.end(); ++i) {
-      if (!ACE_OS::strcmp(ACE_TEXT_ALWAYS_CHAR(config_name.c_str()), ACE_TEXT_ALWAYS_CHAR(i->config_name.c_str()))) {
-        inst.transport_name = i->transport_name;
-        inst.config_name = i->config_name;
-        inst.transport_info = i->transport_info;
-
-        ret = true;
-        break;
-      }
-    }
-  }
-
-  if (DCPS_debug_level > 0) {
-    ACE_DEBUG((LM_DEBUG,
-               ACE_TEXT("(%P|%t) TransportRegistry::get_transport_info: ")
-               ACE_TEXT("%C config %s\n"),
-               ret ? "found" : "did not find", config_name.c_str()));
-  }
-
-  return ret;
-}
-
-bool TransportRegistry::has_transports() const
-{
-  return !transports_.empty();
 }
 
 void

--- a/dds/DCPS/transport/framework/TransportRegistry.cpp
+++ b/dds/DCPS/transport/framework/TransportRegistry.cpp
@@ -157,7 +157,7 @@ bool TransportRegistry::process_config(const String& config_id)
                    "The inst (%C) in [config/%C] section is undefined.\n",
                    pos->c_str(), config->name().c_str()));
       }
-      return -1;
+      return false;
     }
     config->instances_.push_back(inst);
   }

--- a/dds/DCPS/transport/framework/TransportRegistry.h
+++ b/dds/DCPS/transport/framework/TransportRegistry.h
@@ -99,8 +99,7 @@ public:
   /// at initialization time. This function iterates each section in
   /// the configuration file, and creates TransportInst and
   /// TransportConfig objects and adds them to the registry.
-  int load_transport_configuration(const OPENDDS_STRING& file_name,
-                                   ACE_Configuration_Heap& cf);
+  int load_transport_configuration(const String& file_name);
 
   /// For internal use by OpenDDS DCPS layer:
   /// If the default config is empty when it's about to be used, allow the
@@ -148,18 +147,11 @@ private:
 
   TransportType_rch load_transport_lib_i(const OPENDDS_STRING& transport_type);
 
-  struct TransportEntry
-  {
-    ACE_TString transport_name;
-    ACE_TString config_name;
-    ValueMap transport_info;
-  };
+  bool process_transport(const String& transport_id,
+                         bool is_template,
+                         OPENDDS_LIST(TransportInst_rch)& instances);
 
-  OPENDDS_VECTOR(TransportEntry) transports_;
-
-  bool get_transport_info(const ACE_TString& config_name, TransportEntry& inst);
-
-  bool has_transports() const;
+  bool process_config(const String& config_id);
 };
 
 } // namespace DCPS

--- a/java/dds/OpenDDS_DCPS_jni.cpp
+++ b/java/dds/OpenDDS_DCPS_jni.cpp
@@ -567,7 +567,7 @@ jint JNICALL Java_OpenDDS_DCPS_transport_TransportConfig_getPassiveConnectDurati
 (JNIEnv * jni, jobject jthis)
 {
   OpenDDS::DCPS::TransportConfig_rch config = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS::TransportConfig>(jni, jthis));
-  return config->passive_connect_duration_;
+  return config->passive_connect_duration().value().msec();
 }
 
 // TransportConfig::setPassiveConnectDuration
@@ -575,7 +575,7 @@ void JNICALL Java_OpenDDS_DCPS_transport_TransportConfig_setPassiveConnectDurati
 (JNIEnv * jni, jobject jthis, jint val)
 {
   OpenDDS::DCPS::TransportConfig_rch config = OpenDDS::DCPS::rchandle_from(recoverCppObj<OpenDDS::DCPS::TransportConfig>(jni, jthis));
-  config->passive_connect_duration_ = val;
+  config->passive_connect_duration(OpenDDS::DCPS::TimeDuration::from_msec(val));
 }
 
 // TransportInst

--- a/tests/DCPS/ConfigFile/ConfigFile.cpp
+++ b/tests/DCPS/ConfigFile/ConfigFile.cpp
@@ -90,7 +90,7 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     TEST_CHECK(config->instances_[0] == inst);
     TEST_CHECK(config->instances_[1] == inst2);
     TEST_CHECK(config->swap_bytes_ == true);
-    TEST_CHECK(config->passive_connect_duration_ == 20000);
+    TEST_CHECK(config->passive_connect_duration_ == TimeDuration::from_msec(20000));
 
     TransportConfig_rch default_config =
 #ifdef DDS_HAS_MINIMUM_BIT
@@ -109,7 +109,7 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     TEST_CHECK(default_config->instances_[2] == inst);   // mytcp
     TEST_CHECK(default_config->instances_[9]->name() == std::string("tcp7"));
     TEST_CHECK(default_config->swap_bytes_ == false);
-    TEST_CHECK(default_config->passive_connect_duration_ == 60000);
+    TEST_CHECK(default_config->passive_connect_duration_ == TimeDuration::from_msec(60000));
 
     TransportConfig_rch global_config =
       TransportRegistry::instance()->global_config();

--- a/tests/DCPS/Thrasher/Publisher.cpp
+++ b/tests/DCPS/Thrasher/Publisher.cpp
@@ -179,7 +179,7 @@ void Publisher::configure_transport()
     // The 2 is a safety factor to allow for control messages.
     rtps_inst->nak_depth(2 * samples_per_thread_);
     rtps_inst->heartbeat_period(OpenDDS::DCPS::TimeDuration::from_msec(200));
-    config->passive_connect_duration_ = 600000;
+    config->passive_connect_duration_ = OpenDDS::DCPS::TimeDuration::from_msec(600000);
     config->instances_.push_back(inst);
     TheTransportRegistry->bind_config(config_name, dp_);
   }

--- a/tools/modeling/plugins/org.opendds.modeling.sdk.model/xsl/traits_cpp.xsl
+++ b/tools/modeling/plugins/org.opendds.modeling.sdk.model/xsl/traits_cpp.xsl
@@ -140,8 +140,16 @@
         '&quot;);', $newline
     )"/>
     <xsl:for-each select="*[name() != 'transportRef']">
-      <xsl:value-of select="concat('    ', $config-varname, '->', name(), '_ = ',
-                                   @value, ';', $newline)"/>
+      <xsl:choose>
+        <xsl:when test="name() = 'passive_connect_duration'">
+          <xsl:value-of select="concat('    ', $config-varname, '->', name(), '(OpenDDS::DCPS::TimeDuration::from_msec(',
+                                @value, '));', $newline)"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="concat('    ', $config-varname, '->', name(), '_ = ',
+                                @value, ';', $newline)"/>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:for-each>
 
     <xsl:for-each select="transportRef">


### PR DESCRIPTION
Problem
-------

`load_transport_configuration` uses `ACE_Configuration_Heap` and `ACE_Configuration_Heap` is being removed where possible as part of #4134.

Solution
--------

Simplify the arguments to only have the file name.