### PR TITLE
TransportImpl: remove unused member function decls

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -3231,15 +3231,8 @@ DataReaderImpl::add_link(const DataLink_rch& link, const GUID_t& peer)
     }
   }
   TransportClient::add_link(link, peer);
-  OPENDDS_STRING type;
-  {
-    TransportImpl_rch impl = link->impl();
-    if (impl) {
-      type = impl->transport_type();
-    }
-  }
 
-  if (type == "rtps_udp" || type == "multicast") {
+  if (!link->uses_end_historic_control_messages()) {
     resume_sample_processing(peer);
   }
 }

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -282,13 +282,14 @@ public:
 
   void set_scheduling_release(bool scheduling_release);
 
-  virtual void send_final_acks (const GUID_t& readerid);
+  virtual void send_final_acks(const GUID_t& readerid);
 
   virtual WeakRcHandle<ICE::Endpoint> get_ice_endpoint() const { return WeakRcHandle<ICE::Endpoint>(); }
 
   virtual bool is_leading(const GUID_t& /*writer*/,
                           const GUID_t& /*reader*/) const { return false; }
 
+  virtual bool uses_end_historic_control_messages() const { return true; }
 
 protected:
 

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -265,20 +265,6 @@ private:
   virtual void local_crypto_handle(DDS::Security::ParticipantCryptoHandle) {}
 #endif
 
-public:
-  /// Called by our friends, the TransportClient, and the DataLink.
-  /// Since this TransportImpl can be attached to many TransportClient
-  /// objects, and each TransportClient object could be "running" in
-  /// a separate thread, we need to protect all of the "reservation"
-  /// methods with a lock.  The protocol is that a client of ours
-  /// must "acquire" our reservation_lock_ before it can proceed to
-  /// call any methods that affect the DataLink reservations.  It
-  /// should release the reservation_lock_ as soon as it is done.
-  int acquire();
-  int tryacquire();
-  int release();
-  int remove();
-
   virtual OPENDDS_STRING transport_type() const = 0;
 
   /// Called by our friend, the TransportClient.

--- a/dds/DCPS/transport/multicast/MulticastDataLink.h
+++ b/dds/DCPS/transport/multicast/MulticastDataLink.h
@@ -108,6 +108,8 @@ private:
   void release_remote_i(const GUID_t& remote);
   RepoIdSet readers_selected_, readers_withheld_;
   bool ready_to_deliver(const ReceivedDataSample& data);
+
+  bool uses_end_historic_control_messages() const { return false; }
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -935,6 +935,8 @@ private:
 
   RcHandle<InternalDataReader<NetworkInterfaceAddress> > network_interface_address_reader_;
   MulticastManager multicast_manager_;
+
+  bool uses_end_historic_control_messages() const { return false; }
 };
 
 } // namespace DCPS

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -108,7 +108,7 @@ RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
 #if defined(OPENDDS_SECURITY)
   {
     if (core_.use_ice()) {
-      ReactorInterceptor_rch ri = reactor_task_->interceptor();
+      ReactorInterceptor_rch ri = reactor_task()->interceptor();
       ri->execute_or_enqueue(make_rch<RemoveHandler>(unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #ifdef ACE_HAS_IPV6
       ri->execute_or_enqueue(make_rch<RemoveHandler>(ipv6_unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
@@ -613,7 +613,7 @@ RtpsUdpTransport::configure_i(const RtpsUdpInst_rch& config)
 
   create_reactor_task(false, "RtpsUdpTransport" + config->name());
 
-  ACE_Reactor* reactor = reactor_task_->get_reactor();
+  ACE_Reactor* reactor = reactor_task()->get_reactor();
   job_queue_ = DCPS::make_rch<DCPS::JobQueue>(reactor);
 
 #ifdef OPENDDS_SECURITY
@@ -950,7 +950,7 @@ RtpsUdpTransport::start_ice()
   GuardThreadType guard_links(links_lock_);
 
   if (!link_) {
-    ReactorInterceptor_rch ri = reactor_task_->interceptor();
+    ReactorInterceptor_rch ri = reactor_task()->interceptor();
     ri->execute_or_enqueue(make_rch<RegisterHandler>(unicast_socket_.get_handle(), ice_endpoint_.get(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #ifdef ACE_HAS_IPV6
     ri->execute_or_enqueue(make_rch<RegisterHandler>(ipv6_unicast_socket_.get_handle(), ice_endpoint_.get(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
@@ -968,7 +968,7 @@ RtpsUdpTransport::stop_ice()
   GuardThreadType guard_links(links_lock_);
 
   if (!link_) {
-    ReactorInterceptor_rch ri = reactor_task_->interceptor();
+    ReactorInterceptor_rch ri = reactor_task()->interceptor();
     ri->execute_or_enqueue(make_rch<RemoveHandler>(unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
 #ifdef ACE_HAS_IPV6
     ri->execute_or_enqueue(make_rch<RemoveHandler>(ipv6_unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));


### PR DESCRIPTION
This made a block of code public that probably wasn't supposed to be.

DataReaderImpl should not have conditional logic based on transport_type()