### PR TITLE
Cleanup ACE_TEMPLATES_REQUIRE_PRAGMA and ACE_TEMPLATES_REQUIRE_SOURCE…

### DIFF
--- a/dds/DCPS/DataCollector_T.h
+++ b/dds/DCPS/DataCollector_T.h
@@ -113,12 +113,6 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 #include "DataCollector_T.inl"
 #endif /* __ACE_INLINE__ */
 
-#if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #include "DataCollector_T.cpp"
-#endif /* ACE_TEMPLATES_REQUIRE_SOURCE */
-
-#if defined (ACE_TEMPLATES_REQUIRE_PRAGMA)
-#pragma implementation ("DataCollector_T.cpp")
-#endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
 
 #endif /* DATA_COLLECTOR_H */

--- a/dds/DCPS/MultiTopicDataReader_T.h
+++ b/dds/DCPS/MultiTopicDataReader_T.h
@@ -193,9 +193,7 @@ private:
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#ifdef ACE_TEMPLATES_REQUIRE_SOURCE
 #include "MultiTopicDataReader_T.cpp"
-#endif
 
 #endif
 #endif

--- a/dds/DCPS/RakeResults_T.h
+++ b/dds/DCPS/RakeResults_T.h
@@ -120,8 +120,6 @@ private:
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #include "RakeResults_T.cpp"
-#endif /* ACE_TEMPLATES_REQUIRE_SOURCE */
 
 #endif /* RAKERESULTS_H  */

--- a/dds/DCPS/TimePoint_T.h
+++ b/dds/DCPS/TimePoint_T.h
@@ -158,12 +158,6 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 #  include "TimePoint_T.inl"
 #endif /* __ACE_INLINE__ */
 
-#if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #  include "TimePoint_T.cpp"
-#endif /* ACE_TEMPLATES_REQUIRE_SOURCE */
-
-#if defined (ACE_TEMPLATES_REQUIRE_PRAGMA)
-#  pragma implementation ("TimePoint_T.cpp")
-#endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
 
 #endif

--- a/dds/DCPS/TimePoint_T.h
+++ b/dds/DCPS/TimePoint_T.h
@@ -158,6 +158,6 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 #  include "TimePoint_T.inl"
 #endif /* __ACE_INLINE__ */
 
-#  include "TimePoint_T.cpp"
+#include "TimePoint_T.cpp"
 
 #endif

--- a/dds/DCPS/ZeroCopyAllocator_T.h
+++ b/dds/DCPS/ZeroCopyAllocator_T.h
@@ -72,12 +72,6 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 #include "ZeroCopyAllocator_T.inl"
 #endif /* __ACE_INLINE__ */
 
-#if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #include "ZeroCopyAllocator_T.cpp"
-#endif /* ACE_TEMPLATES_REQUIRE_SOURCE */
-
-#if defined (ACE_TEMPLATES_REQUIRE_PRAGMA)
-#pragma implementation ("ZeroCopyAllocator_T.cpp")
-#endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
 
 #endif /* ZEROCOPYALLOCATOR_H  */

--- a/dds/DCPS/ZeroCopySeq_T.h
+++ b/dds/DCPS/ZeroCopySeq_T.h
@@ -222,13 +222,6 @@ TAO_END_VERSIONED_NAMESPACE_DECL
 #include "ZeroCopySeq_T.inl"
 #endif /* __ACE_INLINE__ */
 
-#if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #include "ZeroCopySeq_T.cpp"
-#endif /* ACE_TEMPLATES_REQUIRE_SOURCE */
-
-#if defined (ACE_TEMPLATES_REQUIRE_PRAGMA)
-#pragma message ("ZeroCopySeq_T.cpp template inst")
-#pragma implementation ("ZeroCopySeq_T.cpp")
-#endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
 
 #endif /* ZEROCOPYSEQ_H  */

--- a/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
+++ b/dds/DCPS/transport/framework/TransportReceiveStrategy_T.h
@@ -186,8 +186,6 @@ OPENDDS_END_VERSIONED_NAMESPACE_DECL
 #include "TransportReceiveStrategy_T.inl"
 #endif /* __ACE_INLINE__ */
 
-#ifdef ACE_TEMPLATES_REQUIRE_SOURCE
 #include "TransportReceiveStrategy_T.cpp"
-#endif
 
 #endif /* OPENDDS_DCPS_TRANSPORTRECEIVESTRATEGY */

--- a/dds/InfoRepo/UpdateListener_T.h
+++ b/dds/InfoRepo/UpdateListener_T.h
@@ -78,13 +78,6 @@ private:
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #include "UpdateListener_T.cpp"
-#endif /* ACE_TEMPLATES_REQUIRE_SOURCE */
-
-#if defined (ACE_TEMPLATES_REQUIRE_PRAGMA)
-#pragma message ("UpdateListener_T.cpp template inst")
-#pragma implementation ("UpdateListener_T.cpp")
-#endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
 
 #endif /* UPDATELISTENER_T_H  */

--- a/dds/InfoRepo/UpdateManager.h
+++ b/dds/InfoRepo/UpdateManager.h
@@ -93,14 +93,7 @@ private:
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #include "UpdateManager_T.cpp"
-#endif /* ACE_TEMPLATES_REQUIRE_SOURCE */
-
-#if defined (ACE_TEMPLATES_REQUIRE_PRAGMA)
-#pragma message ("UpdateManager_T.cpp template inst")
-#pragma implementation ("UpdateManager_T.cpp")
-#endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 

--- a/dds/InfoRepo/UpdateProcessor_T.h
+++ b/dds/InfoRepo/UpdateProcessor_T.h
@@ -84,13 +84,6 @@ public:
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #include "UpdateProcessor_T.cpp"
-#endif /* ACE_TEMPLATES_REQUIRE_SOURCE */
-
-#if defined (ACE_TEMPLATES_REQUIRE_PRAGMA)
-#pragma message ("UpdateProcessor_T.cpp template inst")
-#pragma implementation ("UpdateProcessor_T.cpp")
-#endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
 
 #endif  /* UPDATEPROCESSOR_T_H */

--- a/dds/InfoRepo/UpdateReceiver_T.h
+++ b/dds/InfoRepo/UpdateReceiver_T.h
@@ -84,13 +84,6 @@ private:
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #include "UpdateReceiver_T.cpp"
-#endif /* ACE_TEMPLATES_REQUIRE_SOURCE */
-
-#if defined (ACE_TEMPLATES_REQUIRE_PRAGMA)
-#pragma message ("UpdateReceiver_T.cpp template inst")
-#pragma implementation ("UpdateReceiver_T.cpp")
-#endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
 
 #endif  /* UPDATE_RECEIVER_T_H */

--- a/tests/DCPS/TestFramework/TestFramework_T.h
+++ b/tests/DCPS/TestFramework/TestFramework_T.h
@@ -153,13 +153,6 @@ protected:
   virtual void fini_i();
 };
 
-#if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #include "TestFramework_T.cpp"
-#endif
-
-#if defined (ACE_TEMPLATES_REQUIRE_PRAGMA)
-#pragma message("TestFramework_T.cpp template inst")
-#pragma implementation("TestFramework_T.cpp")
-#endif
 
 #endif  /* DCPS_TESTFRAMEWORK_T_H */

--- a/tools/modeling/codegen/model/Service_T.h
+++ b/tools/modeling/codegen/model/Service_T.h
@@ -130,13 +130,7 @@ namespace OpenDDS { namespace Model {
 
 OPENDDS_END_VERSIONED_NAMESPACE_DECL
 
-#if defined (ACE_TEMPLATES_REQUIRE_SOURCE)
 #include "Service_T.cpp"
-#endif /* ACE_TEMPLATES_REQUIRE_SOURCE */
-
-#if defined (ACE_TEMPLATES_REQUIRE_PRAGMA)
-#pragma implementation ("Service_T.cpp")
-#endif /* ACE_TEMPLATES_REQUIRE_PRAGMA */
 
 #include /**/ "ace/post.h"
 


### PR DESCRIPTION
…, fixed #4560

    * dds/DCPS/DataCollector_T.h:
    * dds/DCPS/MultiTopicDataReader_T.h:
    * dds/DCPS/RakeResults_T.h:
    * dds/DCPS/TimePoint_T.h:
    * dds/DCPS/ZeroCopyAllocator_T.h:
    * dds/DCPS/ZeroCopySeq_T.h:
    * dds/DCPS/transport/framework/TransportReceiveStrategy_T.h:
    * dds/InfoRepo/UpdateListener_T.h:
    * dds/InfoRepo/UpdateManager.h:
    * dds/InfoRepo/UpdateProcessor_T.h:
    * dds/InfoRepo/UpdateReceiver_T.h:
    * tests/DCPS/TestFramework/TestFramework_T.h:
    * tools/modeling/codegen/model/Service_T.h: