### PR TITLE
Internal DDS cannot efficiently filter on instances

### DIFF
--- a/dds/DCPS/InternalDataReader.h
+++ b/dds/DCPS/InternalDataReader.h
@@ -197,6 +197,18 @@ public:
     return listener_.lock();
   }
 
+  void set_interesting_instances(const SampleSequence& instances)
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+    interesting_instances_ = instances;
+  }
+
+  const SampleSequence& get_interesting_instances() const
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, interesting_instances_);
+    return interesting_instances_;
+  }
+
   void read(SampleSequence& samples,
             InternalSampleInfoSequence& infos,
             CORBA::Long max_samples,
@@ -294,6 +306,8 @@ private:
   // pointer to prevent a cycle that prevents the listener from being
   // destroyed.
   Listener_wrch listener_;
+
+  SampleSequence interesting_instances_;
 
   typedef OPENDDS_SET(InternalEntity_wrch) PublicationSet;
 
@@ -495,7 +509,7 @@ private:
     {
       publication_set_.insert(publication_handle);
 
-      if (instance_state_ != DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
+      if (instance_state_ == DDS::ALIVE_INSTANCE_STATE) {
         instance_state_ = DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE;
         disposed_expiration_date_ = SystemTimePoint::now().to_dds_time() + qos.reader_data_lifecycle.autopurge_disposed_samples_delay;
         informed_of_not_alive_ = false;


### PR DESCRIPTION
Problem
-------

It is foreseeable that "demuxing" will be a necessary feature of the Internal DDS system.  For example, suppose a socket abstract writes RTPS message samples which are keyed by the participant guid prefix. A reader is probably only interested in one participant.  The write could give the sample to all readers which would be inefficient since only one reader is actually interested.

Solution
--------

This solution assumes that an InternalDataReader reader is interested in a set of instances that known a priori and are specified explicitly.  The InternalDataReader indexes attached readers on the instances to efficiently deliver samples to readers that are only interested in those instances.

Note
----

A "real" DDS systems would content-filtering to accomplish the same objective.