### PR TITLE
`vread` for unions uses uninitialized memory

### DIFF
--- a/dds/idl/value_reader_generator.cpp
+++ b/dds/idl/value_reader_generator.cpp
@@ -339,18 +339,16 @@ bool value_reader_generator::gen_union(AST_Union* u,
     be_global->impl_ <<
       "  if (!value_reader.begin_union(" << extensibility_kind(ek) << ")) return false;\n"
       "  if (!value_reader.begin_discriminator()) return false;\n"
-      "  {\n"
-      "    " << scoped(discriminator->name()) << " d;\n";
+      " " << scoped(discriminator->name()) << " d;\n";
     generate_read("d", "", discriminator, "i", 2);
     be_global->impl_ <<
-      "    value._d(d);\n"
-      "  }\n"
       "  if (!value_reader.end_discriminator()) return false;\n";
 
-    generateSwitchForUnion(u, "value._d()", branch_helper, branches,
+    generateSwitchForUnion(u, "d", branch_helper, branches,
                            discriminator, "", "", type_name.c_str(),
                            false, false);
     be_global->impl_ <<
+      "  value._d(d);\n"
       "  if (!value_reader.end_union()) return false;\n"
       "  return true;\n";
   }


### PR DESCRIPTION
Problem
-------

The `vread` function generated for unions sets the discriminant explicitly and then sets the member.  Setting the discriminant first sets the discriminant but doesn't initialize the member.  Setting the member examines the previous discriminant to de-initialize the previous member.  Thus, the sequence used by `vread` causes uninitialized memory to be "deinitialized."

Solution
--------

Defer setting discriminant until after the member has been set.