### PR TITLE
RtpsRelay: reduce contention for GuidAddrSet's lock

### DIFF
--- a/tools/rtpsrelay/GuidAddrSet.cpp
+++ b/tools/rtpsrelay/GuidAddrSet.cpp
@@ -8,8 +8,7 @@
 namespace RtpsRelay {
 
 ParticipantStatisticsReporter&
-GuidAddrSet::record_activity(const Proxy& proxy,
-                             const AddrPort& remote_address,
+GuidAddrSet::record_activity(const AddrPort& remote_address,
                              const OpenDDS::DCPS::MonotonicTimePoint& now,
                              const OpenDDS::DCPS::GUID_t& src_guid,
                              MessageType msg_type,
@@ -38,7 +37,7 @@ GuidAddrSet::record_activity(const Proxy& proxy,
       const auto pos = guid_addr_set_map_.find(result.first->second);
       const auto prev_guid = result.first->second;
       if (pos != guid_addr_set_map_.end()) {
-        remove(proxy, prev_guid, pos, now, &relay_participant_status_reporter_);
+        remove(prev_guid, pos, now, &relay_participant_status_reporter_);
         result = remote_map_.insert(std::make_pair(remote, src_guid));
         if (!result.second) {
           result.first->second = src_guid;
@@ -68,7 +67,7 @@ GuidAddrSet::record_activity(const Proxy& proxy,
     deactivation_guid_queue_.push_back(std::make_pair(deactivation, src_guid));
   }
   addr_set_stats.deactivation = deactivation;
-  relay_participant_status_reporter_.set_alive_active(proxy, src_guid, true, true);
+  relay_participant_status_reporter_.set_alive_active(src_guid, true, true);
 
   if (addr_set_stats.upsert_address(remote_address, now, expiration, config_.max_ips_per_client())) {
     if (config_.log_activity()) {
@@ -97,8 +96,7 @@ GuidAddrSet::record_activity(const Proxy& proxy,
   return stats_reporter;
 }
 
-void GuidAddrSet::process_expirations(const Proxy& proxy,
-                                      const OpenDDS::DCPS::MonotonicTimePoint& now)
+void GuidAddrSet::process_expirations(const OpenDDS::DCPS::MonotonicTimePoint& now)
 {
   bool update_reject_stat = false;
   auto it = rejected_address_expiration_queue_.begin();
@@ -132,7 +130,7 @@ void GuidAddrSet::process_expirations(const Proxy& proxy,
     AddrSetStats& addr_stats = pos->second;
 
     if (addr_stats.deactivation <= now) {
-      relay_participant_status_reporter_.set_active(proxy, guid, false);
+      relay_participant_status_reporter_.set_active(guid, false);
       addr_stats.deactivation = OpenDDS::DCPS::MonotonicTimePoint::zero_value;
     } else {
       deactivation_guid_queue_.push_back(std::make_pair(addr_stats.deactivation, guid));
@@ -186,7 +184,7 @@ void GuidAddrSet::process_expirations(const Proxy& proxy,
     relay_stats_reporter_.expired_address(now);
 
     if (addr_stats.ip_to_ports.empty()) {
-      remove(proxy, ga.guid, pos, now, &relay_participant_status_reporter_);
+      remove(ga.guid, pos, now, &relay_participant_status_reporter_);
     }
   }
 }
@@ -257,8 +255,7 @@ bool GuidAddrSet::ignore_rtps(bool from_application_participant,
   return false;
 }
 
-void GuidAddrSet::remove(const Proxy& proxy,
-                         const OpenDDS::DCPS::GUID_t& guid,
+void GuidAddrSet::remove(const OpenDDS::DCPS::GUID_t& guid,
                          GuidAddrSetMap::iterator it,
                          const OpenDDS::DCPS::MonotonicTimePoint& now,
                          RelayParticipantStatusReporter* reporter)
@@ -296,7 +293,7 @@ void GuidAddrSet::remove(const Proxy& proxy,
   }
 
   if (reporter) {
-    reporter->set_alive(proxy, guid, false);
+    reporter->set_alive(guid, false);
   }
 }
 

--- a/tools/rtpsrelay/GuidAddrSet.h
+++ b/tools/rtpsrelay/GuidAddrSet.h
@@ -304,7 +304,7 @@ public:
                     const size_t& msg_len,
                     const RelayHandler& handler)
     {
-      return gas_.record_activity(*this, remote_address, now, src_guid, msg_type, msg_len, handler);
+      return gas_.record_activity(remote_address, now, src_guid, msg_type, msg_len, handler);
     }
 
     ParticipantStatisticsReporter&
@@ -338,7 +338,7 @@ public:
         return;
       }
 
-      gas_.remove(*this, guid, it, now, reporter);
+      gas_.remove(guid, it, now, reporter);
     }
 
     void reject_address(const ACE_INET_Addr& addr,
@@ -354,7 +354,7 @@ public:
 
     void process_expirations(const OpenDDS::DCPS::MonotonicTimePoint& now)
     {
-      gas_.process_expirations(*this, now);
+      gas_.process_expirations(now);
     }
 
     bool admitting() const
@@ -386,16 +386,14 @@ private:
   }
 
   ParticipantStatisticsReporter&
-  record_activity(const Proxy& proxy,
-                  const AddrPort& remote_address,
+  record_activity(const AddrPort& remote_address,
                   const OpenDDS::DCPS::MonotonicTimePoint& now,
                   const OpenDDS::DCPS::GUID_t& src_guid,
                   MessageType msg_type,
                   const size_t& msg_len,
                   const RelayHandler& handler);
 
-  void process_expirations(const Proxy& proxy,
-                           const OpenDDS::DCPS::MonotonicTimePoint& now);
+  void process_expirations(const OpenDDS::DCPS::MonotonicTimePoint& now);
 
   bool admitting() const
   {
@@ -409,8 +407,7 @@ private:
                    const OpenDDS::DCPS::MonotonicTimePoint& now,
                    bool& admitted);
 
-  void remove(const Proxy& proxy,
-              const OpenDDS::DCPS::GUID_t& guid,
+  void remove(const OpenDDS::DCPS::GUID_t& guid,
               GuidAddrSetMap::iterator it,
               const OpenDDS::DCPS::MonotonicTimePoint& now,
               RelayParticipantStatusReporter* reporter);

--- a/tools/rtpsrelay/GuidPartitionTable.cpp
+++ b/tools/rtpsrelay/GuidPartitionTable.cpp
@@ -7,8 +7,7 @@
 namespace RtpsRelay {
 
 GuidPartitionTable::Result GuidPartitionTable::insert(const OpenDDS::DCPS::GUID_t& guid,
-                                                      const DDS::StringSeq& partitions,
-                                                      const OpenDDS::DCPS::MonotonicTimePoint& now)
+                                                      const DDS::StringSeq& partitions)
 {
   Result result;
   std::vector<RelayPartitions> relay_partitions;
@@ -87,8 +86,7 @@ GuidPartitionTable::Result GuidPartitionTable::insert(const OpenDDS::DCPS::GUID_
 
   if (!spdp_replay.partitions().empty() && config_.log_activity()) {
     const auto part_guid = make_id(guid, OpenDDS::DCPS::ENTITYID_PARTICIPANT);
-    GuidAddrSet::Proxy proxy(guid_addr_set_);
-    ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: GuidPartitionTable::insert %C add partitions %C %C into session\n"), guid_to_string(part_guid).c_str(), OpenDDS::DCPS::to_json(spdp_replay).c_str(), proxy.get_session_time(part_guid, now).sec_str().c_str()));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: GuidPartitionTable::insert %C add partitions %C\n"), guid_to_string(part_guid).c_str(), OpenDDS::DCPS::to_json(spdp_replay).c_str()));
   }
 
   return result;

--- a/tools/rtpsrelay/GuidPartitionTable.h
+++ b/tools/rtpsrelay/GuidPartitionTable.h
@@ -41,8 +41,7 @@ public:
 
   // Insert a reader/writer guid and its partitions.
   Result insert(const OpenDDS::DCPS::GUID_t& guid,
-                const DDS::StringSeq& partitions,
-                const OpenDDS::DCPS::MonotonicTimePoint& now);
+                const DDS::StringSeq& partitions);
 
   void remove(const OpenDDS::DCPS::GUID_t& guid)
   {

--- a/tools/rtpsrelay/ParticipantListener.cpp
+++ b/tools/rtpsrelay/ParticipantListener.cpp
@@ -41,8 +41,7 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
     switch (info.instance_state) {
     case DDS::ALIVE_INSTANCE_STATE:
       if (info.valid_data) {
-        GuidAddrSet::Proxy proxy(guid_addr_set_);
-        participant_status_reporter_.add_participant(proxy, participant_->get_repoid(info.instance_handle), data);
+        participant_status_reporter_.add_participant(participant_->get_repoid(info.instance_handle), data);
       }
       break;
     case DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE:

--- a/tools/rtpsrelay/PublicationListener.cpp
+++ b/tools/rtpsrelay/PublicationListener.cpp
@@ -56,7 +56,7 @@ void PublicationListener::on_data_available(DDS::DataReader_ptr reader)
         const auto& info = infos[idx];
         if (info.valid_data) {
           const auto repoid = participant_->get_repoid(info.instance_handle);
-          const auto r = guid_partition_table_.insert(repoid, data.partition.name, now);
+          const auto r = guid_partition_table_.insert(repoid, data.partition.name);
 
           if (r == GuidPartitionTable::ADDED) {
             if (config_.log_discovery()) {

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -144,12 +144,14 @@ protected:
                                const OpenDDS::DCPS::MonotonicTimePoint& now,
                                const OpenDDS::DCPS::Lockable_Message_Block_Ptr& msg,
                                MessageType& type) override;
+
   ParticipantStatisticsReporter& record_activity(GuidAddrSet::Proxy& proxy,
                                                  const AddrPort& remote_address,
                                                  const OpenDDS::DCPS::MonotonicTimePoint& now,
                                                  const OpenDDS::DCPS::GUID_t& src_guid,
                                                  MessageType msg_type,
                                                  const size_t& msg_len);
+
   CORBA::ULong send(GuidAddrSet::Proxy& proxy,
                     const OpenDDS::DCPS::GUID_t& src_guid,
                     const StringSet& to_partitions,
@@ -157,6 +159,7 @@ protected:
                     bool send_to_application_participant,
                     const OpenDDS::DCPS::Lockable_Message_Block_Ptr& msg,
                     const OpenDDS::DCPS::MonotonicTimePoint& now);
+
   size_t send(const ACE_INET_Addr& addr,
               OpenDDS::STUN::Message message,
               const OpenDDS::DCPS::MonotonicTimePoint& now);
@@ -197,6 +200,7 @@ public:
                     HandlerStatisticsReporter& stats_reporter);
 
   void vertical_handler(VerticalHandler* vertical_handler) { vertical_handler_ = vertical_handler; }
+
   void enqueue_message(const ACE_INET_Addr& addr,
                        const StringSet& to_partitions,
                        const GuidSet& to_guids,

--- a/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
+++ b/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
@@ -2,8 +2,7 @@
 
 namespace RtpsRelay {
 
-void RelayParticipantStatusReporter::add_participant(GuidAddrSet::Proxy& proxy,
-                                                     const OpenDDS::DCPS::GUID_t& repoid,
+void RelayParticipantStatusReporter::add_participant(const OpenDDS::DCPS::GUID_t& repoid,
                                                      const DDS::ParticipantBuiltinTopicData& data)
 {
   const auto monotonic_now = OpenDDS::DCPS::MonotonicTimePoint::now();
@@ -32,9 +31,8 @@ void RelayParticipantStatusReporter::add_participant(GuidAddrSet::Proxy& proxy,
     if (p.second) {
       if (config_.log_discovery()) {
         ACE_DEBUG((LM_INFO, "(%P|%t) INFO: RelayParticipantStatusReporter::add_participant "
-                   "add local participant %C %C %C into session\n",
-                   guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
-                   proxy.get_session_time(repoid, monotonic_now).sec_str().c_str()));
+                   "add local participant %C %C\n",
+                   guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str()));
       }
     } else {
       p.first->second = status;
@@ -78,8 +76,7 @@ void RelayParticipantStatusReporter::remove_participant(GuidAddrSet::Proxy& prox
   stats_reporter_.local_participants(guids_.size(), monotonic_now);
 }
 
-void RelayParticipantStatusReporter::set_alive(const GuidAddrSet::Proxy& /*proxy*/,
-                                               const OpenDDS::DCPS::GUID_t& repoid,
+void RelayParticipantStatusReporter::set_alive(const OpenDDS::DCPS::GUID_t& repoid,
                                                bool alive)
 {
   const auto system_now = OpenDDS::DCPS::SystemTimePoint::now();
@@ -105,8 +102,7 @@ void RelayParticipantStatusReporter::set_alive(const GuidAddrSet::Proxy& /*proxy
   }
 }
 
-void RelayParticipantStatusReporter::set_active(const GuidAddrSet::Proxy& /*proxy*/,
-                                                const OpenDDS::DCPS::GUID_t& repoid,
+void RelayParticipantStatusReporter::set_active(const OpenDDS::DCPS::GUID_t& repoid,
                                                 bool active)
 {
   const auto system_now = OpenDDS::DCPS::SystemTimePoint::now();
@@ -132,8 +128,7 @@ void RelayParticipantStatusReporter::set_active(const GuidAddrSet::Proxy& /*prox
   }
 }
 
-void RelayParticipantStatusReporter::set_alive_active(const GuidAddrSet::Proxy& /*proxy*/,
-                                                      const OpenDDS::DCPS::GUID_t& repoid,
+void RelayParticipantStatusReporter::set_alive_active(const OpenDDS::DCPS::GUID_t& repoid,
                                                       bool alive,
                                                       bool active)
 {

--- a/tools/rtpsrelay/RelayParticipantStatusReporter.h
+++ b/tools/rtpsrelay/RelayParticipantStatusReporter.h
@@ -20,23 +20,19 @@ public:
     , stats_reporter_(stats_reporter)
   {}
 
-  void add_participant(GuidAddrSet::Proxy& proxy,
-                       const OpenDDS::DCPS::GUID_t& repoid,
+  void add_participant(const OpenDDS::DCPS::GUID_t& repoid,
                        const DDS::ParticipantBuiltinTopicData& data);
 
   void remove_participant(GuidAddrSet::Proxy& proxy,
                           const OpenDDS::DCPS::GUID_t& repoid);
 
-  void set_alive(const GuidAddrSet::Proxy& proxy,
-                 const OpenDDS::DCPS::GUID_t& repoid,
+  void set_alive(const OpenDDS::DCPS::GUID_t& repoid,
                  bool alive);
 
-  void set_active(const GuidAddrSet::Proxy& proxy,
-                  const OpenDDS::DCPS::GUID_t& repoid,
+  void set_active(const OpenDDS::DCPS::GUID_t& repoid,
                   bool active);
 
-  void set_alive_active(const GuidAddrSet::Proxy& proxy,
-                        const OpenDDS::DCPS::GUID_t& repoid,
+  void set_alive_active(const OpenDDS::DCPS::GUID_t& repoid,
                         bool alive,
                         bool active);
 

--- a/tools/rtpsrelay/SubscriptionListener.cpp
+++ b/tools/rtpsrelay/SubscriptionListener.cpp
@@ -56,7 +56,7 @@ void SubscriptionListener::on_data_available(DDS::DataReader_ptr reader)
     case DDS::ALIVE_INSTANCE_STATE:
       if (info.valid_data) {
         const auto repoid = participant_->get_repoid(info.instance_handle);
-        const auto r = guid_partition_table_.insert(repoid, data.partition.name, now);
+        const auto r = guid_partition_table_.insert(repoid, data.partition.name);
 
         if (r == GuidPartitionTable::ADDED) {
           if (config_.log_discovery()) {


### PR DESCRIPTION
The tradeoff is that in certain cases the "session time" is no longer logged (with LogActivity=1).