### PR TITLE
ConfigStore is not available in Java

### DIFF
--- a/java/dds/OpenDDS/DCPS/TheServiceParticipant.java
+++ b/java/dds/OpenDDS/DCPS/TheServiceParticipant.java
@@ -24,4 +24,6 @@ public final class TheServiceParticipant {
     public static native String get_unique_id(DomainParticipant participant);
 
     public static native NetworkConfigModifier network_config_modifier();
+
+    public static native ConfigStore config_store();
 }

--- a/java/dds/OpenDDS_DCPS_jni.cpp
+++ b/java/dds/OpenDDS_DCPS_jni.cpp
@@ -179,6 +179,20 @@ jobject JNICALL Java_OpenDDS_DCPS_TheServiceParticipant_network_1config_1modifie
 #endif
 }
 
+jobject JNICALL Java_OpenDDS_DCPS_TheServiceParticipant_config_1store
+(JNIEnv * jni, jclass)
+{
+  try {
+    OpenDDS::DCPS::ConfigStore_var c_ret(TheServiceParticipant->config_store().get());
+    jobject j_ret = 0;
+    copyToJava (jni, j_ret, c_ret, true);
+    return j_ret;
+  } catch (const CORBA::SystemException& se) {
+    throw_java_exception(jni, se);
+    return 0;
+  }
+}
+
 // NetworkConfigModifier
 
 // NetworkConfigModifier::_jni_fini

--- a/java/tests/transport_config/TransportConfigTest.java
+++ b/java/tests/transport_config/TransportConfigTest.java
@@ -10,6 +10,7 @@ import org.omg.CORBA.SystemException;
 
 import OpenDDS.DCPS.TheServiceParticipant;
 import OpenDDS.DCPS.TheParticipantFactory;
+import OpenDDS.DCPS.ConfigStore;
 
 import OpenDDS.DCPS.transport.TheTransportRegistry;
 import OpenDDS.DCPS.transport.TransportConfig;
@@ -34,6 +35,7 @@ public class TransportConfigTest {
     public static void main(String[] args) throws Exception {
         setUp(args);
 
+        testConfigStore();
         testModifyTransportFromFileTCP();
         testCreateNewTransportUdp();
         testCreateNewTransportMulticast();
@@ -42,6 +44,14 @@ public class TransportConfigTest {
         tearDown();
     }
 
+    protected static void testConfigStore() throws Exception {
+        ConfigStore cs = TheServiceParticipant.config_store();
+        assert cs.get_string("TRANSPORT_TCP1_TRANSPORT_TYPE", "").equals("tcp");
+        assert cs.get_uint32("TRANSPORT_TCP1_MAX_SAMPLES_PER_PACKET", 0) == 5;
+        assert cs.get_uint32("TRANSPORT_TCP1_CONN_RETRY_ATTEMPTS", 0) == 42;
+        cs.set_string("MY_KEY", "value");
+        assert cs.get_string("MY_KEY", "").equals("value");
+    }
 
     protected static void testModifyTransportFromFileTCP() throws Exception {
         final String ID = "tcp1"; //matches .ini file


### PR DESCRIPTION
Problem
-------

The ConfigStore is not avaiable in Java.  If it was available, Java users could configure anything that can be configured.

Solution
--------

Expose the ConfigStore via the Service Participant.