### PR TITLE
Clean up C++11 and `dcpslib` related mpb files

### DIFF
--- a/MPC/config/dcpslib.mpb
+++ b/MPC/config/dcpslib.mpb
@@ -1,7 +1,5 @@
-// Base project for internal OpenDDS libraries.
-// External: Use base dcps to depend on the OpenDDS_Dcps shared library
-// Internal: Use this base dcpslib to build depend on the library and
-//           place libraries in correct destination
+// Base project only for OpenDDS libraries that go in DDS_ROOT/lib. This should
+// NOT be used by users, for tests, or mpbs. Use dcps instead.
 project : dcps {
   libout      = $(DDS_ROOT)/lib
 }

--- a/MPC/config/opendds_cxx11.mpb
+++ b/MPC/config/opendds_cxx11.mpb
@@ -1,3 +1,5 @@
+// This is for projects that use the IDL to C++11 Mapping. Use
+// opendds_uses_cxx11 if the project only requires C++11.
 project: dcps, dcps_ts_defaults, opendds_uses_cxx11 {
   dcps_ts_flags += -Lc++11
   idlflags += -SS -Sa -St

--- a/MPC/config/opendds_cxx11.mpb
+++ b/MPC/config/opendds_cxx11.mpb
@@ -1,8 +1,4 @@
-project: dcps, dcps_ts_defaults {
-
-  avoids += no_cxx11
-  requires += no_opendds_safety_profile
-  macros += OPENDDS_HAS_CXX11
+project: dcps, dcps_ts_defaults, opendds_uses_cxx11 {
   dcps_ts_flags += -Lc++11
   idlflags += -SS -Sa -St
 

--- a/MPC/config/opendds_uses_cxx11.mpb
+++ b/MPC/config/opendds_uses_cxx11.mpb
@@ -1,3 +1,5 @@
+// This is for projects that require C++11. Use opendds_cxx11 for the IDL to
+// C++11 Mapping.
 project {
   avoids += no_cxx11
   requires += no_opendds_safety_profile

--- a/MPC/config/opendds_uses_cxx11.mpb
+++ b/MPC/config/opendds_uses_cxx11.mpb
@@ -1,4 +1,4 @@
-project: dcpslib {
+project {
   avoids += no_cxx11
   requires += no_opendds_safety_profile
   macros += OPENDDS_HAS_CXX11

--- a/MPC/config/rtps_relay_lib.mpb
+++ b/MPC/config/rtps_relay_lib.mpb
@@ -1,4 +1,4 @@
-project: dcpslib, opendds_uses_cxx11 {
+project: dcps, opendds_uses_cxx11 {
   after += RtpsRelayLib
   libs += OpenDDS_RtpsRelay
   includes += $(DDS_ROOT)/tools

--- a/java/tests/complex_idl/complex_idl_test.mpc
+++ b/java/tests/complex_idl/complex_idl_test.mpc
@@ -1,4 +1,4 @@
-project: dcpslib, dcps_tcp, dcps_test_java {
+project: dcps, dcps_tcp, dcps_test_java {
 
     sharedname      = complex_idl_test
 

--- a/java/tests/multirepo/multirepo_test.mpc
+++ b/java/tests/multirepo/multirepo_test.mpc
@@ -1,4 +1,4 @@
-project: dcpslib, dcps_tcp, dcps_test_java {
+project: dcps, dcps_tcp, dcps_test_java {
 
     sharedname      = multirepo_test
 

--- a/java/tests/two_idl/two_idl.mpc
+++ b/java/tests/two_idl/two_idl.mpc
@@ -1,4 +1,4 @@
-project: dcpslib, dcps_tcp, dcps_test_java {
+project: dcps, dcps_tcp, dcps_test_java {
 
     sharedname      = two_idl_test
 

--- a/performance-tests/bench/bench_builder_exe.mpb
+++ b/performance-tests/bench/bench_builder_exe.mpb
@@ -1,5 +1,4 @@
 project: ../bench_builder_idl_lib, dcps_inforepodiscovery {
-  avoids += no_cxx11
   after    += Bench_Builder
   libs     += Bench_Builder
   expand(BENCH_BUILDER_ROOT) {

--- a/performance-tests/bench/bench_builder_idl_lib.mpb
+++ b/performance-tests/bench/bench_builder_idl_lib.mpb
@@ -1,5 +1,4 @@
-project: dcps_rtps_udp {
-  avoids += no_cxx11
+project: dcps_rtps_udp, opendds_uses_cxx11 {
   after    += Bench_Builder_Idl
   libs     += Bench_Builder_Idl
   expand(BENCH_BUILDER_ROOT) {

--- a/performance-tests/bench/bench_exe.mpb
+++ b/performance-tests/bench/bench_exe.mpb
@@ -1,5 +1,4 @@
-project: dcps_rtps_udp, dcps_ts_defaults, rapidjson {
-  avoids += no_cxx11
+project: dcps_rtps_udp, dcps_ts_defaults, rapidjson, opendds_uses_cxx11 {
   after    += Bench_Common Bench_Idl Bench_Builder Bench_Builder_Idl
   libs     += Bench_Common Bench_Idl Bench_Builder Bench_Builder_Idl
   expand(BENCH_ROOT) {

--- a/performance-tests/bench/bench_idl_lib.mpb
+++ b/performance-tests/bench/bench_idl_lib.mpb
@@ -1,5 +1,4 @@
-project: dcps_rtps_udp {
-  avoids += no_cxx11
+project: dcps_rtps_udp, opendds_uses_cxx11 {
   after    += Bench_Idl
   libs     += Bench_Idl
   expand(BENCH_ROOT) {

--- a/performance-tests/bench/builder/Bench_Builder.mpc
+++ b/performance-tests/bench/builder/Bench_Builder.mpc
@@ -1,4 +1,4 @@
-project: dcpslib, dcps_inforepodiscovery, ../bench_builder_idl_lib {
+project: dcps, dcps_inforepodiscovery, ../bench_builder_idl_lib {
   avoids += no_cxx11
   dynamicflags += BENCH_BUILDER_BUILD_DLL
   libout = $(BENCH_BUILDER_ROOT)/lib

--- a/performance-tests/bench/builder/Bench_Builder.mpc
+++ b/performance-tests/bench/builder/Bench_Builder.mpc
@@ -1,5 +1,4 @@
 project: dcps, dcps_inforepodiscovery, ../bench_builder_idl_lib {
-  avoids += no_cxx11
   dynamicflags += BENCH_BUILDER_BUILD_DLL
   libout = $(BENCH_BUILDER_ROOT)/lib
 }

--- a/performance-tests/bench/builder_idl/Bench_Builder_Idl.mpc
+++ b/performance-tests/bench/builder_idl/Bench_Builder_Idl.mpc
@@ -1,4 +1,4 @@
-project: dcpslib, msvc_bigobj {
+project: dcps, msvc_bigobj {
   idlflags      += -Wb,stub_export_include=Bench_Builder_Idl_Export.h \
                    -Wb,stub_export_macro=Bench_Builder_Idl_Export \
                    -I$(DDS_ROOT)/dds

--- a/performance-tests/bench/common/Bench_Common.mpc
+++ b/performance-tests/bench/common/Bench_Common.mpc
@@ -1,4 +1,4 @@
-project: dcpslib, ../bench_idl_lib, ../bench_builder_idl_lib, dcps_ts_defaults, rapidjson {
+project: dcps, ../bench_idl_lib, ../bench_builder_idl_lib, dcps_ts_defaults, rapidjson {
   avoids += no_cxx11
 
   after    += Bench_Builder

--- a/performance-tests/bench/common/Bench_Common.mpc
+++ b/performance-tests/bench/common/Bench_Common.mpc
@@ -1,6 +1,4 @@
 project: dcps, ../bench_idl_lib, ../bench_builder_idl_lib, dcps_ts_defaults, rapidjson {
-  avoids += no_cxx11
-
   after    += Bench_Builder
   libs     += Bench_Builder
 

--- a/performance-tests/bench/idl/Bench_Idl.mpc
+++ b/performance-tests/bench/idl/Bench_Idl.mpc
@@ -1,4 +1,4 @@
-project: dcpslib, ../bench_builder_idl_lib, dcps_ts_defaults, rapidjson, msvc_bigobj {
+project: dcps, ../bench_builder_idl_lib, dcps_ts_defaults, rapidjson, msvc_bigobj {
   idlflags      += -Wb,stub_export_include=Bench_Idl_Export.h \
                    -Wb,stub_export_macro=Bench_Idl_Export \
                    -I$(DDS_ROOT)/dds \

--- a/tests/DCPS/C++11/Messenger/Publisher/DDS_Cxx11_Messenger_Publisher.mpc
+++ b/tests/DCPS/C++11/Messenger/Publisher/DDS_Cxx11_Messenger_Publisher.mpc
@@ -1,6 +1,4 @@
-project: dcpsexe, dcps_test, dcps_transports_for_test{
-  avoids   += no_cxx11
-  requires += no_opendds_safety_profile
+project: dcpsexe, dcps_test, dcps_transports_for_test, opendds_uses_cxx11 {
   exename   = publisher
   after    += DDS_Cxx11_Messenger_Idl
   libs     += DDS_Cxx11_Messenger_Idl

--- a/tests/DCPS/C++11/Messenger/Subscriber/DDS_Cxx11_Messenger_Subscriber.mpc
+++ b/tests/DCPS/C++11/Messenger/Subscriber/DDS_Cxx11_Messenger_Subscriber.mpc
@@ -1,6 +1,4 @@
-project: dcpsexe, dcps_test, dcps_transports_for_test{
-  avoids   += no_cxx11
-  requires += no_opendds_safety_profile
+project: dcpsexe, dcps_test, dcps_transports_for_test, opendds_uses_cxx11 {
   exename   = subscriber
   after    += DDS_Cxx11_Messenger_Idl
   libs     += DDS_Cxx11_Messenger_Idl

--- a/tests/DCPS/Compiler/vread_vwrite/VreadVwriteTest.mpc
+++ b/tests/DCPS/Compiler/vread_vwrite/VreadVwriteTest.mpc
@@ -1,10 +1,6 @@
-project: dcpsexe, dcps_test, googletest, rapidjson {
-
+project: dcpsexe, dcps_test, googletest, rapidjson, opendds_uses_cxx11 {
   dcps_ts_flags += -Gxtypes-complete
   exename = *
-
-  requires += no_opendds_safety_profile
-  avoids += no_cxx11
 
   Idl_Files {
     VreadVwriteTest.idl


### PR DESCRIPTION
- `opendds_cxx11.mpb` Should Use `opendds_uses_cxx11.mpb`
- Tests, mpb files, and mpcs with a `libout` should not be using `dcpslib`.
- Add comments to `opendds_cxx11.mpb`, `opendds_uses_cxx11.mpb`, and `dcpslib.mpb` to try to make their usage clear.
- Replace projects `avoids += no_cxx11` with `opendds_uses_cxx11`.