### PR TITLE
Improve QoS Documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,7 +152,7 @@ intersphinx_mapping = {
     'cmake': ('https://cmake.org/cmake/help/latest', None),
 }
 
-manpages_url = 'https://linux.die.net/man/{section}/{page}'
+manpages_url = 'https://manpages.debian.org/{page}({section})'
 
 
 # -- Options for Markdown output ---------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,6 +152,9 @@ intersphinx_mapping = {
     'cmake': ('https://cmake.org/cmake/help/latest', None),
 }
 
+manpages_url = 'https://linux.die.net/man/{section}/{page}'
+
+
 # -- Options for Markdown output ---------------------------------------------
 # This builder is just used to generate the release notes for GitHub
 

--- a/docs/devguide/annex.rst
+++ b/docs/devguide/annex.rst
@@ -1,0 +1,37 @@
+.. _annex:
+
+#####
+Annex
+#####
+
+Documentation that doesn't fit with other sections, but isn't big enough to justify having a separate section.
+
+.. _fnmatch-exprs:
+
+*******************
+Fnmatch Expressions
+*******************
+
+A wildcard-capable string used to match one or more names from a set.
+This is used in :ref:`qos-partition` and in :ref:`sec` documents.
+Recognized values will conform to POSIX ``fnmatch()`` function as specified in POSIX 1003.2-1992, Section B.6.
+This is a subset of UNIX shell file matching and is similar to, but separate from standard regular expressions.
+
+Simplified, this consists of the following:
+
+``?``
+  Will match any single character.
+  For example ``ab?`` matches ``abc`` and ``abb``.
+
+``*``
+  Will match any zero or more characters.
+  For example ``*`` will match anything and ``a*`` matches ``a``, ``abc``, and ``aaaaa``.
+
+``[]``
+  Will match a single character specified in the brackets.
+  For example ``a[bc]`` matches ``ab`` and ``ac``.
+  Can also use ranges, for example ``a[b-d]`` matches ``ab``, ``ac``, and ``ad``.
+
+``\``
+  Will escape the following character.
+  For example ``\?`` just matches ``?`` and ``\\`` matches ``\``.

--- a/docs/devguide/annex.rst
+++ b/docs/devguide/annex.rst
@@ -4,8 +4,6 @@
 Annex
 #####
 
-Documentation that doesn't fit with other sections, but isn't big enough to justify having a separate section.
-
 .. _fnmatch-exprs:
 
 *******************

--- a/docs/devguide/building/index.rst
+++ b/docs/devguide/building/index.rst
@@ -297,7 +297,7 @@ To explicitly enable the feature, use ``feature=1`` above.
 
 .. _building--disabling-the-building-of-built-in-topic-support:
 
-Disabling the Building of Built-In Topic Support
+Disabling the Building of Built-in Topic Support
 ------------------------------------------------
 
 ..
@@ -306,7 +306,7 @@ Disabling the Building of Built-In Topic Support
 Feature Name: ``built_in_topics``
 
 You can reduce the footprint of the core DDS library by up to 30% by disabling Built-in Topic Support.
-See :ref:`bit` for a description of Built-In Topics.
+See :ref:`bit` for a description of built-in topics.
 
 .. _building--disabling-the-building-of-compliance-profile-features:
 
@@ -366,7 +366,7 @@ Persistence Profile
 
 Feature Name: ``persistence_profile``
 
-This profile adds the QoS policy ``DURABILITY_SERVICE`` and the settings ``TRANSIENT`` and ``PERSISTENT`` of the ``DURABILITY`` QoS policy ``kind``.
+This profile adds the :ref:`qos-durability-service` policy and the settings ``TRANSIENT`` and ``PERSISTENT`` of the :ref:`qos-durability` policy ``kind``.
 
 .. _building--ownership-profile:
 
@@ -380,14 +380,14 @@ Feature Name: ``ownership_profile``
 
 This profile adds:
 
-* the setting ``EXCLUSIVE`` of the ``OWNERSHIP`` ``kind``
+* the setting ``EXCLUSIVE`` of :ref:`qos-ownership`
 
-* support for the ``OWNERSHIP_STRENGTH`` policy
+* support for the :ref:`qos-ownership-strength` policy
 
-* setting a ``depth > 1`` for the ``HISTORY`` QoS policy.
+* setting a ``depth > 1`` for the :ref:`qos-history` policy
 
-*Some users may wish to exclude support for the Exclusive OWNERSHIP policy and its associated OWNERSHIP_STRENGTH without impacting use of HISTORY.*
-*In order to support this configuration, OpenDDS also has the MPC feature ownership_kind_exclusive (configure script option --no-ownership-kind-exclusive).*
+Some users may wish to exclude support for the exclusive :ref:`qos-ownership` policy and its associated :ref:`qos-ownership-strength` without impacting use of :ref:`qos-history`.
+In order to support this configuration, OpenDDS also has the MPC feature ``ownership_kind_exclusive`` (configure script option ``--no-ownership-kind-exclusive``).
 
 .. _building--object-model-profile:
 
@@ -399,9 +399,9 @@ Object Model Profile
 
 Feature Name: ``object_model_profile``
 
-This profile includes support for the ``PRESENTATION`` access_scope setting of ``GROUP``.
+This profile includes support for the :ref:`qos-presentation` ``access_scope`` setting of ``GROUP``.
 
-.. note:: Currently, the ``PRESENTATION`` access_scope of ``TOPIC`` is also excluded when ``object_model_profile`` is disabled.
+.. note:: Currently, the :ref:`qos-presentation` ``access_scope`` of ``TOPIC`` is also excluded when ``object_model_profile`` is disabled.
 
 .. _cross_compiling:
 

--- a/docs/devguide/conditions_and_listeners.rst
+++ b/docs/devguide/conditions_and_listeners.rst
@@ -70,7 +70,7 @@ Inconsistent Topic Status
 ..
     Sect<4.2.1.1>
 
-The ``INCONSISTENT_TOPIC`` status indicates that a :term:`topic` was attempted to be registered that already exists with different characteristics.
+The ``INCONSISTENT_TOPIC`` status indicates that the :term:`topic` being registered has different characteristics than an existing topic with the same name.
 Typically, the existing topic may have a different type associated with it.
 The IDL associated with the Inconsistent Topic Status is listed below:
 

--- a/docs/devguide/conditions_and_listeners.rst
+++ b/docs/devguide/conditions_and_listeners.rst
@@ -398,6 +398,103 @@ The ``current_count`` value is the current number of data readers matched to thi
 The ``current_count_change`` value is the change in the current count since the last time this status was accessed.
 The ``last_subscription_handle`` value is a handle for the last data reader matched.
 
+.. _conditions_and_listeners--budget-exceeded-status:
+
+Budget Exceeded Status
+----------------------
+
+This is an OpenDDS-specific listener extension allows for reporting delays in excess of the :ref:`qos-latency-budget`.
+The ``OpenDDS::DCPS::DataReaderListener`` interface has an additional operation for notification that samples were received with a measured transport delay greater than the latency budget policy duration.
+The IDL for this method is:
+
+.. code-block:: omg-idl
+
+      struct BudgetExceededStatus {
+        long total_count;
+        long total_count_change;
+        DDS::InstanceHandle_t last_instance_handle;
+      };
+
+      void on_budget_exceeded(
+             in DDS::DataReader reader,
+             in BudgetExceededStatus status);
+
+To use the extended listener callback you will need to derive the listener implementation from the extended interface, as shown in the following code fragment:
+
+.. code-block:: cpp
+
+      class DataReaderListenerImpl
+            : public virtual
+              OpenDDS::DCPS::LocalObject<OpenDDS::DCPS::DataReaderListener>
+
+Then you must provide a non-null implementation for the ``on_budget_exceeded()`` operation.
+Note that you will need to provide empty implementations for the following extended operations as well:
+
+.. code-block:: cpp
+
+      on_subscription_disconnected()
+      on_subscription_reconnected()
+      on_subscription_lost()
+      on_connection_deleted()
+
+OpenDDS also makes the summary latency statistics available via an extended interface of the data reader.
+This extended interface is located in the ``OpenDDS::DCPS`` module and the IDL is defined as:
+
+.. code-block:: omg-idl
+
+      struct LatencyStatistics {
+        GUID_t        publication;
+        unsigned long n;
+        double        maximum;
+        double        minimum;
+        double        mean;
+        double        variance;
+      };
+
+      typedef sequence<LatencyStatistics> LatencyStatisticsSeq;
+
+      local interface DataReaderEx : DDS::DataReader {
+        /// Obtain a sequence of statistics summaries.
+        void get_latency_stats(inout LatencyStatisticsSeq stats);
+
+        /// Clear any intermediate statistical values.
+        void reset_latency_stats();
+
+        /// Statistics gathering enable state.
+        attribute boolean statistics_enabled;
+      };
+
+To gather this statistical summary data you will need to use the extended interface.
+You can do so simply by dynamically casting the OpenDDS data reader pointer and calling the operations directly.
+In the following example, we assume that reader is initialized correctly by calling ``DDS::Subscriber::create_datareader()``:
+
+.. code-block:: cpp
+
+      DDS::DataReader_var reader;
+      // ...
+
+      // To start collecting new data.
+      dynamic_cast<OpenDDS::DCPS::DataReaderImpl*>(reader.in())->
+        reset_latency_stats();
+      dynamic_cast<OpenDDS::DCPS::DataReaderImpl*>(reader.in())->
+        statistics_enabled(true);
+
+      // ...
+
+      // To collect data.
+      OpenDDS::DCPS::LatencyStatisticsSeq stats;
+      dynamic_cast<OpenDDS::DCPS::DataReaderImpl*>(reader.in())->
+        get_latency_stats(stats);
+      for (unsigned long i = 0; i < stats.length(); ++i)
+      {
+        std::cout << "stats[" << i << "]:" << std::endl;
+        std::cout << "         n = " << stats[i].n << std::endl;
+        std::cout << "       max = " << stats[i].maximum << std::endl;
+        std::cout << "       min = " << stats[i].minimum << std::endl;
+        std::cout << "      mean = " << stats[i].mean << std::endl;
+        std::cout << "  variance = " << stats[i].variance << std::endl;
+      }
+
 .. _conditions_and_listeners--listeners:
 
 *********

--- a/docs/devguide/conditions_and_listeners.rst
+++ b/docs/devguide/conditions_and_listeners.rst
@@ -423,19 +423,37 @@ To use the extended listener callback you will need to derive the listener imple
 
 .. code-block:: cpp
 
-      class DataReaderListenerImpl
-            : public virtual
-              OpenDDS::DCPS::LocalObject<OpenDDS::DCPS::DataReaderListener>
+  class DataReaderListenerImpl
+    : public virtual OpenDDS::DCPS::LocalObject<OpenDDS::DCPS::DataReaderListener>
+  {
+    void on_budget_exceeded(
+      DDS::DataReader* reader,
+      const OpenDDS::DCPS::BudgetExceededStatus& status)
+    {
+    }
 
 Then you must provide a non-null implementation for the ``on_budget_exceeded()`` operation.
 Note that you will need to provide empty implementations for the following extended operations as well:
 
 .. code-block:: cpp
 
-      on_subscription_disconnected()
-      on_subscription_reconnected()
-      on_subscription_lost()
-      on_connection_deleted()
+  void on_subscription_disconnected(
+    DDS::DataReader* reader,
+    const OpenDDS::DCPS::SubscriptionDisconnectedStatus& status)
+  {
+  }
+
+  void on_subscription_reconnected(
+    DDS::DataReader* reader,
+    const OpenDDS::DCPS::SubscriptionReconnectedStatus& status)
+  {
+  }
+
+  void on_subscription_lost(
+    DDS::DataReader* reader,
+    const OpenDDS::DCPS::SubscriptionLostStatus& status)
+  {
+  }
 
 OpenDDS also makes the summary latency statistics available via an extended interface of the data reader.
 This extended interface is located in the ``OpenDDS::DCPS`` module and the IDL is defined as:

--- a/docs/devguide/conditions_and_listeners.rst
+++ b/docs/devguide/conditions_and_listeners.rst
@@ -485,8 +485,7 @@ In the following example, we assume that reader is initialized correctly by call
       OpenDDS::DCPS::LatencyStatisticsSeq stats;
       dynamic_cast<OpenDDS::DCPS::DataReaderImpl*>(reader.in())->
         get_latency_stats(stats);
-      for (unsigned long i = 0; i < stats.length(); ++i)
-      {
+      for (unsigned long i = 0; i < stats.length(); ++i) {
         std::cout << "stats[" << i << "]:" << std::endl;
         std::cout << "         n = " << stats[i].n << std::endl;
         std::cout << "       max = " << stats[i].maximum << std::endl;

--- a/docs/devguide/conditions_and_listeners.rst
+++ b/docs/devguide/conditions_and_listeners.rst
@@ -20,7 +20,7 @@ The DDS specification defines two separate mechanisms for notifying applications
 Most of the status types define a structure that contains information related to the change of status and can be detected by the application using conditions or listeners.
 The different status types are described in :ref:`conditions_and_listeners--communication-status-types`.
 
-Each entity type (domain participant, topic, publisher, subscriber, data reader, and data writer) defines its own corresponding listener interface.
+Each :term:`entity` type defines its own corresponding listener interface.
 Applications can implement this interface and then attach their listener implementation to the entity.
 Each listener interface contains an operation for each status that can be reported for that entity.
 The listener is asynchronously called back with the appropriate operation whenever a qualifying status change occurs.
@@ -40,7 +40,7 @@ Communication Status Types
 ..
     Sect<4.2>
 
-Each status type is associated with a particular entity type.
+Each status type is associated with a particular :term:`entity` type.
 This section is organized by the entity types, with the corresponding statuses described in subsections under the associated entity type.
 
 Most of the statuses below are plain communication statuses.
@@ -52,8 +52,7 @@ The read statuses are simple notifications to the application which then reads o
 Incremental values in the status data structure report a change since the last time the status was accessed.
 A status is considered accessed when a listener is called for that status or the status is read from its entity.
 
-Fields in the status data structure with a type of ``InstanceHandle_t`` identify an entity (topic, data reader, data writer, etc.)
-by the instance handle used for that entity in the Built-In-Topics.
+Fields in the status data structure with a type of ``InstanceHandle_t`` identify an entity by the instance handle used for that entity in the :term:`built-in topics`.
 
 .. _conditions_and_listeners--topic-status-types:
 
@@ -71,7 +70,7 @@ Inconsistent Topic Status
 ..
     Sect<4.2.1.1>
 
-The ``INCONSISTENT_TOPIC`` status indicates that a topic was attempted to be registered that already exists with different characteristics.
+The ``INCONSISTENT_TOPIC`` status indicates that a :term:`topic` was attempted to be registered that already exists with different characteristics.
 Typically, the existing topic may have a different type associated with it.
 The IDL associated with the Inconsistent Topic Status is listed below:
 
@@ -153,7 +152,7 @@ Liveliness Changed Status
 ..
     Sect<4.2.3.2>
 
-The ``LIVELINESS_CHANGED`` status indicates that there have been liveliness changes for one or more data writers that are publishing instances for this data reader.
+The ``LIVELINESS_CHANGED`` status indicates that there have been :ref:`liveliness changes <qos-liveliness>` for one or more data writers that are publishing instances for this data reader.
 The IDL associated with the Liveliness Changed Status is listed below:
 
 .. code-block:: omg-idl
@@ -166,7 +165,7 @@ The IDL associated with the Liveliness Changed Status is listed below:
       InstanceHandle_t last_publication_handle;
     };
 
-The ``alive_count`` value is the total number of data writers currently active on the topic this data reader is reading.
+The ``alive_count`` value is the total number of data writers currently active on the :term:`topic` this data reader is reading.
 The ``not_alive_count`` value is the total number of data writers writing to the data reader's topic that are no longer asserting their liveliness.
 The ``alive_count_change`` value is the change in the alive count since the last time the status was accessed.
 The ``not_alive_count_change`` value is the change in the not alive count since the last time the status was accessed.
@@ -180,7 +179,7 @@ Requested Deadline Missed Status
 ..
     Sect<4.2.3.3>
 
-The ``REQUESTED_DEADLINE_MISSED`` status indicates that the deadline requested via the Deadline QoS policy was not respected for a specific instance.
+The ``REQUESTED_DEADLINE_MISSED`` status indicates that the deadline requested via the :ref:`qos-deadline` policy was not respected for a specific instance.
 The IDL associated with the Requested Deadline Missed Status is listed below:
 
 .. code-block:: omg-idl
@@ -203,7 +202,8 @@ Requested Incompatible QoS Status
 ..
     Sect<4.2.3.4>
 
-The ``REQUESTED_INCOMPATIBLE_QOS`` status indicates that one or more QoS policy values that were requested were incompatible with what was offered.
+The ``REQUESTED_INCOMPATIBLE_QOS`` status indicates that one or more :term:`qos` policy values that were requested by a local :term:`DataReader` were incompatible with what was offered by a :term:`DataWriter`.
+See :ref:`qos-changing` for details.
 The IDL associated with the Requested Incompatible QoS Status is listed below:
 
 .. code-block:: omg-idl
@@ -324,7 +324,7 @@ Offered Deadline Missed Status
 ..
     Sect<4.2.4.2>
 
-The ``OFFERED_DEADLINE_MISSED`` status indicates that the deadline offered by the data writer has been missed for one or more instances.
+The ``OFFERED_DEADLINE_MISSED`` status indicates that the :ref:`deadline <qos-deadline>` offered by the data writer has been missed for one or more instances.
 The IDL associated with the Offered Deadline Missed Status is listed below:
 
 .. code-block:: omg-idl
@@ -347,7 +347,8 @@ Offered Incompatible QoS Status
 ..
     Sect<4.2.4.3>
 
-The ``OFFERED_INCOMPATIBLE_QOS`` status indicates that an offered QoS was incompatible with the requested QoS of a data reader.
+The ``OFFERED_INCOMPATIBLE_QOS`` status indicates that one or more :term:`qos` policy values offered by a local :term:`DataWriter` were incompatible with what was requested by a :term:`DataReader`.
+See :ref:`qos-changing` for details.
 The IDL associated with the Offered Incompatible QoS Status is listed below:
 
 .. code-block:: omg-idl

--- a/docs/devguide/content_subscription_profile.rst
+++ b/docs/devguide/content_subscription_profile.rst
@@ -69,7 +69,7 @@ This data reader is functionally equivalent to a normal data reader except that 
 
 Filter expressions are first evaluated at the publisher so that data samples which would be ignored by the subscriber can be dropped before even getting to the transport.
 This feature can be turned off with ``-DCPSPublisherContentFilter 0`` or the equivalent setting in the ``[common]`` section of the configuration file.
-The behavior of non-default ``DEADLINE`` or ``LIVELINESS`` QoS policies may be affected by this policy.
+The behavior of non-default :ref:`qos-deadline` or :ref:`qos-liveliness` policies may be affected by this policy.
 Special consideration must be given to how the "missing" samples impact the QoS behavior, see the document in :ghfile:`docs/design/CONTENT_SUBSCRIPTION`.
 
 .. note:: RTPS_UDP transport does not always do Writer-side filtering.

--- a/docs/devguide/dds_security.rst
+++ b/docs/devguide/dds_security.rst
@@ -445,35 +445,6 @@ If there's a need to be selective about what domains are chosen, here's an annot
       <id_range><min>10</min></id_range> <!-- 10 and onward -->
     </domains>
 
-.. _dds_security--fnmatch-expr:
-
-Fnmatch Expression
-==================
-
-A wildcard-capable string used to match one or more names from a set.
-This is used to match topic and partition names to the rules that apply to them.
-Recognized values will conform to POSIX ``fnmatch()`` function as specified in POSIX 1003.2-1992, Section B.6.
-This is a subset of UNIX shell file matching and is similar to, but separate from standard regular expressions.
-
-Simplified, this consists of the following:
-
-``?``
-  Will match any single character.
-  For example ``ab?`` matches ``abc`` and ``abb``.
-
-``*``
-  Will match any zero or more characters.
-  For example ``*`` will match anything and ``a*`` matches ``a``, ``abc``, and ``aaaaa``.
-
-``[]``
-  Will match a single character specified in the brackets.
-  For example ``a[bc]`` matches ``ab`` and ``ac``.
-  Can also use ranges, for example ``a[b-d]`` matches ``ab``, ``ac``, and ``ad``.
-
-``\``
-  Will escape the following character.
-  For example ``\?`` just matches ``?`` and ``\\`` matches ``\``.
-
 .. _dds_security--domain-governance-document:
 
 **************************
@@ -614,7 +585,7 @@ The following XML elements are used to configure topic endpoint behaviors:
 topic_expression
 ----------------
 
-A :ref:`dds_security--fnmatch-expr` of the topic names to match.
+A :ref:`fnmatch expression <fnmatch-exprs>` of the topic names to match.
 A default rule to catch all previously unmatched topics can be made with: ``<topic_expression>*</topic_expression>``
 
 .. _dds_security--enable-discovery-protection:
@@ -829,7 +800,7 @@ topics
 """"""
 
 The list of topics and/or topic expressions for which a rule applies.
-Topic names and expressions are matched using :ref:`dds_security--fnmatch-expr`.
+Topic names and expressions are matched using :ref:`fnmatch-exprs`.
 If the triggering operation matches any of the topics listed, the topic condition is met.
 The topic section must always be present for a PSR rule, so there there is no default behavior.
 
@@ -839,7 +810,7 @@ partitions
 """"""""""
 
 The partitions list contains the set of partition names for which the parent PSR rule applies.
-Similarly to topics, partition names and expressions are matched using :ref:`dds_security--fnmatch-expr`.
+Similarly to topics, partition names and expressions are matched using :ref:`fnmatch-exprs`.
 For "allow" PSR rules, the DDS entity of the associated triggering operation must be using a strict subset of the partitions listed for the rule to apply.
 When no partition list is given for an "allow" PSR rule, the "empty string" partition is used as the default value.
 For "deny" PSR rules, the rule will apply if the associated DDS entity is using any of the partitions listed.

--- a/docs/devguide/dds_security.rst
+++ b/docs/devguide/dds_security.rst
@@ -144,15 +144,15 @@ The following configuration steps are required to enable OpenDDS Security featur
 
 .. _dds_security--dds-security-configuration-via-propertyqospolicy:
 
-DDS Security Configuration via PropertyQosPolicy
-================================================
+DDS Security Configuration via Property Qos Policy
+==================================================
 
 ..
     Sect<14.5.1>
 
-When the application creates a DomainParticipant object, the DomainParticipantQos passed to the ``create_participant()`` method now contains a PropertyQosPolicy object which has a sequence of name-value pairs.
+When the application creates a :term:`DomainParticipant`, the ``DomainParticipantQos`` passed to the ``create_participant()`` method contains :ref:`qos-property`, which has a sequence of name-value pairs.
 The following properties must be included to enable security.
-Except where noted, these values take the form of a URI starting with either the scheme "file:" followed by a filesystem path (absolute or relative) or the scheme "data:," followed by the literal data.
+Except where noted, these values take the form of a URI starting with either the scheme ``file:`` followed by a filesystem path (absolute or relative) or the scheme ``data:``, followed by the literal data.
 
 .. list-table::
    :header-rows: 1
@@ -173,7 +173,7 @@ Except where noted, these values take the form of a URI starting with either the
 
      - Certificate PEM file
 
-     - Can be the ``same as identity_ca``
+     - Can be the same as ``identity_ca``
 
    * - ``dds.sec.access.governance``
 
@@ -207,13 +207,13 @@ Except where noted, these values take the form of a URI starting with either the
 
 .. _dds_security--propertyqospolicy-example-code:
 
-PropertyQosPolicy Example Code
-==============================
+Example Code
+------------
 
 ..
     Sect<14.5.2>
 
-Below is an example of code that sets the DDS Participant QoS's PropertyQoSPolicy in order to configure DDS Security.
+Below is an example of code that sets the Participant QoS's :ref:`qos-property` in order to configure DDS Security.
 
 .. code-block:: cpp
 

--- a/docs/devguide/faq.rst
+++ b/docs/devguide/faq.rst
@@ -315,5 +315,5 @@ What could account for increasing memory usage in subscribing processes?
 ========================================================================
 
 If the subscribing process contains Data Readers which have received many instances from the corresponding Data Writers, it will need some resources to track each instance.
-This can be bounded by the ``RESOURCE_LIMITS`` QoS policy and by the subscribing application taking samples from the Data Reader.
-The ``READER_DATA_LIFECYCLE`` QoS policy may also be helpful.
+This can be bounded by the :ref:`qos-resource-limits` policy and by the subscribing application taking samples from the Data Reader.
+The :ref:`qos-reader-data-lifecycle` policy may also be helpful.

--- a/docs/devguide/getting_started.rst
+++ b/docs/devguide/getting_started.rst
@@ -769,13 +769,9 @@ If the take is successful and returns valid data, we print out each of the messa
                 << "  from = " << message.from.in()  << std::endl
                 << "  count = " << message.count  << std::endl
                 << "  text = " << message.text.in()  << std::endl;
-          }
-          else if (si.instance_state == DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE)
-          {
+          } else if (si.instance_state == DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
             std::cout << "instance is disposed" << std::endl;
-          }
-          else if (si.instance_state == DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE)
-          {
+          } else if (si.instance_state == DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
             std::cout << "instance is unregistered" << std::endl;
           }
           else
@@ -822,7 +818,7 @@ Once this is done, we can use the domain participant factory to delete our domai
 
 Since the publication and subscription of data within DDS is decoupled, data is not guaranteed to be delivered if a publication is disassociated (shutdown) prior to all data that has been sent having been received by the subscriptions.
 If the application requires that all published data be received, the ``wait_for_acknowledgments()`` operation is available to allow the publication to wait until all written data has been received.
-Data readers must have a ``RELIABLE`` setting for the ``RELIABILITY`` QoS (which is the default) in order for ``wait_for_acknowledgments()`` to work.
+Data readers must have :ref:`qos-reliability` set to ``RELIABLE_RELIABILITY_QOS`` (which is the default) in order for ``wait_for_acknowledgments()`` to work.
 This operation is called on individual ``DataWriters`` and includes a timeout value to bound the time to wait.
 The following code illustrates the use of ``wait_for_acknowledgments()`` to block for up to 15 seconds to wait for subscriptions to acknowledge receipt of all written data:
 
@@ -831,7 +827,7 @@ The following code illustrates the use of ``wait_for_acknowledgments()`` to bloc
       DDS::Duration_t shutdown_delay = {15, 0};
       DDS::ReturnCode_t result;
       result = writer->wait_for_acknowledgments(shutdown_delay);
-      if( result != DDS::RETCODE_OK) {
+      if (result != DDS::RETCODE_OK) {
         std::cerr << "Failed while waiting for acknowledgment of "
                   << "data being received by subscriptions, some data "
                   << "may not have been delivered." << std::endl;

--- a/docs/devguide/getting_started.rst
+++ b/docs/devguide/getting_started.rst
@@ -762,27 +762,24 @@ If the take is successful and returns valid data, we print out each of the messa
         DDS::ReturnCode_t status = reader_i->take_next_sample(message, si);
 
         if (status == DDS::RETCODE_OK) {
-
-          if (si.valid_data == 1) {
+          if (si.valid_data) {
               std::cout << "Message: subject = " << message.subject.in() << std::endl
-                << "  subject_id = " << message.subject_id  << std::endl
-                << "  from = " << message.from.in()  << std::endl
-                << "  count = " << message.count  << std::endl
-                << "  text = " << message.text.in()  << std::endl;
+                << "  subject_id = " << message.subject_id << std::endl
+                << "  from = " << message.from.in() << std::endl
+                << "  count = " << message.count << std::endl
+                << "  text = " << message.text.in() << std::endl;
           } else if (si.instance_state == DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE) {
             std::cout << "instance is disposed" << std::endl;
           } else if (si.instance_state == DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE) {
             std::cout << "instance is unregistered" << std::endl;
-          }
-          else
-          {
+          } else {
             std::cerr << "ERROR: received unknown instance state "
                       << si.instance_state << std::endl;
           }
         } else if (status == DDS::RETCODE_NO_DATA) {
             cerr << "ERROR: reader received DDS::RETCODE_NO_DATA!" << std::endl;
         } else {
-            cerr << "ERROR: read Message: Error: " <<  status << std::endl;
+            cerr << "ERROR: read Message: Error: " << status << std::endl;
         }
 
 Note the sample read may contain invalid data.

--- a/docs/devguide/index.rst
+++ b/docs/devguide/index.rst
@@ -28,3 +28,4 @@ The Developer's Guide explains how to use OpenDDS.
   internet_enabled_rtps
   xtypes
   faq
+  annex

--- a/docs/devguide/introduction.rst
+++ b/docs/devguide/introduction.rst
@@ -178,9 +178,9 @@ Section 2 of the DDS specification defines five compliance points for a DDS impl
 OpenDDS complies with the entire DDS specification (including all optional profiles).
 This includes the implementation of all Quality of Service policies with the following notes:
 
-* RELIABILITY.kind = RELIABLE is supported by the RTPS_UDP transport, the TCP transport, or the IP Multicast transport (when configured as reliable).
+* :ref:`qos-reliability` ``RELIABLE_RELIABILITY_QOS`` is supported by the RTPS_UDP transport, the TCP transport, and the IP Multicast transport (when configured as reliable).
 
-* TRANSPORT_PRIORITY is not implemented as changeable.
+* :ref:`qos-transport-priority` is not implemented as changeable.
 
 Although version 1.5 of the DDS specification is not yet published, OpenDDS incorporates some changes planned for that version that are required for a robust implementation:
 
@@ -216,7 +216,7 @@ Items not implemented in OpenDDS:
 
    OpenDDS may still drop samples that aren't needed (due to content filtering) by any associated readers -- this is done above the transport layer
 
-#. :omgspec:`rtps:8.7.6 Coherent Sets` for ``PRESENTATION`` QoS
+#. :omgspec:`rtps:8.7.6 Coherent Sets` for :ref:`qos-presentation`
 
 #. :omgspec:`rtps:8.7.7 Directed Write`
 
@@ -224,7 +224,7 @@ Items not implemented in OpenDDS:
 
 #. :omgspec:`rtps:8.7.8 Property Lists`
 
-#. :omgspec:`rtps:8.7.9 Original Writer Info` for ``DURABLE`` data
+#. :omgspec:`rtps:8.7.9 Original Writer Info` for :ref:`qos-durability`
 
    This would only be used for transient and persistent durability, which are :omgspec:`not supported by the RTPS specification <rtps:8.7.2.2.1>`
 

--- a/docs/devguide/quality_of_service.rst
+++ b/docs/devguide/quality_of_service.rst
@@ -557,7 +557,7 @@ Partition QoS
     Sect<3.2.8>
 
 The partition QoS policy allows the creation of logical partitions within a :term:`domain`.
-It only allows data readers and data writers to be associated if they have matched partition strings.
+Data readers and data writers can only be associated if they have at least one matched partition string.
 This policy applies to the publisher and subscriber entities via the ``partition`` member of their respective QoS structures.
 
 .. important::

--- a/docs/devguide/quality_of_service.rst
+++ b/docs/devguide/quality_of_service.rst
@@ -286,8 +286,8 @@ History QoS
     Sect<3.2.4>
 
 The history QoS policy determines how :term:`sample`\s are held in the data writer and data reader for a particular :term:`instance`.
-For data writers these values are held until the publisher retrieves them and successfully sends them to all connected subscribers.
-For data readers these values are held until :ref:`taken <getting_started--reading-multiple-samples>` by the application.
+For data writers these samples are held until the publisher retrieves them and successfully sends them to all connected subscribers.
+For data readers these samples are held until :ref:`taken <getting_started--reading-multiple-samples>` by the application.
 This policy applies to the topic, data reader, and data writer entities via the ``history`` member of their respective QoS structures.
 
 .. important::

--- a/docs/devguide/quality_of_service.rst
+++ b/docs/devguide/quality_of_service.rst
@@ -1518,6 +1518,63 @@ The ownership strength QoS policy is used in conjunction with the :ref:`qos-owne
 The ``value`` member is used to determine which data writer is the *owner* of the :term:`instance`.
 The default value is zero.
 
+.. _qos-property:
+
+Property QoS
+============
+
+The property QoS policy contains sequences of key-value pairs for the :term:`DomainParticipant`.
+
+.. important::
+
+  This policy is :ref:`immutable <qos-changing>` and affects association indirectly through security.
+
+  IDL:
+
+  .. code-block:: omg-idl
+
+    struct Property_t {
+      string name;
+      string value;
+      boolean propagate;
+    };
+    typedef sequence<Property_t> PropertySeq;
+
+    struct BinaryProperty_t {
+      string name;
+      OctetSeq value;
+      boolean propagate;
+    };
+    typedef sequence<BinaryProperty_t> BinaryPropertySeq;
+
+    struct PropertyQosPolicy {
+      PropertySeq value;
+      BinaryPropertySeq binary_value;
+    };
+
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`DomainParticipant`
+
+       - ``value``
+
+         ``binary_value``
+
+       - (empty sequence)
+
+         (empty sequence)
+
+  Specification: :omgspec:`sec:7.2.5 PropertyQosPolicy, DomainParticipantQos, DataWriterQos, and DataReaderQos`
+
+Right now these are only used for :ref:`dds_security--dds-security-configuration-via-propertyqospolicy`.
+
 .. _qos-data-representation:
 
 Data Representation QoS
@@ -1670,8 +1727,8 @@ This XTypes concept is explained in detail in :ref:`xtypes--type-consistency-enf
 
 .. attention::
 
-  OpenDDS only supports setting one of them: ``ignore_member_names``.
-  All other members should be kept at their default values.
+  OpenDDS only supports ``ignore_member_names``.
+  All other members should be left at their default values.
 
 ``ignore_member_names`` defaults to ``false`` so member names (along with member IDs, see :ref:`xtypes--member-id-assignment`) are significant for type compatibility.
 Changing this to ``true`` means that only member IDs are used for type compatibility.

--- a/docs/devguide/quality_of_service.rst
+++ b/docs/devguide/quality_of_service.rst
@@ -7,29 +7,10 @@ Quality of Service
 
 ..
     Sect<3>
-
-.. _quality_of_service--introduction:
-
-************
-Introduction
-************
-
-..
     Sect<3.1>
-
-The previous examples use default QoS policies for the various entities.
-This section discusses the QoS policies which are implemented in OpenDDS and the details of their usage.
-See the DDS specification for further information about the policies discussed in this section.
-
-.. _quality_of_service--qos-policies:
-
-************
-QoS Policies
-************
-
-..
     Sect<3.2>
 
+Quality of Service (QoS) policies are sets of requested policies for how :term:`entities <Entity>` should behave.
 Each policy defines a structure to specify its data.
 Each entity supports a subset of the policies and defines a QoS structure that is composed of the supported policy structures.
 The set of allowable policies for a given entity is constrained by the policy structures nested in its QoS structure.
@@ -47,26 +28,28 @@ For example, the Publisher's QoS structure is defined in the specification's IDL
     };
 
 Setting policies is as simple as obtaining a structure with the default values already set, modifying the individual policy structures as necessary, and then applying the QoS structure to an entity (usually when it is created).
-See :ref:`quality_of_service--default-qos-policy-values` for examples of how to obtain the default QoS policies for various entity types.
+See :ref:`qos-defaults` for examples of how to obtain the default QoS policies for various entity types.
 
-Applications can change the QoS of any entity by calling the set_qos() operation on the entity.
-If the QoS is changeable, existing associations are removed if they are no longer compatible and new associations are added if they become compatible.
-The ``DCPSInfoRepo`` re-evaluates the QoS compatibility and associations according to the QoS specification.
-If the compatibility checking fails, the call to set_qos() will return an error.
-The association re-evaluation may result in removal of existing associations or addition of new associations.
+.. _qos-changing:
 
-If the user attempts to change a QoS policy that is immutable (not changeable), then ``set_qos()`` returns ``DDS::RETCODE_IMMUTABLE_POLICY``.
+*********************
+Changing QoS Policies
+*********************
 
-A subset of the QoS policies are changeable.
-Some changeable QoS policies, such as ``USER_DATA``, ``TOPIC_DATA``, ``GROUP_DATA``, ``LIFESPAN``, ``OWNERSHIP_STRENGTH``, ``TIME_BASED_FILTER``, ``ENTITY_FACTORY``, ``WRITER_DATA_LIFECYCLE``, and ``READER_DATA_LIFECYCLE``, do not require compatibility and association re-evaluation.
-The ``DEADLINE`` and ``LATENCY_BUDGET`` QoS policies require compatibility re-evaluation, but not for association.
-The ``PARTITION`` QoS policy does not require compatibility re-evaluation, but does require association re-evaluation.
-The DDS specification lists ``TRANSPORT_PRIORITY`` as changeable, but the OpenDDS implementation does not support dynamically modifying this policy.
+Applications can change the QoS of any entity by calling the ``set_qos()`` operation on the entity.
+If the QoS policy values are either invalid or have conflicting polices, then ``set_qos()`` returns ``DDS::RETCODE_INCONSISTENT_POLICY``.
+If the application attempts to change a QoS policy that is immutable (not changeable), then ``set_qos()`` returns ``DDS::RETCODE_IMMUTABLE_POLICY``.
 
+If the ``set_qos`` is successful, existing associations are removed if they are no longer compatible and new associations are added if they become compatible.
+The policies specify if they are mutable or not and how they affect associations.
+The application can detect failed associations caused by incompatible QoS using :ref:`conditions_and_listeners--offered-incompatible-qos-status` for writers and :ref:`conditions_and_listeners--requested-incompatible-qos-status` for readers.
+
+.. _qos-defaults:
 .. _quality_of_service--default-qos-policy-values:
 
+*************************
 Default QoS Policy Values
-=========================
+*************************
 
 ..
     Sect<3.2.1>
@@ -120,609 +103,30 @@ The following examples illustrate how to obtain the default policies for publish
       std::cerr << "Could not get default data reader QoS" << std::endl;
     }
 
-The following tables summarize the default QoS policies for each entity type in OpenDDS to which policies can be applied.
-
-.. list-table:: Default DomainParticipant QoS Policies
-   :header-rows: 1
-
-   * - Policy
-
-     - Member
-
-     - Default Value
-
-   * - ``USER_DATA``
-
-     - ``value``
-
-     - ``(empty sequence)``
-
-   * - ``ENTITY_FACTORY``
-
-     - ``autoenable_created_entities``
-
-     - ``true``
-
-.. list-table:: Default Topic QoS Policies
-   :header-rows: 1
-
-   * - Policy
-
-     - Member
-
-     - Default Value
-
-   * - ``TOPIC_DATA``
-
-     - ``value``
-
-     - ``(empty sequence)``
-
-   * - ``DURABILITY``
-
-     - ``kind``
-
-       ``service_cleanup_delay.sec``
-
-       ``service_cleanup_delay.nanosec``
-
-     - ``VOLATILE_DURABILITY_QOS``
-
-       ``DURATION_ZERO_SEC``
-
-       ``DURATION_ZERO_NSEC``
-
-   * - ``DURABILITY_SERVICE``
-
-     - ``service_cleanup_delay.sec``
-
-       ``service_cleanup_delay.nanosec``
-
-       ``history_kind``
-
-       ``history_depth``
-
-       ``max_samples``
-
-       ``max_instances``
-
-       ``max_samples_per_instance``
-
-     - ``DURATION_ZERO_SEC``
-
-       ``DURATION_ZERO_NSEC``
-
-       ``KEEP_LAST_HISTORY_QOS``
-
-       ``1``
-
-       ``LENGTH_UNLIMITED``
-
-       ``LENGTH_UNLIMITED``
-
-       ``LENGTH_UNLIMITED``
-
-   * - ``DEADLINE``
-
-     - ``period.sec``
-
-       ``period.nanosec``
-
-     - ``DURATION_INFINITE_SEC``
-
-       ``DURATION_INFINITE_NSEC``
-
-   * - ``LATENCY_BUDGET``
-
-     - ``duration.sec``
-
-       ``duration.nanosec``
-
-     - ``DURATION_ZERO_SEC``
-
-       ``DURATION_ZERO_NSEC``
-
-   * - ``LIVELINESS``
-
-     - ``kind``
-
-       ``lease_duration.sec``
-
-       ``lease_duration.nanosec``
-
-     - ``AUTOMATIC_LIVELINESS_QOS``
-
-       ``DURATION_INFINITE_SEC``
-
-       ``DURATION_INFINITE_NSEC``
-
-   * - ``RELIABILITY``
-
-     - ``kind``
-
-       ``max_blocking_time.sec``
-
-       ``max_blocking_time.nanosec``
-
-     - ``BEST_EFFORT_RELIABILITY_QOS``
-
-       ``DURATION_INFINITE_SEC``
-
-       ``DURATION_INFINITE_NSEC``
-
-   * - ``DESTINATION_ORDER``
-
-     - ``kind``
-
-     - ``BY_RECEPTION_TIMESTAMP_``
-
-       ``DESTINATIONORDER_QOS``
-
-   * - ``HISTORY``
-
-     - ``kind``
-
-       ``depth``
-
-     - ``KEEP_LAST_HISTORY_QOS``
-
-       ``1``
-
-   * - ``RESOURCE_LIMITS``
-
-     - ``max_samples``
-
-       ``max_instances``
-
-       ``max_samples_per_instance``
-
-     - ``LENGTH_UNLIMITED``
-
-       ``LENGTH_UNLIMITED``
-
-       ``LENGTH_UNLIMITED``
-
-   * - ``TRANSPORT_PRIORITY``
-
-     - ``value``
-
-     - ``0``
-
-   * - ``LIFESPAN``
-
-     - ``duration.sec``
-
-       ``duration.nanosec``
-
-     - ``DURATION_INFINITE_SEC``
-
-       ``DURATION_INFINITE_NSEC``
-
-   * - ``OWNERSHIP``
-
-     - ``kind``
-
-     - ``SHARED_OWNERSHIP_QOS``
-
-.. _quality_of_service--publisher:
-
-.. list-table:: Default Publisher QoS Policies
-   :header-rows: 1
-
-   * - Policy
-
-     - Member
-
-     - Default Value
-
-   * - ``PRESENTATION``
-
-     - ``access_scope``
-
-       ``coherent_access``
-
-       ``ordered_access``
-
-     - ``INSTANCE_PRESENTATION_QOS``
-
-       ``0``
-
-       ``0``
-
-   * - ``PARTITION``
-
-     - ``name``
-
-     - ``(empty sequence)``
-
-   * - ``GROUP_DATA``
-
-     - ``value``
-
-     - ``(empty sequence)``
-
-   * - ``ENTITY_FACTORY``
-
-     - ``autoenable_created_entities``
-
-     - ``true``
-
-.. _quality_of_service--reftable5:
-
-.. list-table:: Default Subscriber QoS Policies
-   :header-rows: 1
-
-   * - Policy
-
-     - Member
-
-     - Default Value
-
-   * - ``PRESENTATION``
-
-     - ``access_scope``
-
-       ``coherent_access``
-
-       ``ordered_access``
-
-     - ``INSTANCE_PRESENTATION_QOS``
-
-       ``0``
-
-       ``0``
-
-   * - ``PARTITION``
-
-     - ``name``
-
-     - ``(empty sequence)``
-
-   * - ``GROUP_DATA``
-
-     - ``value``
-
-     - ``(empty sequence)``
-
-   * - ``ENTITY_FACTORY``
-
-     - ``autoenable_created_entities``
-
-     - ``true``
-
-.. _quality_of_service--reftable6:
-
-.. list-table:: Default DataWriter QoS Policies
-   :header-rows: 1
-
-   * - Policy
-
-     - Member
-
-     - Default Value
-
-   * - ``DURABILITY``
-
-     - ``kind``
-
-       ``service_cleanup_delay.sec``
-
-       ``service_cleanup_delay.nanosec``
-
-     - ``VOLATILE_DURABILITY_QOS``
-
-       ``DURATION_ZERO_SEC``
-
-       ``DURATION_ZERO_NSEC``
-
-   * - ``DURABILITY_SERVICE``
-
-     - ``service_cleanup_delay.sec``
-
-       ``service_cleanup_delay.nanosec``
-
-       ``history_kind``
-
-       ``history_depth``
-
-       ``max_samples``
-
-       ``max_instances``
-
-       ``max_samples_per_instance``
-
-     - ``DURATION_ZERO_SEC``
-
-       ``DURATION_ZERO_NSEC``
-
-       ``KEEP_LAST_HISTORY_QOS``
-
-       ``1``
-
-       ``LENGTH_UNLIMITED``
-
-       ``LENGTH_UNLIMITED``
-
-       ``LENGTH_UNLIMITED``
-
-   * - ``DEADLINE``
-
-     - ``period.sec``
-
-       ``period.nanosec``
-
-     - ``DURATION_INFINITE_SEC``
-
-       ``DURATION_INFINITE_NSEC``
-
-   * - ``LATENCY_BUDGET``
-
-     - ``duration.sec``
-
-       ``duration.nanosec``
-
-     - ``DURATION_ZERO_SEC``
-
-       ``DURATION_ZERO_NSEC``
-
-   * - ``LIVELINESS``
-
-     - ``kind``
-
-       ``lease_duration.sec``
-
-       ``lease_duration.nanosec``
-
-     - ``AUTOMATIC_LIVELINESS_QOS``
-
-       ``DURATION_INFINITE_SEC``
-
-       ``DURATION_INFINITE_NSEC``
-
-   * - ``RELIABILITY``
-
-     - ``kind``
-
-       ``max_blocking_time.sec``
-
-       ``max_blocking_time.nanosec``
-
-     - ``RELIABLE_RELIABILITY_QOS`` [#footnote1]_
-
-       ``0``
-
-       ``100000000 (100 ms)``
-
-   * - ``DESTINATION_ORDER``
-
-     - ``kind``
-
-     - ``BY_RECEPTION_TIMESTAMP_``
-
-       ``DESTINATIONORDER_QOS``
-
-   * - ``HISTORY``
-
-     - ``kind``
-
-       ``depth``
-
-     - ``KEEP_LAST_HISTORY_QOS``
-
-       ``1``
-
-   * - ``RESOURCE_LIMITS``
-
-     - ``max_samples``
-
-       ``max_instances``
-
-       ``max_samples_per_instance``
-
-     - ``LENGTH_UNLIMITED``
-
-       ``LENGTH_UNLIMITED``
-
-       ``LENGTH_UNLIMITED``
-
-   * - ``TRANSPORT_PRIORITY``
-
-     - ``value``
-
-     - ``0``
-
-   * - ``LIFESPAN``
-
-     - ``duration.sec``
-
-       ``duration.nanosec``
-
-     - ``DURATION_INFINITE_SEC``
-
-       ``DURATION_INFINITE_NSEC``
-
-   * - ``USER_DATA``
-
-     - ``value``
-
-     - ``(empty sequence)``
-
-   * - ``OWNERSHIP``
-
-     - ``kind``
-
-     - ``SHARED_OWNERSHIP_QOS``
-
-   * - ``OWNERSHIP_STRENGTH``
-
-     - ``value``
-
-     - ``0``
-
-   * - ``WRITER_DATA_LIFECYCLE``
-
-     - ``autodispose_unregistered_instances``
-
-     - ``1``
-
-.. _quality_of_service--reftable7:
-
-.. list-table:: Default DataReader QoS Policies
-   :header-rows: 1
-
-   * - Policy
-
-     - Member
-
-     - Default Value
-
-   * - ``DURABILITY``
-
-     - ``kind``
-
-       ``service_cleanup_delay.sec``
-
-       ``service_cleanup_delay.nanosec``
-
-     - ``VOLATILE_DURABILITY_QOS``
-
-       ``DURATION_ZERO_SEC``
-
-       ``DURATION_ZERO_NSEC``
-
-   * - ``DEADLINE``
-
-     - ``period.sec``
-
-       ``period.nanosec``
-
-     - ``DURATION_INFINITE_SEC``
-
-       ``DURATION_INFINITE_NSEC``
-
-   * - ``LATENCY_BUDGET``
-
-     - ``duration.sec``
-
-       ``duration.nanosec``
-
-     - ``DURATION_ZERO_SEC``
-
-       ``DURATION_ZERO_NSEC``
-
-   * - ``LIVELINESS``
-
-     - ``kind``
-
-       ``lease_duration.sec``
-
-       ``lease_duration.nanosec``
-
-     - ``AUTOMATIC_LIVELINESS_QOS``
-
-       ``DURATION_INFINITE_SEC``
-
-       ``DURATION_INFINITE_NSEC``
-
-   * - ``RELIABILITY``
-
-     - ``kind``
-
-       ``max_blocking_time.sec``
-
-       ``max_blocking_time.nanosec``
-
-     - ``BEST_EFFORT_RELIABILITY_QOS``
-
-       ``DURATION_INFINITE_SEC``
-
-       ``DURATION_INFINITE_NSEC``
-
-   * - ``DESTINATION_ORDER``
-
-     - ``kind``
-
-     - ``BY_RECEPTION_TIMESTAMP_``
-
-       ``DESTINATIONORDER_QOS``
-
-   * - ``HISTORY``
-
-     - ``kind``
-
-       ``depth``
-
-     - ``KEEP_LAST_HISTORY_QOS``
-
-       ``1``
-
-   * - ``RESOURCE_LIMITS``
-
-     - ``max_samples``
-
-       ``max_instances``
-
-       ``max_samples_per_instance``
-
-     - ``LENGTH_UNLIMITED``
-
-       ``LENGTH_UNLIMITED``
-
-       ``LENGTH_UNLIMITED``
-
-   * - ``USER_DATA``
-
-     - ``value``
-
-     - ``(empty sequence)``
-
-   * - ``OWNERSHIP``
-
-     - ``kind``
-
-     - ``SHARED_OWNERSHIP_QOS``
-
-   * - ``TIME_BASED_FILTER``
-
-     - ``minimum_separation.sec``
-
-       ``minimum_separation.nanosec``
-
-     - ``DURATION_ZERO_SEC``
-
-       ``DURATION_ZERO_NSEC``
-
-   * - ``READER_DATA_LIFECYCLE``
-
-     - ``autopurge_nowriter_samples_delay.sec``
-
-       ``autopurge_nowriter_samples_delay.nanosec``
-
-       ``autopurge_disposed_samples_delay.sec``
-
-       ``autopurge_disposed_samples_delay.nanosec``
-
-     - ``DURATION_INFINITE_SEC``
-
-       ``DURATION_INFINITE_NSEC``
-
-       ``DURATION_INFINITE_SEC``
-
-       ``DURATION_INFINITE_NSEC``
-
+********
+Policies
+********
+
+.. _qos-liveliness:
 .. _quality_of_service--liveliness:
 
-LIVELINESS
-==========
+Liveliness QoS
+==============
 
 ..
     Sect<3.2.2>
 
-The ``LIVELINESS`` policy applies to the topic, data reader, and data writer entities via the liveliness member of their respective QoS structures.
+The liveliness QoS policy controls when and how the service determines whether participants are considered "alive", meaning they are still reachable and active.
+This policy applies to the topic, data reader, and data writer entities via the ``liveliness`` member of their respective QoS structures.
 Setting this policy on a topic means it is in effect for all data readers and data writers on that topic.
-Below is the IDL related to the liveliness QoS policy:
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`immutable <qos-changing>` and affects :ref:`association <qos-liveliness-association>`.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     enum LivelinessQosPolicyKind {
       AUTOMATIC_LIVELINESS_QOS,
@@ -735,17 +139,43 @@ Below is the IDL related to the liveliness QoS policy:
       Duration_t lease_duration;
     };
 
-The ``LIVELINESS`` policy controls when and how the service determines whether participants are alive, meaning they are still reachable and active.
-The kind member setting indicates whether liveliness is asserted automatically by the service or manually by the specified entity.
-A setting of ``AUTOMATIC_LIVELINESS_QOS`` means that the service will send a liveliness indication if the participant has not sent any network traffic for the lease_duration.
-The ``MANUAL_BY_PARTICIPANT_LIVELINESS_QOS`` or ``MANUAL_BY_TOPIC_LIVELINESS_QOS`` setting means the specified entity (data writer for the "by topic" setting or domain participant for the "by participant" setting) must either write a sample or manually assert its liveliness within a specified heartbeat interval.
-The desired heartbeat interval is specified by the lease_duration member.
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic`, :term:`DataWriter`, and :term:`DataReader`
+
+       - ``kind``
+
+         ``lease_duration.sec``
+
+         ``lease_duration.nanosec``
+
+       - ``AUTOMATIC_LIVELINESS_QOS``
+
+         ``DURATION_INFINITE_SEC``
+
+         ``DURATION_INFINITE_NSEC``
+
+  Specification: :omgspec:`dds:2.2.3.11 LIVELINESS`
+
+The ``kind`` member setting indicates whether liveliness is asserted automatically by the service or manually by the specified entity.
+A setting of ``AUTOMATIC_LIVELINESS_QOS`` means that the service will send a liveliness indication if the participant has not sent any network traffic for the ``lease_duration``.
+The ``MANUAL_BY_PARTICIPANT_LIVELINESS_QOS`` or ``MANUAL_BY_TOPIC_LIVELINESS_QOS`` setting means the specified entity (data writer for the "by topic" setting or domain participant for the "by participant" setting) must either write a :term:`sample` or manually assert its liveliness within a specified heartbeat interval.
+The desired heartbeat interval is specified by the ``lease_duration`` member.
 The default lease duration is a pre-defined infinite value, which disables any liveliness testing.
 
 To manually assert liveliness without publishing a sample, the application must call the ``assert_liveliness()`` operation on the data writer (for the "by topic" setting) or on the domain participant (for the "by participant" setting) within the specified heartbeat interval.
 
 Data writers specify (*offer*) their own liveliness criteria and data readers specify (*request*) the desired liveliness of their writers.
-Writers that are not heard from within the lease duration (either by writing a sample or by asserting liveliness) cause a change in the ``LIVELINESS_CHANGED_STATUS`` communication status and notification to the application (e.g., by calling the data reader listener's ``on_liveliness_changed()`` callback operation or by signaling any related wait sets).
+Writers that are not heard from within the lease duration (either by writing a sample or by asserting liveliness) cause a change in the :ref:`LIVELINESS_CHANGED_STATUS <conditions_and_listeners--liveliness-changed-status>` communication status and notification to the application (e.g., by calling the data reader listener's ``on_liveliness_changed()`` callback operation or by signaling any related wait sets).
+
+.. _qos-liveliness-association:
 
 This policy is considered during the establishment of associations between data writers and data readers.
 The value of both sides of the association must be compatible in order for an association to be established.
@@ -763,18 +193,25 @@ The liveliness kind values are ordered as follows:
 In addition, the writer's offered lease duration must be less than or equal to the reader's requested lease duration.
 Both of these conditions must be met for the offered and requested liveliness policy settings to be considered compatible and the association established.
 
+.. _qos-reliability:
 .. _quality_of_service--reliability:
 
-RELIABILITY
-===========
+Reliability QoS
+===============
 
 ..
     Sect<3.2.3>
 
-The ``RELIABILITY`` policy applies to the topic, data reader, and data writer entities via the reliability member of their respective QoS structures.
-Below is the IDL related to the reliability QoS policy:
+The reliability QoS policy applies to the topic, data reader, and data writer entities via the ``reliability`` member of their respective QoS structures.
+This policy controls how data readers and writers treat the :term:`sample`\s they process.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`immutable <qos-changing>` and affects :ref:`association <qos-reliability-association>`.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     enum ReliabilityQosPolicyKind {
       BEST_EFFORT_RELIABILITY_QOS,
@@ -786,33 +223,80 @@ Below is the IDL related to the reliability QoS policy:
       Duration_t max_blocking_time;
     };
 
-This policy controls how data readers and writers treat the data samples they process.
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic` and :term:`DataReader`
+
+       - ``kind``
+
+         ``max_blocking_time.sec``
+
+         ``max_blocking_time.nanosec``
+
+       - ``BEST_EFFORT_RELIABILITY_QOS``
+
+         ``DURATION_INFINITE_SEC``
+
+         ``DURATION_INFINITE_NSEC``
+
+     * - :term:`DataWriter`
+
+       - ``kind``
+
+         ``max_blocking_time.sec``
+
+         ``max_blocking_time.nanosec``
+
+       - ``RELIABLE_RELIABILITY_QOS`` [#footnote1]_
+
+         ``0``
+
+         ``100000000`` (100 ms)
+
+  Specification: :omgspec:`dds:2.2.3.14 RELIABILITY`
+
 The "best effort" value (``BEST_EFFORT_RELIABILITY_QOS``) makes no promises as to the reliability of the samples and could be expected to drop samples under some circumstances.
 The "reliable" value (``RELIABLE_RELIABILITY_QOS``) indicates that the service should eventually deliver all values to eligible data readers.
 
-The ``max_blocking_time`` member of this policy is used when the history QoS policy is set to "keep all" and the writer is unable to proceed because of resource limits.
-When this situation occurs and the writer blocks for more than the specified time, then the write fails with a timeout return code.
-The default for this policy for data readers and topics is "best effort," while the default value for data writers is "reliable."
+The ``max_blocking_time`` member of this policy is used when the :ref:`qos-history` policy is set to "keep all" and the writer is unable to proceed because of :ref:`qos-resource-limits`.
+When this situation occurs and the writer blocks for more than the specified time, then the write fails with a ``DDS::RETCODE_TIMEOUT`` return code.
+The default for this policy for data readers and topics is "best effort", while the default value for data writers is "reliable".
+
+.. _qos-reliability-association:
 
 This policy is considered during the creation of associations between data writers and data readers.
 The value of both sides of the association must be compatible in order for an association to be created.
 The reliability kind of data writer must be greater than or equal to the value of data reader.
+In other words, all combinations are valid except that a reliable reader can only associate with a reliable writer, not a "best effort" one.
 
+.. _qos-history:
 .. _quality_of_service--history:
 
-HISTORY
-=======
+History QoS
+===========
 
 ..
     Sect<3.2.4>
 
-The ``HISTORY`` policy determines how samples are held in the data writer and data reader for a particular instance.
+The history QoS policy determines how :term:`sample`\s are held in the data writer and data reader for a particular :term:`instance`.
 For data writers these values are held until the publisher retrieves them and successfully sends them to all connected subscribers.
-For data readers these values are held until "taken" by the application.
-This policy applies to the topic, data reader, and data writer entities via the history member of their respective QoS structures.
-Below is the IDL related to the history QoS policy:
+For data readers these values are held until :ref:`taken <getting_started--reading-multiple-samples>` by the application.
+This policy applies to the topic, data reader, and data writer entities via the ``history`` member of their respective QoS structures.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`immutable <qos-changing>` and does not affect association.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     enum HistoryQosPolicyKind {
       KEEP_LAST_HISTORY_QOS,
@@ -824,28 +308,53 @@ Below is the IDL related to the history QoS policy:
       long depth;
     };
 
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic`, :term:`DataWriter`, and :term:`DataReader`
+
+       - ``kind``
+
+         ``depth``
+
+       - ``KEEP_LAST_HISTORY_QOS``
+
+         ``1``
+
+  Specification: :omgspec:`dds:2.2.3.18 HISTORY`
+
 The "keep all" value (``KEEP_ALL_HISTORY_QOS``) specifies that all possible samples for that instance should be kept.
-When "keep all" is specified and the number of unread samples is equal to the "resource limits" field of ``max_samples_per_instance`` then any incoming samples are rejected.
+When "keep all" is specified and the number of unread samples is equal to the :ref:`qos-resource-limits` field of ``max_samples_per_instance`` then any incoming samples are rejected.
 
 The "keep last" value (``KEEP_LAST_HISTORY_QOS``) specifies that only the last ``depth`` values should be kept.
 When a data writer contains depth samples of a given instance, a write of new samples for that instance are queued for delivery and the oldest unsent samples are discarded.
 When a data reader contains depth samples of a given instance, any incoming samples for that instance are kept and the oldest samples are discarded.
 
-This policy defaults to a "keep last" with a ``depth`` of one.
-
+.. _qos-durability:
 .. _quality_of_service--durability:
 
-DURABILITY
-==========
+Durability QoS
+==============
 
 ..
     Sect<3.2.5>
 
-The ``DURABILITY`` policy controls whether data writers should maintain samples after they have been sent to known subscribers.
-This policy applies to the topic, data reader, and data writer entities via the durability member of their respective QoS structures.
-Below is the IDL related to the durability QoS policy:
+The durability QoS policy controls whether data writers should maintain :term:`sample`\s after they have been sent to known subscribers.
+This policy applies to the topic, data reader, and data writer entities via the ``durability`` member of their respective QoS structures.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`immutable <qos-changing>` and affects :ref:`association <qos-durability-association>`.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     enum DurabilityQosPolicyKind {
       VOLATILE_DURABILITY_QOS,         // Least Durability
@@ -858,7 +367,24 @@ Below is the IDL related to the durability QoS policy:
       DurabilityQosPolicyKind kind;
     };
 
-By default the kind is ``VOLATILE_DURABILITY_QOS``.
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic`, :term:`DataWriter`, and :term:`DataReader`
+
+       - ``kind``
+
+       - ``VOLATILE_DURABILITY_QOS``
+
+  Specification: :omgspec:`dds:2.2.3.4 DURABILITY`
+
+.. _VOLATILE_DURABILITY_QOS:
 
 A durability kind of ``VOLATILE_DURABILITY_QOS`` means samples are discarded after being sent to all known subscribers.
 As a side effect, subscribers cannot recover samples sent before they connect.
@@ -869,9 +395,13 @@ A durability kind of ``TRANSIENT_DURABILITY_QOS`` means that samples outlive a d
 The samples are kept in memory, but are not persisted to permanent storage.
 A data reader subscribed to the same topic and partition within the same domain will be sent all of the cached samples that belong to the same topic/partition.
 
+.. _PERSISTENT_DURABILITY_QOS:
+
 A durability kind of ``PERSISTENT_DURABILITY_QOS`` provides basically the same functionality as transient durability except the cached samples are persisted and will survive process destruction.
 
-When transient or persistent durability is specified, the ``DURABILITY_SERVICE`` QoS policy specifies additional tuning parameters for the durability cache.
+When transient or persistent durability is specified, the :ref:`qos-durability-service` QoS policy specifies additional tuning parameters for the durability cache.
+
+.. _qos-durability-association:
 
 The durability policy is considered during the creation of associations between data writers and data readers.
 The value of both sides of the association must be compatible in order for an association to be created.
@@ -885,19 +415,25 @@ The durability kind values are ordered as follows:
     TRANSIENT_LOCAL_DURABILITY_QOS >
     VOLATILE_DURABILITY_QOS
 
+.. _qos-durability-service:
 .. _quality_of_service--durability-service:
 
-DURABILITY_SERVICE
-==================
+Durability Service QoS
+======================
 
 ..
     Sect<3.2.6>
 
-The ``DURABILITY_SERVICE`` policy controls deletion of samples in ``TRANSIENT`` or ``PERSISTENT`` durability cache.
-This policy applies to the topic and data writer entities via the durability_service member of their respective QoS structures and provides a way to specify ``HISTORY`` and ``RESOURCE_LIMITS`` for the sample cache.
-Below is the IDL related to the durability service QoS policy:
+The durability service QoS policy controls deletion of :term:`sample`\s in the transient or persistent durability caches.
+This policy applies to the topic and data writer entities via the ``durability_service`` member of their respective QoS structures and provides a way to specify :ref:`qos-history` and :ref:`qos-resource-limits` for the sample cache.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`immutable <qos-changing>` and does not affect association.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct DurabilityServiceQosPolicy {
       Duration_t              service_cleanup_delay;
@@ -908,23 +444,70 @@ Below is the IDL related to the durability service QoS policy:
       long                    max_samples_per_instance;
     };
 
-The history and resource limits members are analogous to, although independent of, those found in the ``HISTORY`` and ``RESOURCE_LIMITS`` policies.
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic` and :term:`DataWriter`
+
+       - ``service_cleanup_delay.sec``
+
+         ``service_cleanup_delay.nanosec``
+
+         ``history_kind``
+
+         ``history_depth``
+
+         ``max_samples``
+
+         ``max_instances``
+
+         ``max_samples_per_instance``
+
+       - ``DURATION_ZERO_SEC``
+
+         ``DURATION_ZERO_NSEC``
+
+         ``KEEP_LAST_HISTORY_QOS``
+
+         ``1``
+
+         ``LENGTH_UNLIMITED``
+
+         ``LENGTH_UNLIMITED``
+
+         ``LENGTH_UNLIMITED``
+
+  Specification: :omgspec:`dds:2.2.3.5 DURABILITY_SERVICE`
+
+The members are analogous to, although independent of, those found in the :ref:`qos-history` and :ref:`qos-resource-limits` policies.
 The ``service_cleanup_delay`` can be set to a desired value.
 By default, it is set to zero, which means never clean up cached samples.
 
+.. _qos-resource-limits:
 .. _quality_of_service--resource-limits:
 
-RESOURCE_LIMITS
-===============
+Resource Limits QoS
+===================
 
 ..
     Sect<3.2.7>
 
-The ``RESOURCE_LIMITS`` policy determines the amount of resources the service can consume in order to meet the requested QoS.
-This policy applies to the topic, data reader, and data writer entities via the resource_limits member of their respective QoS structures.
-Below is the IDL related to the resource limits QoS policy.
+The resource limits determines the amount of resources the service can consume in order to meet the requested QoS.
+This policy applies to the topic, data reader, and data writer entities via the ``resource_limits`` member of their respective QoS structures.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`immutable <qos-changing>` and does not affect association.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct ResourceLimitsQosPolicy {
       long max_samples;
@@ -932,64 +515,138 @@ Below is the IDL related to the resource limits QoS policy.
       long max_samples_per_instance;
     };
 
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic`, :term:`DataWriter`, and :term:`DataReader`
+
+       - ``max_samples``
+
+         ``max_instances``
+
+         ``max_samples_per_instance``
+
+       - ``LENGTH_UNLIMITED``
+
+         ``LENGTH_UNLIMITED``
+
+         ``LENGTH_UNLIMITED``
+
+  Specification: :omgspec:`dds:2.2.3.19 RESOURCE_LIMITS`
+
 The ``max_samples`` member specifies the maximum number of samples a single data writer or data reader can manage across all of its instances.
 The ``max_instances`` member specifies the maximum number of instances that a data writer or data reader can manage.
 The ``max_samples_per_instance`` member specifies the maximum number of samples that can be managed for an individual instance in a single data writer or data reader.
-The values of all these members default to unlimited (``DDS::LENGTH_UNLIMITED``).
 
 Resources are used by the data writer to queue samples written to the data writer but not yet sent to all data readers because of backpressure from the transport.
 Resources are used by the data reader to queue samples that have been received, but not yet read/taken from the data reader.
 
+.. _qos-partition:
 .. _quality_of_service--partition:
 
-PARTITION
-=========
+Partition QoS
+=============
 
 ..
     Sect<3.2.8>
 
-The ``PARTITION`` QoS policy allows the creation of logical partitions within a domain.
+The partition QoS policy allows the creation of logical partitions within a :term:`domain`.
 It only allows data readers and data writers to be associated if they have matched partition strings.
-This policy applies to the publisher and subscriber entities via the partition member of their respective QoS structures.
-Below is the IDL related to the partition QoS policy.
+This policy applies to the publisher and subscriber entities via the ``partition`` member of their respective QoS structures.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`mutable <qos-changing>` and :ref:`affects association <qos-partition-association>`.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct PartitionQosPolicy {
       StringSeq name;
     };
 
-The name member defaults to an empty sequence of strings.
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Publisher` and :term:`Subscriber`
+
+       - ``name``
+
+       - (empty sequence)
+
+  Specification: :omgspec:`dds:2.2.3.13 PARTITION`
+
 The default partition name is an empty string and causes the entity to participate in the default partition.
-The partition names may contain wildcard characters as defined by the POSIX ``fnmatch`` function (POSIX 1003.2-1992 section B.6).
+The partition names may contain wildcard characters as they are :ref:`fnmatch-exprs`.
+
+.. _qos-partition-association:
 
 The establishment of data reader and data writer associations depends on matching partition strings on the publication and subscription ends.
 Failure to match partitions is not considered a failure and does not trigger any callbacks or set any status values.
 
-The value of this policy may be changed at any time.
-Changes to this policy may cause associations to be removed or added.
-
+.. _qos-deadline:
 .. _quality_of_service--deadline:
 
-DEADLINE
-========
+Deadline QoS
+============
 
 ..
     Sect<3.2.9>
 
-The ``DEADLINE`` QoS policy allows the application to detect when data is not written or read within a specified amount of time.
-This policy applies to the topic, data writer, and data reader entities via the deadline member of their respective QoS structures.
-Below is the IDL related to the deadline QoS policy.
+The deadline QoS policy allows the application to detect when :term:`sample`\s are not written or read within a specified amount of time.
+This policy applies to the topic, data writer, and data reader entities via the ``deadline`` member of their respective QoS structures.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`mutable <qos-changing>` and :ref:`affects association <qos-deadline-association>`.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct DeadlineQosPolicy {
       Duration_t period;
     };
 
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic`, :term:`DataWriter`, and :term:`DataReader`
+
+       - ``period.sec``
+
+         ``period.nanosec``
+
+       - ``DURATION_INFINITE_SEC``
+
+         ``DURATION_INFINITE_NSEC``
+
+  Specification: :omgspec:`dds:2.2.3.7 DEADLINE`
+
 The default value of the ``period`` member is infinite, which requires no behavior.
 When this policy is set to a finite value, then the data writer monitors the changes to data made by the application and indicates failure to honor the policy by setting the corresponding status condition and triggering the ``on_offered_deadline_missed()`` listener callback.
 A data reader that detects that the data has not changed before the period has expired sets the corresponding status condition and triggers the ``on_requested_deadline_missed()`` listener callback.
+
+.. _qos-deadline-association:
 
 This policy is considered during the creation of associations between data writers and data readers.
 The value of both sides of the association must be compatible in order for an association to be created.
@@ -997,122 +654,251 @@ The deadline period of the data reader must be greater than or equal to the corr
 
 The value of this policy may change after the associated entity is enabled.
 In the case where the policy of a data reader or data writer is made, the change is successfully applied only if the change remains consistent with the remote end of all associations in which the reader or writer is participating.
-If the policy of a topic is changed, it will affect only data readers and writers that are created after the change has been made.
+If the policy of a topic is changed, it will only affect data readers and writers that are created after the change has been made.
 Any existing readers or writers, and any existing associations between them, will not be affected by the topic policy value change.
 
+.. _qos-lifespan:
 .. _quality_of_service--lifespan:
 
-LIFESPAN
-========
+Lifespan QoS
+============
 
 ..
     Sect<3.2.10>
 
-The ``LIFESPAN`` QoS policy allows the application to specify when a sample expires.
+The lifespan QoS policy allows the application to specify when a :term:`sample` expires.
 Expired samples will not be delivered to subscribers.
-This policy applies to the topic and data writer entities via the lifespan member of their respective QoS structures.
-Below is the IDL related to the lifespan QoS policy.
+This policy applies to the topic and data writer entities via the ``lifespan`` member of their respective QoS structures.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`mutable <qos-changing>` and does not affect association.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct LifespanQosPolicy {
       Duration_t duration;
     }
 
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic` and :term:`DataWriter`
+
+       - ``duration.sec``
+
+         ``duration.nanosec``
+
+       - ``DURATION_INFINITE_SEC``
+
+         ``DURATION_INFINITE_NSEC``
+
+  Specification: :omgspec:`dds:2.2.3.16 LIFESPAN`
+
 The default value of the ``duration`` member is infinite, which means samples never expire.
-OpenDDS currently supports expired sample detection on the publisher side when using a ``DURABILITY`` ``kind`` other than ``VOLATILE``.
-The current OpenDDS implementation may not remove samples from the data writer and data reader caches when they expire after being placed in the cache.
 
-The value of this policy may be changed at any time.
-Changes to this policy affect only data written after the change.
+.. note::
 
+  OpenDDS currently supports expired sample detection on the publisher side when using a :ref:`qos-durability` ``kind`` other than :ref:`VOLATILE_DURABILITY_QOS <VOLATILE_DURABILITY_QOS>`.
+  The current OpenDDS implementation may not remove samples from the data writer and data reader caches when they expire after being placed in the cache.
+
+The value of this policy may be changed at any time, but only affects data written after the change.
+
+.. _qos-user-data:
 .. _quality_of_service--user-data:
 
-USER_DATA
-=========
+User Data QoS
+=============
 
 ..
     Sect<3.2.11>
 
-The ``USER_DATA`` policy applies to the domain participant, data reader, and data writer entities via the user_data member of their respective QoS structures.
-Below is the IDL related to the user data QoS policy:
+The user data QoS policy can be used to attach arbitrary information to the created :term:`entity`.
+This policy applies to the domain participant, data reader, and data writer entities via the ``user_data`` member of their respective QoS structures.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`mutable <qos-changing>` and does not affect association.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct UserDataQosPolicy {
       sequence<octet> value;
     };
 
-By default, the ``value`` member is not set.
-It can be set to any sequence of octets which can be used to attach information to the created entity.
-The value of the ``USER_DATA`` policy is available in respective built-in topic data.
-The remote application can obtain the information via the built-in topic and use it for its own purposes.
-For example, the application could attach security credentials via the ``USER_DATA`` policy that can be used by the remote application to authenticate the source.
+  .. list-table::
+     :header-rows: 1
 
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`DomainParticipant`, :term:`DataWriter`, :term:`DataReader`
+
+       - ``value``
+
+       - (empty sequence)
+
+  Specification: :omgspec:`dds:2.2.3.1 USER_DATA`
+
+The value of the policy is available in respective :ref:`built-in topic data <bit>`.
+The value's use is defined by the application.
+For example, the application could attach security credentials via the policy that can be used by the remote application to authenticate the source. [#user_data_ex]_
+
+.. warning::
+
+  When using :ref:`dds_security`, the user data of a participant can be leaked in unsecured discovery messages.
+  Enabling ``[rtps_discovery]SecureParticipantUserData`` will only send and provide the real user data when it can be securely sent.
+  This is an OpenDDS-specific extension.
+
+.. _qos-topic-data:
 .. _quality_of_service--topic-data:
 
-TOPIC_DATA
-==========
+Topic Data QoS
+==============
 
 ..
     Sect<3.2.12>
 
-The ``TOPIC_DATA`` policy applies to topic entities via the topic_data member of TopicQoS structures.
-Below is the IDL related to the topic data QoS policy:
+The topic data QoS policy can be used to attach arbitrary information to the created :term:`topic`.
+This policy applies to topic entities via the ``topic_data`` member of ``TopicQoS`` structures.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`mutable <qos-changing>` and does not affect association.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct TopicDataQosPolicy {
       sequence<octet> value;
     };
 
-By default, the ``value`` is not set.
-It can be set to attach additional information to the created topic.
-The value of the ``TOPIC_DATA`` policy is available in data writer, data reader, and topic built-in topic data.
-The remote application can obtain the information via the built-in topic and use it in an application-defined way.
+  .. list-table::
+     :header-rows: 1
 
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic`
+
+       - ``value``
+
+       - (empty sequence)
+
+
+  Specification: :omgspec:`dds:2.2.3.2 TOPIC_DATA`
+
+The value of the topic data policy is available in data writer, data reader, and topic :ref:`built-in topic data <bit>`.
+The value's use is defined by the application.
+
+.. _qos-group-data:
 .. _quality_of_service--group-data:
 
-GROUP_DATA
-==========
+Group Data QoS
+==============
 
 ..
     Sect<3.2.13>
 
-The ``GROUP_DATA`` policy applies to the publisher and subscriber entities via the group_data member of their respective QoS structures.
-Below is the IDL related to the group data QoS policy:
+The group data QoS policy can be used to attach arbitrary information to the created :term:`entity`.
+This policy applies to the publisher and subscriber entities via the ``group_data`` member of their respective QoS structures.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`mutable <qos-changing>` and does not affect association.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct GroupDataQosPolicy {
       sequence<octet> value;
     };
 
-By default, the ``value`` member is not set.
-It can be set to attach additional information to the created entities.
-The value of the ``GROUP_DATA`` policy is propagated via built-in topics.
-The data writer built-in topic data contains the ``GROUP_DATA`` from the publisher and the data reader built-in topic data contains the ``GROUP_DATA`` from the subscriber.
-The ``GROUP_DATA`` policy could be used to implement matching mechanisms similar to those of the :ref:`PARTITION policy <quality_of_service--partition>` except the decision could be made based on an application-defined policy.
+  .. list-table::
+     :header-rows: 1
 
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Publisher` and :term:`Subscriber`
+
+       - ``value``
+
+       - (empty sequence)
+
+  Specification: :omgspec:`dds:2.2.3.3 GROUP_DATA`
+
+The value of the group data policy is propagated via :ref:`built-in topics <bit>` using the writer built-in topic data for the publisher and the reader built-in topic data for the subscriber.
+The value's use is defined by the application.
+This could be used to implement matching mechanisms similar to those of the :ref:`qos-partition` except the decision could be made based on an application-defined policy.
+
+.. _qos-transport-priority:
 .. _quality_of_service--transport-priority:
 
-TRANSPORT_PRIORITY
-==================
+Transport Priority QoS
+======================
 
 ..
     Sect<3.2.14>
 
-The ``TRANSPORT_PRIORITY`` policy applies to topic and data writer entities via the transport_priority member of their respective QoS policy structures.
-Below is the IDL related to the TransportPriority QoS policy:
+The transport priority QoS policy is considered a hint to the transport layer to indicate at what priority to send messages.
+This policy applies to topic and data writer entities via the ``transport_priority`` member of their respective QoS policy structures.
 
-.. code-block:: omg-idl
+.. important::
+
+  OpenDDS currently only uses this in the tcp and udp transports.
+
+  This policy is :ref:`immutable <qos-changing>` and does not affect association.
+  This is opposed to the DDS specification, which specifies that it's mutable.
+  OpenDDS does not currently support modifications of the transport priority policy values after creation of the data writer.
+  This can be worked around by creating new data writers as different priority values are required.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct TransportPriorityQosPolicy {
       long value;
     };
 
-The default value member of ``transport_priority`` is zero.
-This policy is considered a hint to the transport layer to indicate at what priority to send messages.
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic` and :term:`DataWriter`
+
+       - ``value``
+
+       - ``0``
+
+  Specification: :omgspec:`dds:2.2.3.15 TRANSPORT_PRIORITY`
+
 Higher values indicate higher priority.
 OpenDDS maps the priority value directly onto thread and DiffServ codepoint values.
 A default priority of zero will not modify either threads or codepoints in messages.
@@ -1125,42 +911,73 @@ Priority values lower than the minimum (lowest) thread priority on a system are 
 Priority values greater than the maximum (highest) thread priority on a system are mapped to that highest priority.
 On most systems, thread priorities can only be set when the process scheduler has been set to allow these operations.
 Setting the process scheduler is generally a privileged operation and will require system privileges to perform.
-On POSIX based systems, the system calls of ``sched_get_priority_min()`` and ``sched_get_priority_max()`` are used to determine the system range of thread priorities.
+On POSIX based systems, the system calls of :manpage:`sched_get_priority_min(2)` and :manpage:`sched_get_priority_max(2)` are used to determine the system range of thread priorities.
 
 OpenDDS will attempt to set the DiffServ codepoint on the socket used to send data for the data writer if it is supported by the transport implementation.
 If the network hardware honors the codepoint values, higher codepoint values will result in better (faster) transport for higher priority samples.
 The default value of zero will be mapped to the (default) codepoint of zero.
 Priority values from 1 through 63 are then mapped to the corresponding codepoint values, and higher priority values are mapped to the highest codepoint value (63).
 
-OpenDDS does not currently support modifications of the transport_priority policy values after creation of the data writer.
-This can be worked around by creating new data writers as different priority values are required.
-
+.. _qos-latency-budget:
 .. _quality_of_service--latency-budget:
 
-LATENCY_BUDGET
-==============
+Latency Budget QoS
+==================
 
 ..
     Sect<3.2.15>
 
-The ``LATENCY_BUDGET`` policy applies to topic, data reader, and data writer entities via the latency_budget member of their respective QoS policy structures.
-Below is the IDL related to the LatencyBudget QoS policy:
+The latency budget QoS policy is considered a hint to the transport layer to indicate the urgency of :term:`sample`\s being sent.
+This policy applies to topic, data reader, and data writer entities via the ``latency_budget`` member of their respective QoS policy structures.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`mutable <qos-changing>` and :ref:`affects association <qos-latency-budget-association>`.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct LatencyBudgetQosPolicy {
       Duration_t duration;
     };
 
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic`, :term:`DataWriter`, and :term:`DataReader`
+
+       - ``duration.sec``
+
+         ``duration.nanosec``
+
+       - ``DURATION_ZERO_SEC``
+
+         ``DURATION_ZERO_NSEC``
+
+  Specification: :omgspec:`dds:2.2.3.8 LATENCY_BUDGET`
+
 The default value of ``duration`` is zero indicating that the delay should be minimized.
-This policy is considered a hint to the transport layer to indicate the urgency of samples being sent.
 OpenDDS uses the value to bound a delay interval for reporting unacceptable delay in transporting samples from publication to subscription.
 This policy is used for monitoring purposes only at this time.
-Use the ``TRANSPORT_PRIORITY`` policy to modify the sending of samples.
+Use :ref:`qos-transport-priority` to modify the sending priority of samples.
+
+.. _qos-latency-budget-association:
+
 The data writer policy value is used only for compatibility comparisons and if left at the default value of zero will result in all requested duration values from data readers being matched.
+The data writer policy value must be greater or equal to a data reader policy value for an association to occur or continue to exist.
+
+..
+  TODO: Move the rest to Listener documentation?
 
 An additional listener extension has been added to allow reporting delays in excess of the policy duration setting.
-The ``OpenDDS::DCPS::DataReaderListener`` interface has an additional operation for notification that samples were received with a measured transport delay greater than the latency_budget policy duration.
+The ``OpenDDS::DCPS::DataReaderListener`` interface has an additional operation for notification that samples were received with a measured transport delay greater than the latency budget policy duration.
 The IDL for this method is:
 
 .. code-block:: omg-idl
@@ -1251,46 +1068,72 @@ In the following example, we assume that reader is initialized correctly by call
         std::cout << "  variance = " << stats[i].variance << std::endl;
       }
 
+.. _qos-entity-factory:
 .. _quality_of_service--entity-factory:
 
-ENTITY_FACTORY
-==============
+Entity Factory QoS
+==================
 
 ..
     Sect<3.2.16>
 
-The ``ENTITY_FACTORY`` policy controls whether entities are automatically enabled when they are created.
-Below is the IDL related to the Entity Factory QoS policy:
+The entity factory QoS policy controls whether :term:`entities <entity>` are automatically enabled by their factories when they are created.
+This policy applies to domain participant factory (as a factory for domain participants), domain participant (as a factory for publishers, subscribers, and topics), publisher (as a factory for data writers), or subscriber (as a factory for data readers).
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`mutable <qos-changing>` and does not affect association.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct EntityFactoryQosPolicy {
       boolean autoenable_created_entities;
     };
 
-This policy can be applied to entities that serve as factories for other entities and controls whether or not entities created by those factories are automatically enabled upon creation.
-This policy can be applied to the domain participant factory (as a factory for domain participants), domain participant (as a factory for publishers, subscribers, and topics), publisher (as a factory for data writers), or subscriber (as a factory for data readers).
-The default value for the ``autoenable_created_entities`` member is ``true``, indicating that entities are automatically enabled when they are created.
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - ``DomainParticipantFactory``, :term:`DomainParticipant`, :term:`Publisher`, and :term:`Subscriber`
+
+       - ``autoenable_created_entities``
+
+       - ``true``
+
+  Specification: :omgspec:`dds:2.2.3.20 ENTITY_FACTORY`
+
 Applications that wish to explicitly enable entities some time after they are created should set the value of the ``autoenable_created_entities`` member of this policy to ``false`` and apply the policy to the appropriate factory entities.
 The application must then manually enable the entity by calling the entity's ``enable()`` operation.
+One use of setting this policy to ``false`` is :ref:`binding specfic transport configurations to readers and writers <run_time_configuration--using-multiple-configurations>`.
 
-The value of this policy may be changed at any time.
-Changes to this policy affect only entities created after the change.
+The value of this policy may be changed at any time, but this only affects entities created after the change.
 
+.. _qos-presentation:
 .. _quality_of_service--presentation:
 
-PRESENTATION
-============
+Presentation QoS
+================
 
 ..
     Sect<3.2.17>
 
-The ``PRESENTATION`` QoS policy controls how changes to instances by publishers are presented to data readers.
+The presentation QoS policy controls how changes to :term:`instance`\s by publishers are presented to data readers.
 It affects the relative ordering of these changes and the scope of this ordering.
-Additionally, this policy introduces the concept of coherent change sets.
-Here is the IDL for the Presentation QoS:
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`immutable <qos-changing>` and affects :ref:`association <qos-presentation-association>`.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     enum PresentationQosPolicyAccessScopeKind {
       INSTANCE_PRESENTATION_QOS,
@@ -1304,10 +1147,35 @@ Here is the IDL for the Presentation QoS:
       boolean ordered_access;
     };
 
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Publisher` and :term:`Subscriber`
+
+       - ``access_scope``
+
+         ``coherent_access``
+
+         ``ordered_access``
+
+       - ``INSTANCE_PRESENTATION_QOS``
+
+         ``0``
+
+         ``0``
+
+  Specification: :omgspec:`dds:2.2.3.6 PRESENTATION`
+
 The scope of these changes (``access_scope``) specifies the level in which an application may be made aware:
 
 * ``INSTANCE_PRESENTATION_QOS`` (the default) indicates that changes occur to instances independently.
-  Instance access essentially acts as a no-op with respect to coherent_access and ordered_access.
+  Instance access essentially acts as a no-op with respect to ``coherent_access`` and ``ordered_access``.
   Setting either of these values to true has no observable affect within the subscribing application.
 
 * ``TOPIC_PRESENTATION_QOS`` indicates that accepted changes are limited to all instances within the same data reader or data writer.
@@ -1320,25 +1188,38 @@ The semantics of coherent changes are similar in nature to those found in transa
 By default, ``coherent_access`` is ``false``.
 
 Changes may also be made available to associated data readers in the order sent by the publisher (``ordered_access``).
-This is similar in nature to the ``DESTINATION_ORDER QoS`` policy, however ``ordered_access`` permits data to be ordered independently of instance ordering.
+This is similar in nature to the :ref:`qos-destination-order` policy, however ``ordered_access`` permits data to be ordered independently of instance ordering.
 By default, ``ordered_access`` is ``false``.
 
-.. note:: This policy controls the ordering and scope of samples made available to the subscriber, but the subscriber application must use the proper logic in reading samples to guarantee the requested behavior.
-  For more details, see :omgspec:`dds:2.2.2.5.1.9`.
+.. note:: This policy controls the ordering and scope of :term:`sample`\s made available to the subscriber, but the subscriber application must use the proper logic in reading samples to guarantee the requested behavior.
+  For more details, see :omgspec:`dds:2.2.2.5.1.9 Data access patterns`.
 
+.. _qos-presentation-association:
+
+For a reader and writer to associate, all the following must be true:
+
+- The writer's ``access_scope`` must be greater or equal to the reader's.
+- The writer's ``coherent_access`` must be ``false`` or else both the reader's and writer's ``coherent_access`` must both be ``true``.
+- The writer's ``ordered_access`` must be ``false`` or else both the reader's and writer's ``ordered_access`` must both be ``true``.
+
+.. _qos-destination-order:
 .. _quality_of_service--destination-order:
 
-DESTINATION_ORDER
-=================
+Destination Order QoS
+=====================
 
 ..
     Sect<3.2.18>
 
-The ``DESTINATION_ORDER`` QoS policy controls the order in which samples within a given instance are made available to a data reader.
-If a history depth of one (the default) is specified, the instance will reflect the most recent value written by all data writers to that instance.
-Here is the IDL for the Destination Order Qos:
+The destination order QoS policy controls the order in which :term:`sample`\s within a given :term:`instance` are made available to a data reader.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`immutable <qos-changing>` and affects :ref:`association <qos-destination-order-association>`.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     enum DestinationOrderQosPolicyKind {
       BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS,
@@ -1349,6 +1230,25 @@ Here is the IDL for the Destination Order Qos:
       DestinationOrderQosPolicyKind kind;
     };
 
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic`, :term:`DataWriter`, and :term:`DataReader`
+
+       - ``kind``
+
+       - ``BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS``
+
+  Specification: :omgspec:`dds:2.2.3.17 DESTINATION_ORDER`
+
+If a :ref:`qos-history` ``depth`` of one (the default) is specified, the instance will reflect the most recent value written by all data writers to that instance.
+
 The ``BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS`` value (the default) indicates that samples within an instance are ordered in the order in which they were received by the data reader.
 Note that samples are not necessarily received in the order sent by the same data writer.
 To enforce this type of ordering, the ``BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS`` value should be used.
@@ -1356,47 +1256,111 @@ To enforce this type of ordering, the ``BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS
 The ``BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS`` value indicates that samples within an instance are ordered based on a timestamp provided by the data writer.
 It should be noted that if multiple data writers write to the same instance, care should be taken to ensure that clocks are synchronized to prevent incorrect ordering on the data reader.
 
+.. _qos-destination-order-association:
+
+For a reader and writer to associate, the writer's ``kind`` must be greater or equal to the reader's.
+In other words, if the reader is ``BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS``, then it the writer can be either value.
+If the reader is ``BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS``, then the writer must also be ``BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS``.
+
+.. _qos-writer-data-lifecycle:
 .. _quality_of_service--writer-data-lifecycle:
 
-WRITER_DATA_LIFECYCLE
-=====================
+Writer Data Lifecycle QoS
+=========================
 
 ..
     Sect<3.2.19>
 
-The ``WRITER_DATA_LIFECYCLE`` QoS policy controls the lifecycle of data instances managed by a data writer.
-Here is the IDL for the Writer Data Lifecycle QoS policy:
+The writer data lifecycle QoS policy controls the lifecycle of :term:`instance`\s managed by a :term:`DataWriter`.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`mutable <qos-changing>` and does not affect association.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct WriterDataLifecycleQosPolicy {
       boolean autodispose_unregistered_instances;
     };
 
-When ``autodispose_unregistered_instances`` is set to ``true`` (the default), a data writer disposes an instance when it is unregistered.
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`DataWriter`
+
+       - ``autodispose_unregistered_instances``
+
+       - ``true``
+
+  Specification: :omgspec:`dds:2.2.3.21 WRITER_DATA_LIFECYCLE`
+
+When ``autodispose_unregistered_instances`` is set to ``true`` (the default), a data writer :term:`dispose`\s an instance when it is :term:`unregister`\ed.
 In some cases, it may be desirable to prevent an instance from being disposed when an instance is unregistered.
-This policy could, for example, allow an ``EXCLUSIVE`` data writer to gracefully defer to the next data writer without affecting the instance state.
+This policy could, for example, allow an :ref:`exclusive ownership <qos-ownership>` data writer to gracefully defer to the next data writer without affecting the instance state.
 Deleting a data writer implicitly unregisters all of its instances prior to deletion.
 
+.. _qos-reader-data-lifecycle:
 .. _quality_of_service--reader-data-lifecycle:
 
-READER_DATA_LIFECYCLE
-=====================
+Reader Data Lifecycle QoS
+=========================
 
 ..
     Sect<3.2.20>
 
-The ``READER_DATA_LIFECYCLE`` QoS policy controls the lifecycle of data instances managed by a data reader.
-Here is the IDL for the Reader Data Lifecycle QoS policy:
+The reader data lifecycle QoS policy controls the lifecycle of :term:`instance`\s managed by a :term:`DataReader`.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`mutable <qos-changing>` and does not affect association.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct ReaderDataLifecycleQosPolicy {
       Duration_t autopurge_nowriter_samples_delay;
       Duration_t autopurge_disposed_samples_delay;
     };
 
-Normally, a data reader maintains data for all instances until there are no more associated data writers for the instance, the instance has been disposed, or the data has been taken by the user.
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`DataReader`
+
+       - ``autopurge_nowriter_samples_delay.sec``
+
+         ``autopurge_nowriter_samples_delay.nanosec``
+
+         ``autopurge_disposed_samples_delay.sec``
+
+         ``autopurge_disposed_samples_delay.nanosec``
+
+       - ``DURATION_INFINITE_SEC``
+
+         ``DURATION_INFINITE_NSEC``
+
+         ``DURATION_INFINITE_SEC``
+
+         ``DURATION_INFINITE_NSEC``
+
+  Specification: :omgspec:`dds:2.2.3.22 READER_DATA_LIFECYCLE`
+
+Normally, a data reader maintains data for all instances until there are no more associated data writers for the instance, the instance has been :term:`dispose`\d, or the data has been :ref:`taken <getting_started--reading-multiple-samples>` by the user.
 
 In some cases, it may be desirable to constrain the reclamation of these resources.
 This policy could, for example, permit a late-joining data writer to prolong the lifetime of an instance in fail-over situations.
@@ -1407,42 +1371,74 @@ By default, ``autopurge_nowriter_samples_delay`` is infinite.
 The ``autopurge_disposed_samples_delay`` controls how long the data reader waits before reclaiming resources once an instance transitions to the ``NOT_ALIVE_DISPOSED`` state.
 By default, ``autopurge_disposed_samples_delay`` is infinite.
 
+.. _qos-time-based-filter:
 .. _quality_of_service--time-based-filter:
 
-TIME_BASED_FILTER
-=================
+Time Based Filter QoS
+=====================
 
 ..
     Sect<3.2.21>
 
-The ``TIME_BASED_FILTER`` QoS policy controls how often a data reader may be interested in changes in values to a data instance.
-Here is the IDL for the Time Based Filter QoS:
+The time based filter QoS policy controls how often a :term:`DataReader` may be interested in changes in values to an :term:`instance`.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`mutable <qos-changing>` and does not affect association.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct TimeBasedFilterQosPolicy {
       Duration_t minimum_separation;
     };
 
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`DataReader`
+
+       - ``minimum_separation.sec``
+
+         ``minimum_separation.nanosec``
+
+       - ``DURATION_ZERO_SEC``
+
+         ``DURATION_ZERO_NSEC``
+
+  Specification: :omgspec:`dds:2.2.3.12 TIME_BASED_FILTER`
+
 An interval (``minimum_separation``) may be specified on the data reader.
 This interval defines a minimum delay between instance value changes; this permits the data reader to throttle changes without affecting the state of the associated data writer.
-By default, minimum_separation is zero, which indicates that no data is filtered.
+By default, ``minimum_separation`` is zero, which indicates that no data is filtered.
 This QoS policy does not conserve bandwidth as instance value changes are still sent to the subscriber process.
 It only affects which samples are made available via the data reader.
 
+.. _qos-ownership:
 .. _quality_of_service--ownership:
 
-OWNERSHIP
-=========
+Ownership QoS
+=============
 
 ..
     Sect<3.2.22>
 
-The ``OWNERSHIP`` policy controls whether more than one Data Writer is able to write samples for the same data-object instance.
-Ownership can be ``EXCLUSIVE`` or ``SHARED``.
-Below is the IDL related to the Ownership QoS policy:
+The ownership QoS policy controls whether more than one :term:`DataWriter` is able to write :term:`sample`\s for the same :term:`instance`.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`immutable <qos-changing>` and affects :ref:`association <qos-ownership-association>`.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     enum OwnershipQosPolicyKind {
       SHARED_OWNERSHIP_QOS,
@@ -1453,30 +1449,232 @@ Below is the IDL related to the Ownership QoS policy:
       OwnershipQosPolicyKind kind;
     };
 
-If the kind member is set to ``SHARED_OWNERSHIP_QOS``, more than one Data Writer is allowed to update the same data-object instance.
-If the kind member is set to ``EXCLUSIVE_OWNERSHIP_QOS``, only one Data Writer is allowed to update a given data-object instance (i.e., the Data Writer is considered to be the *owner* of the instance) and associated Data Readers will only see samples written by that Data Writer.
-The owner of the instance is determined by value of the ``OWNERSHIP_STRENGTH`` policy; the data writer with the highest value of strength is considered the owner of the data-object instance.
-Other factors may also influence ownership, such as whether the data writer with the highest strength is "alive" (as defined by the ``LIVELINESS`` policy) and has not violated its offered publication deadline constraints (as defined by the ``DEADLINE`` policy).
+  .. list-table::
+     :header-rows: 1
 
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`Topic`, :term:`DataWriter`, and :term:`DataReader`
+
+       - ``kind``
+
+       - ``SHARED_OWNERSHIP_QOS``
+
+  Specification: :omgspec:`dds:2.2.3.9 OWNERSHIP`
+
+If the kind member is set to ``SHARED_OWNERSHIP_QOS``, more than one data writer is allowed to update the same instance.
+If the kind member is set to ``EXCLUSIVE_OWNERSHIP_QOS``, only one data writer is allowed to update a given instance (i.e., the data writer is considered to be the *owner* of the instance) and associated :term:`DataReader`\s will only see samples written by that data writer.
+The owner of the instance is determined by value of the :ref:`qos-ownership-strength` policy; the data writer with the highest value of strength is considered the owner of the instance.
+Other factors may also influence ownership, such as whether the data writer with the highest strength is "alive" (as defined by the :ref:`qos-liveliness` policy) and has not violated its offered publication deadline constraints (as defined by the :ref:`qos-deadline` policy).
+
+.. _qos-ownership-association:
+
+For a reader and writer to associate, the ``kind`` must be the same.
+
+.. _qos-ownership-strength:
 .. _quality_of_service--ownership-strength:
 
-OWNERSHIP_STRENGTH
-==================
+Ownership Strength QoS
+======================
 
 ..
     Sect<3.2.23>
 
-The ``OWNERSHIP_STRENGTH`` policy is used in conjunction with the ``OWNERSHIP`` policy, when the ``OWNERSHIP`` ``kind`` is set to ``EXCLUSIVE``.
-Below is the IDL related to the Ownership Strength QoS policy:
+The ownership strength QoS policy is used in conjunction with the :ref:`qos-ownership` ``EXCLUSIVE_OWNERSHIP_QOS`` policy on :term:`DataWriter`\s.
 
-.. code-block:: omg-idl
+.. important::
+
+  This policy is :ref:`mutable <qos-changing>` and does not affect association.
+
+  IDL:
+
+  .. code-block:: omg-idl
 
     struct OwnershipStrengthQosPolicy {
       long value;
     };
 
-The value member is used to determine which Data Writer is the *owner* of the data-object instance.
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`DataWriter`
+
+       - ``value``
+
+       - ``0``
+
+  Specification: :omgspec:`dds:2.2.3.10 OWNERSHIP_STRENGTH`
+
+The ``value`` member is used to determine which data writer is the *owner* of the :term:`instance`.
 The default value is zero.
+
+.. _qos-data-representation:
+
+Data Representation QoS
+=======================
+
+The data representation QoS policy defines how a :term:`DataWriter` encodes :term:`sample`\s and what encodings a :term:`DataReader` will accept.
+This XTypes concept is explained in detail in :ref:`xtypes--data-representation`.
+
+.. important::
+
+  This policy is :ref:`immutable <qos-changing>` and affects :ref:`association <qos-data-representation-association>`.
+
+  IDL:
+
+  .. code-block:: omg-idl
+
+    module DDS {
+      const DataRepresentationId_t XCDR_DATA_REPRESENTATION = 0;
+      const DataRepresentationId_t XML_DATA_REPRESENTATION = 1;
+      const DataRepresentationId_t XCDR2_DATA_REPRESENTATION = 2;
+
+      typedef sequence<DataRepresentationId_t> DataRepresentationIdSeq;
+
+      struct DataRepresentationQosPolicy {
+        DataRepresentationIdSeq value;
+      };
+    };
+
+    module OpenDDS {
+      module DCPS {
+        const DDS::DataRepresentationId_t UNALIGNED_CDR_DATA_REPRESENTATION = -12140;
+      };
+    };
+
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`DataWriter` using rtps_udp
+
+       - ``value``
+
+       - (empty sequence) -- interpreted as a sequence containing ``XCDR2_DATA_REPRESENTATION``
+
+     * - :term:`DataReader` using rtps_udp
+
+       - ``value``
+
+       - (empty sequence) -- interpreted as a sequence containing ``XCDR_DATA_REPRESENTATION`` and ``XCDR2_DATA_REPRESENTATION``
+
+     * - :term:`DataWriter` using other transports
+
+       - ``value``
+
+       - (empty sequence) -- interpreted as a sequence containing ``UNALIGNED_CDR_DATA_REPRESENTATION``
+
+     * - :term:`DataReader` using other transports
+
+       - ``value``
+
+       - (empty sequence) -- interpreted as a sequence containing ``XCDR_DATA_REPRESENTATION``, ``XCDR2_DATA_REPRESENTATION``, and ``UNALIGNED_CDR_DATA_REPRESENTATION``
+
+  Specification: :omgspec:`xtypes:7.6.3.1 Data Representation QoS Policy`
+
+.. warning::
+
+  The default interpretation of ``value`` is OpenDDS-specific as of XTypes 1.3.
+  The XTypes specification v1.3 specifies that it should be interpreted as a sequence containing ``XCDR_DATA_REPRESENTATION``.
+  This is because OpenDDS defaults to XCDR2 instead of XCDR1 when using rtps_udp, the use of unaligned CDR, and the desire to have readers be as compatible as possible by default.
+  See :ref:`xtypes--data-representation` for details.
+
+.. _qos-data-representation-association:
+
+For a reader and writer to associate, the first value in the writer's effective ``value`` must be contained in the reader's effective ``value``.
+Other items values in a writer's ``value`` are ignored.
+
+.. _qos-type-consistency-enforcement:
+
+Type Consistency Enforcement QoS
+================================
+
+The type consistency enforcement QoS policy lets the application fine-tune details of how :term:`topic type`\s may differ between :term:`DataWriter`\s and :term:`DataReader`\s.
+This XTypes concept is explained in detail in :ref:`xtypes--type-consistency-enforcement`.
+
+.. important::
+
+  This is only used when using RTPS discovery.
+
+  This policy is :ref:`immutable <qos-changing>` and affects :ref:`association <xtypes--type-consistency-enforcement>`.
+
+  IDL:
+
+  .. code-block:: omg-idl
+
+    enum TypeConsistencyKind {
+      DISALLOW_TYPE_COERCION,
+      ALLOW_TYPE_COERCION
+    };
+
+    struct TypeConsistencyEnforcementQosPolicy {
+      TypeConsistencyEnforcementQosPolicyKind_t kind;
+      boolean ignore_sequence_bounds;
+      boolean ignore_string_bounds;
+      boolean ignore_member_names;
+      boolean prevent_type_widening;
+      boolean force_type_validation;
+    };
+
+  .. list-table::
+     :header-rows: 1
+
+     * - :term:`Applicable entities <Entity>`
+
+       - Members
+
+       - :ref:`Default values <qos-defaults>`
+
+     * - :term:`DataReader`
+
+       - ``kind``
+
+         ``ignore_sequence_bounds``
+
+         ``ignore_string_bounds``
+
+         ``ignore_member_names``
+
+         ``prevent_type_widening``
+
+         ``force_type_validation``
+
+       - ``ALLOW_TYPE_COERCION``
+
+         ``true``
+
+         ``true``
+
+         ``false``
+
+         ``false``
+
+         ``false``
+
+  Specification: :omgspec:`xtypes:7.6.3.4 Type Consistency Enforcement QoS Policy`
+
+.. attention::
+
+  OpenDDS only supports setting one of them: ``ignore_member_names``.
+  All other members should be kept at their default values.
+
+``ignore_member_names`` defaults to ``false`` so member names (along with member IDs, see :ref:`xtypes--member-id-assignment`) are significant for type compatibility.
+Changing this to ``true`` means that only member IDs are used for type compatibility.
 
 .. _quality_of_service--policy-example:
 
@@ -1510,15 +1708,15 @@ The following sample code illustrates some policies being set and applied for a 
 
 This code creates a publisher with the following qualities:
 
-* ``HISTORY`` set to Keep All
+* :ref:`qos-history` set to "keep all"
 
-* ``RELIABILITY`` set to Reliable with a maximum blocking time of 10 seconds
+* :ref:`qos-reliability` set to "reliable" with a maximum blocking time of 10 seconds
 
-* The maximum samples per instance resource limit set to 100
+* The maximum :term:`sample`\s per :term:`instance` :ref:`qos-resource-limits` set to 100
 
 This means that when 100 samples are waiting to be delivered, the writer can block up to 10 seconds before returning an error code.
-These same QoS settings on the Data Reader side would mean that up to 100 unread samples are queued by the framework before any are rejected.
-Rejected samples are dropped and the SampleRejectedStatus is updated.
+These same QoS settings on the data reader side would mean that up to 100 unread samples are queued by the framework before any are rejected.
+Rejected samples are dropped and the :ref:`SampleRejectedStatus <conditions_and_listeners--sample-rejected-status>` is updated.
 
 .. rubric:: Footnotes
 
@@ -1526,3 +1724,8 @@ Rejected samples are dropped and the SampleRejectedStatus is updated.
 
    For OpenDDS versions, up to 2.0, the default reliability kind for data writers is best effort.
    For versions 2.0.1 and later, this is changed to reliable (to conform to the DDS specification).
+
+.. [#user_data_ex]
+
+  This is an example that was given by the DDS specification.
+  If you actually need to authenticate remote participants in a secure way, it's highly recommended to use :ref:`sec`.

--- a/docs/devguide/quality_of_service.rst
+++ b/docs/devguide/quality_of_service.rst
@@ -1434,7 +1434,8 @@ The property QoS policy contains sequences of key-value pairs for the :term:`Dom
 
 .. important::
 
-  This policy is :ref:`immutable <qos-changing>` and affects association indirectly through security.
+  This policy is :ref:`mutable <qos-changing>`, but updates to properties after creating the participant might not an effect.
+  This policy affects association indirectly through security.
 
   IDL:
 

--- a/docs/devguide/quickstart/windows.rst
+++ b/docs/devguide/quickstart/windows.rst
@@ -1,6 +1,6 @@
-###################
-Windows Quick Start
-###################
+#######
+Windows
+#######
 
 The goal of this guide is help you download and compile OpenDDS and run a simple example.
 

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -232,14 +232,14 @@ The following table summarizes the ``[common]`` configuration options:
 
    * - ``DCPSChunks=n``
 
-     - Configurable number of chunks that a data writer's and reader's cached allocators will preallocate when the ``RESOURCE_LIMITS`` QoS value is infinite.
+     - Configurable number of chunks that a data writer's and reader's cached allocators will preallocate when the :ref:`qos-resource-limits` QoS value is infinite.
        When all of the preallocated chunks are in use, OpenDDS allocates from the heap.
 
      - ``20``
 
    * - ``DCPSChunkAssociationMultiplier=n``
 
-     - Multiplier for the DCPSChunks or ``resource_limits.max_samples`` value to determine the total number of shallow copy chunks that are preallocated.
+     - Multiplier for ``DCPSChunks`` or the :ref:`qos-resource-limits` ``max_samples`` value to determine the total number of shallow copy chunks that are preallocated.
        Set this to a value greater than the number of connections so the preallocated chunk handles do not run out.
        A sample written to multiple data readers will not be copied multiple times but there is a shallow copy handle to that sample used to manage the delivery to each data reader.
        The size of the handle is small so there is not great need to set this value close to the number of connections.
@@ -489,7 +489,7 @@ They are named differently since they are inherited from TAO.
 The options starting with "ORB" listed in this table are implemented directly by OpenDDS (not passed to TAO) and are supported either on the command line (using a "-" prefix) or in the configuration file.
 Other command-line options that begin with ``-ORB`` are passed to TAO's ``ORB_init`` if DCPSInfoRepo discovery is used.
 
-The ``DCPSChunks`` option allows application developers to tune the amount of memory preallocated when the ``RESOURCE_LIMITS`` are set to infinite.
+The ``DCPSChunks`` option allows application developers to tune the amount of memory preallocated when the :ref:`qos-resource-limits` are set to infinite.
 Once the allocated memory is exhausted, additional chunks are allocated/deallocated from the heap.
 This feature of allocating from the heap when the preallocated memory is exhausted provides flexibility but performance will decrease when the preallocated memory is exhausted.
 
@@ -1227,7 +1227,7 @@ Those properties, along with options specific to OpenDDS's RTPS Discovery implem
 
    * - ``SecureParticipantUserData=[0|1]``
 
-     - If DDS Security is enabled, the Participant's USER_DATA QoS is omitted from unsecured discovery messages.
+     - If DDS Security is enabled, the Participant's :ref:`qos-user-data` is omitted from unsecured discovery messages.
 
      - ``0``
 
@@ -1456,7 +1456,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--durability`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``deadline.period.sec=[``
 
@@ -1464,7 +1464,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--deadline`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``deadline.period.nanosec=[``
 
@@ -1472,7 +1472,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--deadline`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``latency_budget.duration.sec=[``
 
@@ -1480,7 +1480,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--latency-budget`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``latency_budget.duration.nanosec=[``
 
@@ -1488,7 +1488,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--latency-budget`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``liveliness.kind=[``
 
@@ -1500,7 +1500,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--liveliness`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``liveliness.lease_duration.sec=[``
 
@@ -1508,7 +1508,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--liveliness`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``liveliness.lease_duration.nanosec=[``
 
@@ -1516,13 +1516,13 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--liveliness`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``reliability.kind=[BEST_EFFORT|RELIABILE]``
 
      - See :ref:`quality_of_service--reliability`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``reliability.max_blocking_time.sec=[``
 
@@ -1530,7 +1530,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--reliability`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``reliability.max_blocking_time.nanosec=[``
 
@@ -1538,7 +1538,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--reliability`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``destination_order.kind=[``
 
@@ -1548,31 +1548,31 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--destination-order`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``history.kind=[KEEP_LAST|KEEP_ALL]``
 
      - See :ref:`quality_of_service--history`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``history.depth=numeric``
 
      - See :ref:`quality_of_service--history`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``resource_limits.max_samples=numeric``
 
      - See :ref:`quality_of_service--resource-limits`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``resource_limits.max_instances=numeric``
 
      - See :ref:`quality_of_service--resource-limits`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``resource_limits.max_samples_per_instance=``
 
@@ -1580,13 +1580,13 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--resource-limits`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``transport_priority.value=numeric``
 
      - See :ref:`quality_of_service--transport-priority`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``lifespan.duration.sec=[``
 
@@ -1594,7 +1594,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--lifespan`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``lifespan.duration.nanosec=[``
 
@@ -1602,19 +1602,19 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--lifespan`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``ownership.kind=[SHARED|EXCLUSIVE]``
 
      - See :ref:`quality_of_service--ownership`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``ownership_strength.value=numeric``
 
      - See :ref:`quality_of_service--ownership-strength`.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
 .. _run_time_configuration--reftable15:
 
@@ -1633,7 +1633,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--durability`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``deadline.period.sec=[``
 
@@ -1641,7 +1641,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--deadline`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``deadline.period.nanosec=[``
 
@@ -1649,7 +1649,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--deadline`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``latency_budget.duration.sec=[``
 
@@ -1657,7 +1657,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--latency-budget`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``latency_budget.duration.nanosec=[``
 
@@ -1665,7 +1665,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--latency-budget`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``liveliness.kind=[``
 
@@ -1677,7 +1677,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--liveliness`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``liveliness.lease_duration.sec=[``
 
@@ -1685,7 +1685,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--liveliness`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``liveliness.lease_duration.nanosec=[``
 
@@ -1693,13 +1693,13 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--liveliness`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``reliability.kind=[BEST_EFFORT|RELIABILE]``
 
      - See :ref:`quality_of_service--reliability`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``reliability.max_blocking_time.sec=[``
 
@@ -1707,7 +1707,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--reliability`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``reliability.max_blocking_time.nanosec=[``
 
@@ -1715,7 +1715,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--reliability`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``destination_order.kind=[``
 
@@ -1725,31 +1725,31 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--destination-order`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``history.kind=[KEEP_LAST|KEEP_ALL]``
 
      - See :ref:`quality_of_service--history`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``history.depth=numeric``
 
      - See :ref:`quality_of_service--history`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``resource_limits.max_samples=numeric``
 
      - See :ref:`quality_of_service--resource-limits`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``resource_limits.max_instances=numeric``
 
      - See :ref:`quality_of_service--resource-limits`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``resource_limits.max_samples_per_instance=``
 
@@ -1757,7 +1757,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--resource-limits`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``time_based_filter.minimum_separation.sec=[``
 
@@ -1765,7 +1765,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--time-based-filter`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``time_based_filter.minimum_separation.nanosec=[``
 
@@ -1773,7 +1773,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--time-based-filter`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``reader_data_lifecycle.``
        ``autopurge_nowriter_samples_delay.sec=[``
@@ -1782,7 +1782,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--reader-data-lifecycle`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``reader_data_lifecycle.``
        ``autopurge_nowriter_samples_delay.nanosec=[``
@@ -1791,7 +1791,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--reader-data-lifecycle`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``reader_data_lifecycle.``
        ``autopurge_dispose_samples_delay.sec=[``
@@ -1800,7 +1800,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--reader-data-lifecycle`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``reader_data_lifecycle.``
        ``autopurge_dispose_samples_delay.nanosec=[``
@@ -1809,7 +1809,7 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--reader-data-lifecycle`.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
 .. _run_time_configuration--reftable16:
 
@@ -1826,25 +1826,25 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--presentation`.
 
-     - See :ref:`Publisher QoS <quality_of_service--publisher>`.
+     -
 
    * - ``presentation.coherent_access=[true|false]``
 
      - See :ref:`quality_of_service--presentation`.
 
-     - See :ref:`Publisher QoS <quality_of_service--publisher>`.
+     -
 
    * - ``presentation.ordered_access=[true|false]``
 
      - See :ref:`quality_of_service--presentation`.
 
-     - See :ref:`Publisher QoS <quality_of_service--publisher>`.
+     -
 
    * - ``partition.name=name0,name1,...``
 
      - See :ref:`quality_of_service--partition`.
 
-     - See :ref:`Publisher QoS <quality_of_service--publisher>`.
+     -
 
 .. _run_time_configuration--reftable17:
 
@@ -1861,25 +1861,25 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - See :ref:`quality_of_service--presentation`.
 
-     - See :ref:`Subscriber QoS <quality_of_service--reftable5>`.
+     -
 
    * - ``presentation.coherent_access=[true|false]``
 
      - See :ref:`quality_of_service--presentation`.
 
-     - See :ref:`Subscriber QoS <quality_of_service--reftable5>`.
+     -
 
    * - ``presentation.ordered_access=[true|false]``
 
      - See :ref:`quality_of_service--presentation`.
 
-     - See :ref:`Subscriber QoS <quality_of_service--reftable5>`.
+     -
 
    * - ``partition.name=name0,name1,...``
 
      - See :ref:`quality_of_service--partition`.
 
-     - See :ref:`Subscriber QoS <quality_of_service--reftable5>`.
+     -
 
 .. _run_time_configuration--reftable18:
 
@@ -1931,25 +1931,25 @@ The static discovery implementation also checks that the QoS of a data reader or
 
      - Refers to a ``[datawriterqos/*]`` section.
 
-     - See :ref:`DataWriter QoS <quality_of_service--reftable6>`.
+     -
 
    * - ``datareaderqos=name``
 
      - Refers to a ``[datareaderqos/*]`` section.
 
-     - See :ref:`DataReader QoS <quality_of_service--reftable7>`.
+     -
 
    * - ``publisherqos=name``
 
      - Refers to a ``[publisherqos/*]`` section.
 
-     - See :ref:`Publisher QoS <quality_of_service--publisher>`.
+     -
 
    * - ``subscriberqos=name``
 
      - Refers to a ``[subscriberqos/*]`` section.
 
-     - See :ref:`Subscriber QoS <quality_of_service--reftable5>`.
+     -
 
    * - ``config``
 
@@ -1981,7 +1981,7 @@ The basic goals of this design were to:
 
 * Support optimized transport development (such as collocated and shared memory transports - note that these are not currently implemented).
 
-* Integrate support for the ``RELIABILITY`` QoS policy with the underlying transport.
+* Integrate support for the :ref:`qos-reliability` policy with the underlying transport.
 
 * Whenever possible, avoid dependence on the ACE Service Configurator and its configuration files.
 

--- a/docs/devguide/the_dcps_information_repository.rst
+++ b/docs/devguide/the_dcps_information_repository.rst
@@ -161,9 +161,9 @@ An example of this would include two platforms which have independently establis
 The current federation capabilities in OpenDDS provide only the ability to statically specify a federation of repositories at startup of applications and repositories.
 A mechanism to dynamically discover and join a federation is planned for a future OpenDDS release.
 
-OpenDDS automatically detects the loss of a repository by using the ``LIVELINESS`` Quality of Service policy on a Built-in Topic.
-When a federation is used, the ``LIVELINESS`` QoS policy is modified to a non-infinite value.
-When ``LIVELINESS`` is lost for a Built-in Topic an application will initiate a failover sequence causing it to associate with a different repository server.
+OpenDDS automatically detects the loss of a repository by using the :ref:`qos-liveliness` policy on a Built-in Topic.
+When a federation is used, the liveliness QoS policy is modified to a non-infinite value.
+When liveliness is lost for a Built-in Topic an application will initiate a failover sequence causing it to associate with a different repository server.
 Because the federation implementation currently uses a Built-in Topic ``ParticipantDataDataReaderListener`` entity, applications should not install their own listeners for this topic.
 Doing so would affect the federation implementation's capability to detect repository failures.
 

--- a/docs/devguide/xtypes.rst
+++ b/docs/devguide/xtypes.rst
@@ -392,7 +392,7 @@ Data representation is the way a data sample can be encoded for transmission.
 The possible data representations are:
 
 XML
-    This isn't currently supported and will be ignored.
+    This isn't currently supported.
 
     The ``DataRepresentationId_t`` value is ``DDS::XML_DATA_REPRESENTATION``
 
@@ -453,8 +453,8 @@ Type Consistency Enforcement
     Sect<16.5>
 
 When a reader/writer match is happening, type consistency enforcement checks that the two types are compatible according to the type objects if they are available.
-This can be affected on the reader side using :ref:`qos-type-consistency-enforcement`.
 This check will not happen if OpenDDS has been :ref:`configured not to generate or use type objects <xtypes--representing-types-with-typeobject-and-dynamictype>` or if the remote DDS doesn't support type objects.
+Some parts of the compatibility check can be controlled on the reader side using :ref:`qos-type-consistency-enforcement`.
 The full type object compatibility check is too detailed to reproduce here.
 It can be found in :omgspec:`xtypes:7.2.4`.
 In general though two topic types and their nested types are compatible if:

--- a/docs/devguide/xtypes.rst
+++ b/docs/devguide/xtypes.rst
@@ -424,7 +424,7 @@ Unaligned CDR
 
 Use :ref:`qos-data-representation` to define what representations writers and readers should use.
 Writers can only encode samples using only one data representation, but readers can accept multiple data representations.
-:ref:`@OpenDDS::data_representation <xtypes--specifying-allowed-data-representations>` can be used to restrict what what data representation can be used for a topic type in IDL.
+:ref:`@OpenDDS::data_representation <xtypes--specifying-allowed-data-representations>` can be used to restrict what data representation can be used for a topic type in IDL.
 
 .. warning::
 

--- a/docs/devguide/xtypes.rst
+++ b/docs/devguide/xtypes.rst
@@ -388,8 +388,8 @@ Data Representation
     Sect<16.4>
 
 Data representation is the way a data sample can be encoded for transmission.
-Writers can only encode samples using one data representation, but readers can accept multiple data representations.
-Data representation can be XML, XCDR1, XCDR2, or unaligned CDR.
+
+The possible data representations are:
 
 XML
     This isn't currently supported and will be ignored.
@@ -422,17 +422,18 @@ Unaligned CDR
 
     The annotation is :ref:`xtypes--opendds-data-representation-unaligned-cdr`.
 
-Data representation is a QoS policy alongside the other QoS options.
-Its listed values represent allowed serialized forms of the data sample.
-The DataWriter and DataReader need to have at least one matching data representation for communication between them to be possible.
+Use :ref:`qos-data-representation` to define what representations writers and readers should use.
+Writers can only encode samples using only one data representation, but readers can accept multiple data representations.
+:ref:`@OpenDDS::data_representation <xtypes--specifying-allowed-data-representations>` can be used to restrict what what data representation can be used for a topic type in IDL.
 
-The default value of the ``DataRepresentationQosPolicy`` is an empty sequence.
-For RTPS-UDP this is interpreted as XCDR2 for DataWriters and accepting XCDR1 and XCDR2 for DataReaders.
-For other transports it's interpreted as Unaligned CDR for DataWriters and accepting XCDR1, XCDR2, and Unaligned CDR for DataReaders.
-A writer or reader without an explicitly-set ``DataRepresentationQosPolicy`` will therefore be able to communicate with another reader or writer which is compatible with XCDR2.
-The example below shows a possible configuration for an XCDR1 DataWriter.
+.. warning::
 
-.. code-block:: cpp
+  Because writers default to XCDR2 instead of XCDR1, they aren't likely to be compatible with readers from OpenDDS versions before 3.16 and other DDS implementations by default.
+  Either the remote readers will have to set to use XCDR2 if they support it or OpenDDS writers will have to be set to use XCDR1.
+
+  The example below shows a possible configuration for an XCDR1 DataWriter.
+
+  .. code-block:: cpp
 
     DDS::DataWriterQos qos;
     pub->get_default_datawriter_qos(qos);
@@ -440,15 +441,7 @@ The example below shows a possible configuration for an XCDR1 DataWriter.
     qos.representation.value[0] = DDS::XCDR_DATA_REPRESENTATION;
     DDS::DataWriter_var dw = pub->create_datawriter(topic, qos, 0, 0);
 
-Note that the IDL constant used for XCDR1 is ``XCDR_DATA_REPRESENTATION`` (without the digit).
-
-In addition to a DataWriter/DataReader QoS setting for data representation, each type defined in IDL can have its own data representation specified via an annotation.
-This value restricts which data representations can be used for that type.
-A DataWriter/DataReader must have at least one data representation in common with the type it uses.
-
-The default value for an unspecified data representation annotation is to allow all forms of serialization.
-
-The type's set of allowed data representations can be specified by the user in IDL with the notation: ``@OpenDDS::data_representation(XCDR2)`` where XCDR2 is replaced with the specific data representation.
+  Note that the IDL constant used for XCDR1 is ``XCDR_DATA_REPRESENTATION`` (without the digit).
 
 .. _xtypes--type-consistency-enforcement:
 
@@ -459,27 +452,8 @@ Type Consistency Enforcement
 ..
     Sect<16.5>
 
-.. _xtypes--typeconsistencyenforcementqospolicy:
-
-TypeConsistencyEnforcementQosPolicy
-===================================
-
-The Type Consistency Enforcement QoS policy lets the application fine-tune details of how types may differ between writers and readers.
-The policy only applies to data readers.
-This means that each reader can set its own policy for how its type may vary from the types of the writers that it may match.
-
-There are six members of the ``TypeConsistencyEnforcementQosPolicy`` struct defined by XTypes, but OpenDDS only supports setting one of them: ``ignore_member_names``.
-All other members should be kept at their default values.
-
-``ignore_member_names`` defaults to ``FALSE`` so member names (along with member IDs, see :ref:`xtypes--member-id-assignment`) are significant for type compatibility.
-Changing this to ``TRUE`` means that only member IDs are used for type compatibility.
-
-.. _xtypes--type-compatibility:
-
-Type Compatibility
-==================
-
 When a reader/writer match is happening, type consistency enforcement checks that the two types are compatible according to the type objects if they are available.
+This can be affected on the reader side using :ref:`qos-type-consistency-enforcement`.
 This check will not happen if OpenDDS has been :ref:`configured not to generate or use type objects <xtypes--representing-types-with-typeobject-and-dynamictype>` or if the remote DDS doesn't support type objects.
 The full type object compatibility check is too detailed to reproduce here.
 It can be found in :omgspec:`xtypes:7.2.4`.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -29,7 +29,7 @@ Common Terms
   BITs
     Built-in Topics are :term:`topics <Topic>` that contain meta-information about local and remote :term:`DDS entites <Entity>` and the operational status of OpenDDS.
 
-    See :doc:`devguide/built_in_topics` for more information.
+    See :ref:`bit` for more information.
 
   Common Data Representation
   CDR
@@ -77,6 +77,11 @@ Common Terms
 
     See :ref:`introduction--dds-discovery` for more information.
 
+  Dispose
+    When an :term:`instance` is disposed by a :term:`DataWriter`, it means keeping the cached data related to it is no longer necessary.
+    This is done automatically if the instance is :term:`unregister`\ed and ``autodispose_unregistered_instances`` of :ref:`qos-writer-data-lifecycle` is set to ``true``.
+    This can also be done manually using ``dispose`` method on ``DataWriter``.
+
   Domain
     Domains are sets of :term:`DomainParticipant` that can interact with one another.
     To interact they must share the same domain identifier and must have compatible :term:`discovery` and :term:`transport`.
@@ -87,6 +92,12 @@ Common Terms
   ``Entity``
     ``Entity`` is the abstract base class for the main classes in the :term:`DDS`/:term:`DCPS` API, including :term:`DataReader` and :term:`DataWriter`.
     All entities have :term:`QoS` and can accept :term:`Listener`\s and :term:`Condition`\s.
+
+  Instance
+    In the specific context of :term:`DDS` and :term:`sample`\s, instances refer to a set of samples that share a common key value.
+    Many parts of the DDS API involve instances, including the :term:`dispose` and :term:`unregister` operations.
+
+    See :ref:`getting_started--keys` for more information.
 
   Interface Definition Language
   IDL
@@ -155,6 +166,11 @@ Common Terms
 
   Transport
     Transports are the configurable methods that :term:`DataWriter`\s and :term:`DataReader`\s use to communicate.
+
+  Unregister
+    When an :term:`instance` is unregistered by a :term:`DataWriter`, it means the writer "no longer has ‘anything to say’ about the instance", as phrased by the DDS specification.
+    This is similar, but separate from :term:`disposing <dispose>` an instance.
+    They are usually done at the same time, but this can be changed using :ref:`qos-writer-data-lifecycle` and the ``unregister_instance`` method of ``DataWriter`` to make what unregister means application-defined.
 
   XTypes
   Extensible and Dynamic Topic Types for DDS

--- a/docs/news.d/devguide-qos.rst
+++ b/docs/news.d/devguide-qos.rst
@@ -1,0 +1,13 @@
+.. news-prs: 4520
+
+.. news-start-section: Documentation
+- :ref:`qos`
+
+  - Added :ref:`qos-property`, :ref:`qos-data-representation`, and :ref:`qos-type-consistency-enforcement`.
+  - Every policy now has a box that says if it's mutable, if it affects writer-reader association, and a link to the spec definition.
+    Also removed large default value tables and put the default values in these boxes.
+  - Added links to the QoS policies.
+
+- Moved :ref:`fnmatch-exprs` into an "annex" file so it can be common between security and partitions QoS.
+- Added definitions for :term:`instance`, :term:`unregister`, and :term:`dispose` to the glossary.
+.. news-end-section


### PR DESCRIPTION
- Quality of Service
  - Rearranged to remove large default value tables.
  - Added Data Representation and Type Consistency Enforcement.
  - Every policy now has a box that says if it's mutable, if it affects writer-reader association, its default values, and links to the spec definition.
  - Added many links to QoS policies
- Move fnmatch expressions into an "annex" file so it can be common between security and partitions QoS.
- Add definitions for "instance", "unregister", and "dispose" to the glossary.