### PR TITLE
Corrected typeobject generation for unions that use qualified enumerators in branch labels

### DIFF
--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -1183,7 +1183,7 @@ typeobject_generator::generate_union_type_identifier(AST_Type* type)
       AST_UnionLabel* label = branch->label(j);
       if (label->label_kind() != AST_UnionLabel::UL_default) {
         if (discEnum && enumValues != enum_values_.end()) {
-          const std::string labelName = canonical_name(label->label_val()->n());
+          const std::string labelName = canonical_name(label->label_val()->n()->last_component());
           const EnumValues::const_iterator iter = enumValues->second.find(labelName);
           if (iter == enumValues->second.end()) {
             be_util::misc_error_and_abort("Unknown union label value", branch);

--- a/tests/DCPS/Compiler/union_defaults/union_defaults.idl
+++ b/tests/DCPS/Compiler/union_defaults/union_defaults.idl
@@ -55,3 +55,22 @@ module Unions {
   };
 };
 
+module DDS_Native
+{
+  module Uni
+  {
+
+    enum DataType {
+      dtLong,
+      dtShort
+    };
+
+    @appendable
+    union Data switch (Uni::DataType) {
+      case Uni::dtLong:
+        long longData;
+      case Uni::dtShort:
+        short shortData;
+    };
+  };
+};

--- a/tests/DCPS/Compiler/union_defaults/union_defaults.idl
+++ b/tests/DCPS/Compiler/union_defaults/union_defaults.idl
@@ -55,10 +55,8 @@ module Unions {
   };
 };
 
-module DDS_Native
-{
-  module Uni
-  {
+module DDS_Native {
+  module Uni {
 
     enum DataType {
       dtLong,


### PR DESCRIPTION
Fixes an issue introduced in #4519 and includes new test case from #4537