### PR TITLE
Extend test with a reproducer for `Unknown union label value` error

### DIFF
--- a/tests/DCPS/Compiler/union_defaults/union_defaults.idl
+++ b/tests/DCPS/Compiler/union_defaults/union_defaults.idl
@@ -55,3 +55,22 @@ module Unions {
   };
 };
 
+module DDS_Native
+{
+  module Uni
+  {
+
+    enum DataType {
+      dtLong,
+      dtShort
+    };
+
+    @appendable
+    union Data switch (Uni::DataType) {
+      case Uni::dtLong:
+        long longData;
+      case Uni::dtShort:
+        short shortData;
+    };
+  };
+};


### PR DESCRIPTION
    * tests/DCPS/Compiler/union_defaults/union_defaults.idl:

New error I found in the AXCIOMA unit tests after the merge of https://github.com/OpenDDS/OpenDDS/pull/4519