### PR TITLE
ConfigStore entries created by SEDP linger

### DIFF
--- a/dds/DCPS/ConfigStoreImpl.cpp
+++ b/dds/DCPS/ConfigStoreImpl.cpp
@@ -1020,6 +1020,22 @@ ConfigStoreImpl::get_section_values(const String& prefix) const
   return retval;
 }
 
+void
+ConfigStoreImpl::unset_section(const String& prefix) const
+{
+  const String cprefix = ConfigPair::canonicalize(prefix);
+
+  ConfigReader::SampleSequence samples;
+  DCPS::InternalSampleInfoSequence infos;
+  config_reader_->read(samples, infos, DDS::LENGTH_UNLIMITED,
+                       DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE);
+  for (ConfigReader::SampleSequence::const_iterator pos = samples.begin(), limit = samples.end(); pos != limit; ++pos) {
+    if (pos->key_has_prefix(cprefix)) {
+      config_writer_->unregister_instance(*pos);
+    }
+  }
+}
+
 DDS::DataWriterQos ConfigStoreImpl::datawriter_qos()
 {
   return DataWriterQosBuilder().durability_transient_local();

--- a/dds/DCPS/ConfigStoreImpl.h
+++ b/dds/DCPS/ConfigStoreImpl.h
@@ -238,6 +238,9 @@ public:
   typedef OPENDDS_MAP(String, String) StringMap;
   StringMap get_section_values(const String& prefix) const;
 
+  /// Remove the section key and all section values.
+  void unset_section(const String& prefix) const;
+
   static DDS::DataWriterQos datawriter_qos();
   static DDS::DataReaderQos datareader_qos();
 

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -2085,11 +2085,14 @@ Sedp::shutdown()
 
   job_queue_.reset();
   reactor_task_.reset();
+  const String config_prefix = transport_inst_->config_prefix();
+
   DCPS::RtpsUdpInst_rch rtps_inst =
     DCPS::static_rchandle_cast<DCPS::RtpsUdpInst>(transport_inst_);
   rtps_inst->opendds_discovery_default_listener_.reset();
   TheTransportRegistry->remove_config(transport_cfg_);
   TheTransportRegistry->remove_inst(transport_inst_);
+  config_store_->unset_section(config_prefix);
 }
 
 void Sedp::process_discovered_writer_data(DCPS::MessageId message_id,

--- a/tests/unit-tests/dds/DCPS/ConfigStoreImpl.cpp
+++ b/tests/unit-tests/dds/DCPS/ConfigStoreImpl.cpp
@@ -594,3 +594,23 @@ TEST(dds_DCPS_ConfigStoreImpl, get_section_values)
   const ConfigStoreImpl::StringMap sm = config_store.get_section_values("MYPREFIX_MY_SECTION");
   EXPECT_EQ(sm, expected_sm);
 }
+
+TEST(dds_DCPS_ConfigStoreImpl, delete_section)
+{
+  ConfigTopic_rch topic = make_rch<ConfigTopic>();
+  ConfigStoreImpl config_store(topic);
+  config_store.set("MYPREFIX_MY_SECTION", "@my_section");
+  config_store.set("MYPREFIX_MY_SECTION_KEY", "not a section");
+  config_store.set("MYPREFIX_MY_SECTION2", "@my_section2");
+  config_store.set("MYPREFIX_MY_SECTION2_KEY", "not a section");
+  config_store.set("NOTMYPREFIX_MY_SECTION2", "@my_section2");
+  config_store.set("NOTMYPREFIX_MY_SECTION2_KEY", "not a section");
+
+  config_store.unset_section("MYPREFIX");
+  EXPECT_FALSE(config_store.has("MYPREFIX_MY_SECTION"));
+  EXPECT_FALSE(config_store.has("MYPREFIX_MY_SECTION_KEY"));
+  EXPECT_FALSE(config_store.has("MYPREFIX_MY_SECTION2"));
+  EXPECT_FALSE(config_store.has("MYPREFIX_MY_SECTION2_KEY"));
+  EXPECT_TRUE(config_store.has("NOTMYPREFIX_MY_SECTION2"));
+  EXPECT_TRUE(config_store.has("NOTMYPREFIX_MY_SECTION2_KEY"));
+}


### PR DESCRIPTION
Problem
-------

SEDP creates ConfigStore entries for the transport instance that it creates.  These entries are not removed when the SEDP intance goes away.  Thus, an application that recreates participants that use RTPS Discovery will leak these entries.

Solution
--------

Remove the entries created by SEDP.