### PR TITLE
OpenDDS cannot be configured with environment variables

### DIFF
--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -595,7 +595,7 @@ sub _process_common {
   my $self = shift;
   my $name = shift;
   my $params = shift;
-  my $debug_logging = 1;
+  my $debug_logging = $self->{dcps_log_level};
 
   if ($$params !~ /-DCPSLogLevel / && $self->{dcps_log_level}) {
     $$params .= " -DCPSLogLevel $self->{dcps_log_level}";

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -608,6 +608,10 @@ private:
   /// Initialize the thread scheduling and initial priority.
   void initializeScheduling();
 
+  /// Parse environment variables.
+  void parse_env();
+  void parse_env(const String& s);
+
   /**
    * Parse the command line for user options. e.g. "-DCPSInfoRepo <iorfile>".
    * It consumes -DCPS* options and their arguments

--- a/tests/DCPS/ConfigFile/ConfigFile.cpp
+++ b/tests/DCPS/ConfigFile/ConfigFile.cpp
@@ -40,6 +40,10 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       TheParticipantFactoryWithArgs(argc, argv);
     TEST_CHECK(dpf.in() != 0);
 
+    // From commandline
+    TEST_CHECK(TheServiceParticipant->config_store()->get("MY_CONFIG_KEY1", "") == "value1");
+    // From environment variable
+    TEST_CHECK(TheServiceParticipant->config_store()->get("MY_CONFIG_KEY2", "") == "value2");
     TEST_CHECK(OpenDDS::DCPS::DCPS_debug_level == 1);
     TEST_CHECK(TheServiceParticipant->n_chunks() == 10);
     TEST_CHECK(TheServiceParticipant->association_chunk_multiplier() == 5);

--- a/tests/DCPS/ConfigFile/run_test.pl
+++ b/tests/DCPS/ConfigFile/run_test.pl
@@ -4,8 +4,6 @@ eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
 
 # -*- perl -*-
 
-use Sys::Hostname;
-
 use Env (DDS_ROOT);
 use lib "$DDS_ROOT/bin";
 use Env (ACE_ROOT);
@@ -16,50 +14,29 @@ use Cwd;
 use File::Copy;
 use strict;
 
-my $status = 0;
+my $test = new PerlDDS::TestFramework();
+$test->{add_pending_timeout} = 0;
+$test->setup_discovery();
 
 my $dcpsrepo_ior = "repo.ior";
 my $dcpsrepo2_ior = "repo2.ior";
 my $dcpsrepo3_ior = "repo3.ior";
-
-
-unlink $dcpsrepo_ior;
-my $DCPSREPO = PerlDDS::create_process("$ENV{DDS_ROOT}/bin/DCPSInfoRepo",
-                                       " -o $dcpsrepo_ior");
-print $DCPSREPO->CommandLine() . "\n";
-$DCPSREPO->Spawn ();
-if (PerlACE::waitforfile_timed ($dcpsrepo_ior, 30) == -1) {
-    print STDERR "ERROR: waiting for Info Repo IOR file\n";
-    $DCPSREPO->Kill ();
-    exit 1;
-}
 
 copy($dcpsrepo_ior, $dcpsrepo2_ior);
 copy($dcpsrepo_ior, $dcpsrepo3_ior);
 
 my $cfg = new PerlACE::ConfigList->check_config('NO_BUILT_IN_TOPICS')
           ? 'test1_nobits.ini' : 'test1.ini';
-my $TST = PerlDDS::create_process("ConfigFile", "-DCPSConfigFile $cfg");
-print $TST->CommandLine() . "\n";
-my $retcode = $TST->SpawnWaitKill(60);
-if ($retcode != 0) {
-    $status = 1;
-}
 
-my $ir = $DCPSREPO->TerminateWaitKill(5);
-if ($ir != 0) {
-    print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
-    $status = 1;
-}
+$test->process('ConfigFile', 'ConfigFile', "-DCPSConfigFile $cfg -OpenDDSMyConfigKey1 value1");
 
-unlink $dcpsrepo_ior;
+$ENV{'OPENDDS_MY_CONFIG_KEY2'} = "value2";
+
+$test->start_process('ConfigFile');
+
+my $status = $test->finish(5);
+
 unlink $dcpsrepo2_ior;
 unlink $dcpsrepo3_ior;
-if ($status == 0) {
-  print "test PASSED.\n";
-}
-else {
-  print STDERR "test FAILED.\n";
-}
 
 exit $status;


### PR DESCRIPTION
Problem
-------

OpenDDS cannot be configured with environment variables.  Configuring with environment variables is useful for containers and cloud deployments.

Solution
--------

Parse environment variables and add them to the ConfigStore.  Only environment variables starting with OPENDDS_ are parsed.  The remainder of the name is used as the key for the ConfigStore. Environment variables are processed before command-line arguments and the config file.