### PR TITLE
Shapes IDL doesn't match interoperability IDL

### DIFF
--- a/examples/DCPS/ishapes/ShapeType.idl
+++ b/examples/DCPS/ishapes/ShapeType.idl
@@ -4,11 +4,12 @@ module org {
       module demo {
 
         @topic
+        @appendable
         struct ShapeType {
-          @key string color;
-          long x;
-          long y;
-          long shapesize;
+          @key string<128> color;
+          int32 x;
+          int32 y;
+          int32 shapesize;
         };
 
       };


### PR DESCRIPTION
Problem
-------

The Shapes IDL doesn't match the interoperability IDL which is causing a lot of test failures.

Solution
--------

Update the IDL to match.