### PR TITLE
Rename Configuration Keys to Properties

### DIFF
--- a/docs/devguide/built_in_topics.rst
+++ b/docs/devguide/built_in_topics.rst
@@ -39,7 +39,7 @@ Four separate topics are defined for each domain.
 Each is dedicated to a particular entity (domain participant :ref:`built_in_topics--dcpsparticipant-topic`, topic :ref:`built_in_topics--dcpsparticipant-topic`, data writer :ref:`built_in_topics--dcpspublication-topic`, data reader :ref:`built_in_topics--dcpssubscription-topic`) and publishes instances describing the state for each entity in the domain.
 
 Subscriptions to built-in topics are automatically created for each domain participant.
-A participant's support for built-in topics can be toggled via the :cfg:key:`DCPSBit` configuration option.
+A participant's support for built-in topics can be toggled via the :cfg:prop:`DCPSBit` configuration option.
 To view the built-in topic data, simply obtain the built-in Subscriber and then use it to access the Data Reader for the built-in topic of interest.
 The Data Reader can then be used like any other Data Reader.
 
@@ -285,7 +285,7 @@ OpenDDSInternalThread Topic
 ..
     Sect<6.8.3>
 
-The built-in topic ``OpenDDSInternalThread`` is published when OpenDDS is configured with :cfg:key:`DCPSThreadStatusInterval`.
+The built-in topic ``OpenDDSInternalThread`` is published when OpenDDS is configured with :cfg:prop:`DCPSThreadStatusInterval`.
 When enabled, the DataReader for this built-in topic will report the status of threads created and managed by OpenDDS within the current process.
 The timestamp associated with samples can be used to determine the health (responsiveness) of the thread.
 

--- a/docs/devguide/content_subscription_profile.rst
+++ b/docs/devguide/content_subscription_profile.rst
@@ -68,7 +68,7 @@ Once the content-filtered topic has been created, it is used by the subscriber's
 This data reader is functionally equivalent to a normal data reader except that incoming data samples which do not meet the filter expression's criteria are dropped.
 
 Filter expressions are first evaluated at the publisher so that data samples which would be ignored by the subscriber can be dropped before even getting to the transport.
-This feature can be turned off by setting :cfg:key:`DCPSPublisherContentFilter` to ``0``.
+This feature can be turned off by setting :cfg:prop:`DCPSPublisherContentFilter` to ``0``.
 The behavior of non-default :ref:`qos-deadline` or :ref:`qos-liveliness` policies may be affected by this policy.
 Special consideration must be given to how the "missing" samples impact the QoS behavior, see the document in :ghfile:`docs/design/CONTENT_SUBSCRIPTION`.
 

--- a/docs/devguide/dds_security.rst
+++ b/docs/devguide/dds_security.rst
@@ -150,7 +150,7 @@ The following configuration steps are required to enable OpenDDS Security featur
 
    * Via API: ``TheServiceParticipant->set_security(true);`` or
 
-   * Via config file: setting :cfg:key:`DCPSSecurity` to ``1``.
+   * Via config file: setting :cfg:prop:`DCPSSecurity` to ``1``.
 
 .. _dds_security--dds-security-configuration-via-propertyqospolicy:
 

--- a/docs/devguide/introduction.rst
+++ b/docs/devguide/introduction.rst
@@ -360,7 +360,7 @@ It also makes it easier to replace these libraries with custom ones.
 
 - :ref:`security <sec>` [#plugins-sec]_
 
-How to enable and use a particular plugin will differ based on the kind of plugin and the plugin itself, but generally they are enabled by some form of configuration setting, for example using ``[transport]transport_type`` or :cfg:key:`DCPSSecurity` in a configuration file.
+How to enable and use a particular plugin will differ based on the kind of plugin and the plugin itself, but generally they are enabled by some form of configuration setting, for example using ``[transport]transport_type`` or :cfg:prop:`DCPSSecurity` in a configuration file.
 The plugin will also have to be linked and initialized at runtime.
 For dynamic libraries (``.dll``, ``.dynlib`` or, ``.so`` files) this is done automatically as the OpenDDS will load the dynamic library and then run any initialization the plugin requires.
 When the plugins are statically linked, then it requires explicit linking and including an initialization header in the application that contains a global object that will initialize the plugin.

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -358,7 +358,7 @@ For example:
 
 .. sec:: common
 
-  .. key:: DCPSBidirGIOP=<boolean>
+  .. prop:: DCPSBidirGIOP=<boolean>
     :default: ``1`` (enabled)
 
     .. note:: This key is only applicable when using :ref:`inforepo-disc`.
@@ -366,26 +366,26 @@ For example:
     Use TAO's BiDirectional GIOP feature for interaction with the :ref:`inforepo`.
     With BiDir enabled, fewer sockets are needed since the same socket can be used for both client and server roles.
 
-  .. key:: DCPSBit=<boolean>
+  .. prop:: DCPSBit=<boolean>
     :default: ``1`` (enabled)
 
     Controls if :ref:`bit` are enabled.
 
-  .. key:: DCPSBitLookupDurationMsec=<msec>
+  .. prop:: DCPSBitLookupDurationMsec=<msec>
     :default: ``2000`` (2 seconds)
 
     The maximum duration in milliseconds that the framework will wait for latent :ref:`bit` information when retrieving BIT data given an instance handle.
     The participant code may get an instance handle for a remote entity before the framework receives and processes the related BIT information.
     The framework waits for up to the given amount of time before it fails the operation.
 
-  .. key:: DCPSBitTransportIPAddress=<addr>
+  .. prop:: DCPSBitTransportIPAddress=<addr>
     :default: ``INADDR_ANY``
 
     .. note:: This key is only applicable when using :ref:`inforepo-disc`.
 
     IP address identifying the local interface to be used by :ref:`tcp-transport` for the :ref:`bit`.
 
-  .. key:: DCPSBitTransportPort=<port>
+  .. prop:: DCPSBitTransportPort=<port>
     :default: ``0``
 
     .. note:: This key is only applicable when using :ref:`inforepo-disc`.
@@ -393,28 +393,28 @@ For example:
     Port used by the :ref:`tcp-transport` for :ref:`bit`.
     If the default of ``0`` is used, the operating system will choose a port to use.
 
-  .. key:: DCPSChunkAssociationMultiplier=<n>
+  .. prop:: DCPSChunkAssociationMultiplier=<n>
     :default: ``10``
 
-    Multiplier for the :key:`DCPSChunks` or the ``max_samples`` value in :ref:`qos-resource-limits` to determine the total number of shallow copy chunks that are preallocated.
+    Multiplier for the :prop:`DCPSChunks` or the ``max_samples`` value in :ref:`qos-resource-limits` to determine the total number of shallow copy chunks that are preallocated.
     Set this to a value greater than the number of connections so the preallocated chunk handles do not run out.
     A sample written to multiple data readers will not be copied multiple times but there is a shallow copy handle to that sample used to manage the delivery to each data reader.
     The size of the handle is small so there is not great need to set this value close to the number of connections.
 
-  .. key:: DCPSChunks=<n>
+  .. prop:: DCPSChunks=<n>
     :default: ``20``
 
     Configurable number of chunks that a data writer's and reader's cached allocators will preallocate when the :ref:`qos-resource-limits` value is infinite.
     When all of the preallocated chunks are in use, OpenDDS allocates from the heap.
     This feature of allocating from the heap when the preallocated memory is exhausted provides flexibility but performance will decrease when the preallocated memory is exhausted.
 
-  .. key:: DCPSDebugLevel=<n>
+  .. prop:: DCPSDebugLevel=<n>
     :default: ``0`` (disabled)
 
     Integer value that controls the amount of :ref:`debug information the DCPS layer logs <run_time_configuration--dcps-layer-debug-logging>`.
     Valid values are ``0`` through ``10``.
 
-  .. key:: DCPSDefaultAddress=<addr>
+  .. prop:: DCPSDefaultAddress=<addr>
     :default: ``0.0.0.0``
 
     Default value for the host portion of ``local_address`` in transport instances and some other host address values:
@@ -423,13 +423,13 @@ For example:
     - ``[transport]local_address`` (udp)
     - ``[transport]local_address`` (multicast)
     - ``[transport]local_address`` (rtps_udp)
-    - ``[transport]ipv6_local_address`` (rstp_udp)
+    - ``[transport]ipv6_local_address`` (rtps_udp)
     - ``[transport]multicast_interface`` (rtps_udp)
     - ``[rtps_discovery]SedpLocalAddress``
     - ``[rtps_discovery]SpdpLocalAddress``
     - ``[rtps_discovery]MulticastInterface``
 
-  .. key:: DCPSDefaultDiscovery=DEFAULT_REPO|DEFAULT_RTPS|DEFAULT_STATIC|<name>
+  .. prop:: DCPSDefaultDiscovery=DEFAULT_REPO|DEFAULT_RTPS|DEFAULT_STATIC|<name>
     :default: :val:`DEFAULT_REPO`
 
     Specifies a discovery configuration to use for any domain not explicitly configured.
@@ -453,7 +453,7 @@ For example:
 
     See :ref:`config-disc` for details about configuring discovery.
 
-  .. key:: DCPSGlobalTransportConfig=<name>|$file
+  .. prop:: DCPSGlobalTransportConfig=<name>|$file
     :default: The default configuration is used as described in :ref:`run_time_configuration--overview`.
 
     The :ref:`transport configuration <config-transport>` that should be used as the global default one.
@@ -466,20 +466,20 @@ For example:
 
       ``$file`` uses a transport configuration that includes all transport instances defined in the configuration file.
 
-  .. key:: DCPSInfoRepo=<objref>
+  .. prop:: DCPSInfoRepo=<objref>
     :default: ``file://repo.ior``
 
     Object reference for locating the :ref:`inforepo` in :ref:`inforepo-disc`.
     This value is passed to ``CORBA::ORB::string_to_object()`` and can be any Object URL type understandable by :term:`TAO` (file, IOR, corbaloc, corbaname).
     A simplified endpoint description of the form ``<host>:<port>`` is also accepted, which is equivalent to ``corbaloc::<host>:<port>/DCPSInfoRepo``.
 
-  .. key:: DCPSLivelinessFactor=<n>
+  .. prop:: DCPSLivelinessFactor=<n>
     :default: ``80``
 
     Percent of the :ref:`qos-liveliness` lease duration after which a liveliness message is sent.
     A value of ``80`` implies a 20% cushion of latency from the last detected heartbeat message.
 
-  .. key:: DCPSLogLevel=none|error|warning|notice|info|debug
+  .. prop:: DCPSLogLevel=none|error|warning|notice|info|debug
     :default: :val:`warning`
 
     General logging control.
@@ -510,30 +510,30 @@ For example:
 
     See :ref:`run_time_configuration--logging` for details.
 
-  .. key:: DCPSMonitor=<boolean>
+  .. prop:: DCPSMonitor=<boolean>
     :default: ``0``
 
     Use the Monitor library to publish data on monitoring topics (see :ghfile:`dds/monitor/README`).
 
-  .. key:: DCPSPendingTimeout=<sec>
+  .. prop:: DCPSPendingTimeout=<sec>
     :default: ``0``
 
     The maximum duration in seconds a data writer will block to allow unsent samples to drain on deletion.
     The default, ``0``, blocks indefinitely.
 
-  .. key:: DCPSPersistentDataDir=<path>
+  .. prop:: DCPSPersistentDataDir=<path>
     :default: ``OpenDDS-durable-data-dir``
 
     The path to a directory on where durable data will be stored for :ref:`PERSISTENT_DURABILITY_QOS <PERSISTENT_DURABILITY_QOS>`.
     If the directory does not exist it will be created automatically.
 
-  .. key:: DCPSPublisherContentFilter=<boolean>
+  .. prop:: DCPSPublisherContentFilter=<boolean>
     :default: ``1``
 
     Controls the filter expression evaluation policy for :ref:`content filtered topics <content_subscription_profile--content-filtered-topic>`.
     When the value is ``1`` the publisher may drop any samples, before handing them off to the transport when these samples would have been ignored by all subscribers.
 
-  .. key:: DCPSSecurity=<boolean>
+  .. prop:: DCPSSecurity=<boolean>
     :default: ``0``
 
     This setting is only available when OpenDDS is compiled with :ref:`dds_security`.
@@ -542,37 +542,37 @@ For example:
 
     See :ref:`dds_security` for more information.
 
-  .. key:: DCPSSecurityDebug=<cat>[,<cat>]...
+  .. prop:: DCPSSecurityDebug=<cat>[,<cat>]...
     :default: ``0`` (No security logging)
 
     This setting is only available when OpenDDS is compiled with :ref:`dds_security` enabled.
     This controls the :ref:`security debug logging <run_time_configuration--security-debug-logging>` granularity by category.
 
-  .. key:: DCPSSecurityDebugLevel=<n>
+  .. prop:: DCPSSecurityDebugLevel=<n>
     :default: ``0`` (No security logging)
 
     This setting is only available when OpenDDS is compiled with :ref:`dds_security` enabled.
     This controls the :ref:`security debug logging <run_time_configuration--security-debug-logging>` granularity by debug level.
 
-  .. key:: DCPSSecurityFakeEncryption=<boolean>
+  .. prop:: DCPSSecurityFakeEncryption=<boolean>
     :default: ``0`` (Real encryption when that's setup)
 
     This setting is only available when OpenDDS is compiled with :ref:`dds_security` enabled.
     This option, when set to ``1``, disables all encryption by making encryption and decryption no-ops.
     OpenDDS still generates keys and performs other security bookkeeping, so this option is useful for debugging the security infrastructure by making it possible to manually inspect all messages.
 
-  .. key:: DCPSThreadStatusInterval=<sec>
+  .. prop:: DCPSThreadStatusInterval=<sec>
     :default: ``0`` (disabled)
 
     Enable :ref:`internal thread status reporting <built_in_topics--openddsinternalthread-topic>` using the specified reporting interval, in seconds.
 
-  .. key:: DCPSTransportDebugLevel=<n>
+  .. prop:: DCPSTransportDebugLevel=<n>
     :default: ``0`` (disabled)
 
     Integer value that controls the amount of :ref:`debug information the transport layer logs <run_time_configuration--transport-layer-debug-logging>`.
     Valid values are ``0`` through ``5``.
 
-  .. key:: DCPSTypeObjectEncoding=Normal|WriteOldFormat|ReadOldFormat
+  .. prop:: DCPSTypeObjectEncoding=Normal|WriteOldFormat|ReadOldFormat
     :default: :val:`Normal`
 
     From when :term:`XTypes` was first implemented in OpenDDS from 3.16.0 until 3.18.0, there was a bug in the encoding and decoding of ``TypeObject`` and related data types for :ref:`representing user types <xtypes--representing-types-with-typeobject-and-dynamictype>`.
@@ -593,12 +593,12 @@ For example:
       The default, correct encoding is used.
       Once all applications are using both OpenDDS 3.18 or later and ``ReadOldFormat``, then ``Normal`` can be used.
 
-  .. key:: ORBLogFile=<filename>
+  .. prop:: ORBLogFile=<path>
     :default: Output to standard error stream on most platforms
 
     Change :ref:`log <run_time_configuration--logging>` message destination to the file specified, which is opened in appending mode. [#orbprefix]_
 
-  .. key:: ORBVerboseLogging=0|1|2
+  .. prop:: ORBVerboseLogging=0|1|2
     :default: ``0``
 
     Add a prefix to each :ref:`log <run_time_configuration--logging>` message, using a format defined by the :term:`ACE` library: [#orbprefix]_
@@ -615,18 +615,18 @@ For example:
 
       Verbose, in addition to "lite" has host name, PID, program name
 
-  .. key:: pool_size=<n_bytes>
+  .. prop:: pool_size=<n_bytes>
     :default: ``41943040`` bytes (40 MiB)
 
     Size of :ref:`safety_profile` memory pool, in bytes.
 
-  .. key:: pool_granularity=<n_bytes>
+  .. prop:: pool_granularity=<n_bytes>
     :default: ``8``
 
     Granularity of :ref:`safety_profile` memory pool in bytes.
     Must be multiple of 8.
 
-  .. key:: Scheduler=SCHED_RR|SCHED_FIFO|SCHED_OTHER
+  .. prop:: Scheduler=SCHED_RR|SCHED_FIFO|SCHED_OTHER
     :default: :val:`SCHED_OTHER`
 
     Selects the scheduler to use for transport sending threads.
@@ -650,10 +650,10 @@ For example:
 
       :ref:`qos-transport-priority`
 
-  .. key:: scheduler_slice=<usec>
+  .. prop:: scheduler_slice=<usec>
     :default: ``0``
 
-    Some operating systems require a time slice value to be set when selecting a :key:`Scheduler` other than the default.
+    Some operating systems require a time slice value to be set when selecting a :prop:`Scheduler` other than the default.
     For those systems, this option can be used to set a value in microseconds.
 
 .. _config-disc:
@@ -754,9 +754,9 @@ For example, if an OpenDDS application assigns a domain ID of 3 to its participa
     [repository/DiscoveryConfig1]
     RepositoryIor=host1.mydomain.com:12345
 
-The ``DCPSDefaultDiscovery`` property tells the application to assign any participant that doesn't have a domain id found in the configuration file to use a discovery type of ``DEFAULT_REPO`` which means "use a ``DCPSInfoRepo`` service"  and that ``DCPSInfoRepo`` service can be found at ``host3.mydomain.com:12345``.
+The :prop:`DCPSDefaultDiscovery` and :prop:`DCPSInfoRepo` properties tell the application that every participant that doesn't have a domain id found in the configuration file to use the :ref:`inforepo` at ``host3.mydomain.com:12345``.
 
-As shown in :ref:`run_time_configuration--common-configuration-options` the ``DCPSDefaultDiscovery`` property has three other values that can be used.
+As shown in :ref:`config-common` the ``DCPSDefaultDiscovery`` property has three other values that can be used.
 The ``DEFAULT_RTPS`` constant value informs participants that don't have a domain configuration to use RTPS discovery to find other participants.
 Similarly, the ``DEFAULT_STATIC`` constant value informs the participants that don't have a domain configuration to use static discovery to find other participants.
 
@@ -3668,7 +3668,7 @@ DCPS Layer Debug Logging
 ..
     Sect<7.6.1>
 
-Debug logging in the DCPS layer of OpenDDS is controlled by the :key:`DCPSDebugLevel` configuration option and command-line option.
+Debug logging in the DCPS layer of OpenDDS is controlled by the :prop:`DCPSDebugLevel` configuration option and command-line option.
 It can also be set in application code using:
 
 .. code-block:: cpp
@@ -3699,7 +3699,7 @@ Transport Layer Debug Logging
 ..
     Sect<7.6.2>
 
-OpenDDS transport debug layer logging is controlled via the :key:`DCPSTransportDebugLevel` configuration option.
+OpenDDS transport debug layer logging is controlled via the :prop:`DCPSTransportDebugLevel` configuration option.
 For example, to add transport layer logging to any OpenDDS application that uses ``TheParticipantFactoryWithArgs``, add the following option to the command line:
 
 .. code-block:: bash
@@ -3764,8 +3764,8 @@ Security Debug Logging
 ..
     Sect<7.6.3>
 
-When OpenDDS is compiled with security enabled, debug logging for security can be enabled using :key:`DCPSSecurityDebug`.
-Security logging is divided into categories, although :key:`DCPSSecurityDebugLevel` is also provided, which controls the categories in a similar manner and using the same scale as :key:`DCPSDebugLevel`.
+When OpenDDS is compiled with security enabled, debug logging for security can be enabled using :prop:`DCPSSecurityDebug`.
+Security logging is divided into categories, although :prop:`DCPSSecurityDebugLevel` is also provided, which controls the categories in a similar manner and using the same scale as :prop:`DCPSDebugLevel`.
 
 .. _run_time_configuration--reftable28:
 
@@ -3889,6 +3889,6 @@ All the following are equivalent:
 
 .. rubric:: Footnotes
 
-.. [#orbprefix] :key:`ORBLogFile` and :key:`ORBVerboseLogging` start with "ORB" because they are inherited from :term:`TAO`.
+.. [#orbprefix] :prop:`ORBLogFile` and :prop:`ORBVerboseLogging` start with "ORB" because they are inherited from :term:`TAO`.
   They are implemented directly by OpenDDS (not passed to TAO) and are supported either on the command line (using a "-" prefix) or in the configuration file.
   Other command-line options that begin with ``-ORB`` are passed to TAO's ``ORB_init`` if :ref:`inforepo-disc` is used.

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -25,6 +25,8 @@ OpenDDS configuration is concerned with three main areas:
    Each pluggable transport can be configured separately.
    See :ref:`config-transport` for details.
 
+.. _config-store-keys:
+
 **********************
 Configuration Approach
 **********************

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -363,7 +363,7 @@ For example:
   .. prop:: DCPSBidirGIOP=<boolean>
     :default: ``1`` (enabled)
 
-    .. note:: This key is only applicable when using :ref:`inforepo-disc`.
+    .. note:: This property is only applicable when using :ref:`inforepo-disc`.
 
     Use TAO's BiDirectional GIOP feature for interaction with the :ref:`inforepo`.
     With BiDir enabled, fewer sockets are needed since the same socket can be used for both client and server roles.
@@ -383,14 +383,14 @@ For example:
   .. prop:: DCPSBitTransportIPAddress=<addr>
     :default: ``INADDR_ANY``
 
-    .. note:: This key is only applicable when using :ref:`inforepo-disc`.
+    .. note:: This property is only applicable when using :ref:`inforepo-disc`.
 
     IP address identifying the local interface to be used by :ref:`tcp-transport` for the :ref:`bit`.
 
   .. prop:: DCPSBitTransportPort=<port>
     :default: ``0``
 
-    .. note:: This key is only applicable when using :ref:`inforepo-disc`.
+    .. note:: This property is only applicable when using :ref:`inforepo-disc`.
 
     Port used by the :ref:`tcp-transport` for :ref:`bit`.
     If the default of ``0`` is used, the operating system will choose a port to use.

--- a/docs/devguide/safety_profile.rst
+++ b/docs/devguide/safety_profile.rst
@@ -96,7 +96,7 @@ Run-time Configurable Options
     Sect<13.4>
 
 The memory pool used by OpenDDS can be configured by setting values in the ``[common]`` section of the configuration file.
-See :cfg:key:`pool_size` and :cfg:key:`pool_granularity`.
+See :cfg:prop:`pool_size` and :cfg:prop:`pool_granularity`.
 
 .. _safety_profile--running-ace-and-opendds-tests:
 

--- a/docs/internal/bench.rst
+++ b/docs/internal/bench.rst
@@ -439,7 +439,7 @@ with configuration of OpenDDS.
 
 The elements of this section are functionally identical to the :ref:`config` sections of an OpenDDS ``.ini`` file with the same name.
 Each config section is created programmatically within the worker process using the name provided and made available to the OpenDDS ``ServiceParticipant`` during entity creation.
-The example here sets the value of both the :cfg:key:`DCPSSecurity` and :cfg:key:`DCPSDebugLevel` keys to ``0``.
+The example here sets the value of both the :cfg:prop:`DCPSSecurity` and :cfg:prop:`DCPSDebugLevel` keys to ``0``.
 
 ::
 

--- a/docs/internal/docs.rst
+++ b/docs/internal/docs.rst
@@ -473,8 +473,8 @@ For :doc:`/devguide/run_time_configuration` there's a custom configuration Sphin
 
 .. rst:directive:: .. cfg:sec:: <name>[@<discriminator>][/<argument>]
 
-  Use to document a configuration section that can contain :rst:dir:`cfg:key` and most other RST content.
-  ``<discriminator>`` is an optional extension of the name to document cases where the available keys depend on something.
+  Use to document a configuration section that can contain :rst:dir:`cfg:prop` and most other RST content.
+  ``<discriminator>`` is an optional extension of the name to document cases where the available properties depend on something.
   Using discriminators requires separate :rst:dir:`cfg:sec` entires.
   ``<arguments>`` is just for display and has no restrictions on the contents.
 
@@ -485,9 +485,9 @@ For :doc:`/devguide/run_time_configuration` there's a custom configuration Sphin
   Do not include arguments if it has arguments in the directive.
   The possible formats are ``<sect_name>`` and ``<sect_name>@<disc_name>``.
 
-.. rst:directive:: .. cfg:key:: <name>=<values>
+.. rst:directive:: .. cfg:prop:: <name>=<values>
 
-  Use to document a configuration key that can contain :rst:dir:`cfg:val` and most other RST content.
+  Use to document a configuration property that can contain :rst:dir:`cfg:val` and most other RST content.
   Must be in a :rst:dir:`cfg:sec`.
   ``<values>`` describe what sort of text is accepted.
   It is just for display and has no restrictions on the contents, but should follow the following conventions to describe the accepted values:
@@ -495,37 +495,37 @@ For :doc:`/devguide/run_time_configuration` there's a custom configuration Sphin
   - ``|`` indicates an OR
   - ``[]`` indicates an optional part of the value
   - ``...`` indicates the previous part can be repeated
-  - Words surrounded angle brackets (ex: ``<property_name>``) indicate placeholders.
+  - Words surrounded angle brackets (ex: ``<prop_name>``) indicate placeholders.
   - Everything else should be considered literal.
 
   For example: ``log_level=none|error|warn|debug``, ``memory_limit=<uint64>``, ``addresses=<ip>[:<port>],...``.
 
   .. rst:directive:option:: required
 
-    Indicates the key is required for the section
+    Indicates the property is required for the section
 
   .. rst:directive:option:: default
 
-    The default value of the key if omitted
+    The default value of the property if omitted
 
-.. rst:role:: cfg:key
+.. rst:role:: cfg:prop
 
-  Use to reference a :rst:dir:`cfg:key` by name.
+  Use to reference a :rst:dir:`cfg:prop` by name.
   Do not include values if it has values in the directive.
   The possible formats are:
 
-  - ``<key_name>``
+  - ``<prop_name>``
 
-    Inside of a :rst:dir:`cfg:sec`, it refers to a key in that section.
-    Outside of a :rst:dir:`cfg:sec`, the key is assumed to be ``common``.
+    Inside of a :rst:dir:`cfg:sec`, it refers to a property in that section.
+    Outside of a :rst:dir:`cfg:sec`, the property is assumed to be ``common``.
 
-  - ``[<sect_name>]<key_name>``
-  - ``[<sect_name>@<disc_name>]<key_name>``
+  - ``[<sect_name>]<prop_name>``
+  - ``[<sect_name>@<disc_name>]<prop_name>``
 
 .. rst:directive:: .. cfg:val:: [<]<name>[>]
 
-  Use to document a part of what a configuration key accepts.
-  Must be in a :rst:dir:`cfg:key`.
+  Use to document a part of what a configuration property accepts.
+  Must be in a :rst:dir:`cfg:prop`.
   The optional angle brackets (``<>``) are just for display and are meant to help distinguish between the value being a literal and a placeholder.
 
 .. rst:role:: cfg:val
@@ -536,15 +536,15 @@ For :doc:`/devguide/run_time_configuration` there's a custom configuration Sphin
 
   - ``<val_name>``
 
-    This must be inside a :rst:dir:`cfg:key`.
+    This must be inside a :rst:dir:`cfg:prop`.
 
-  - ``<key_name>=<val_name>``
+  - ``<prop_name>=<val_name>``
 
-    Inside of a :rst:dir:`cfg:sec`, it refers to a value of a key in that section.
-    Outside of a :rst:dir:`cfg:sec`, the key is assumed to be ``common``.
+    Inside of a :rst:dir:`cfg:sec`, it refers to a value of a property in that section.
+    Outside of a :rst:dir:`cfg:sec`, the property is assumed to be ``common``.
 
-  - ``[<sect_name>]<key_name>=<val_name>``
-  - ``[<sect_name>@<disc_name>]<key_name>=<val_name>``
+  - ``[<sect_name>]<prop_name>=<val_name>``
+  - ``[<sect_name>@<disc_name>]<prop_name>=<val_name>``
 
 Example
 ^^^^^^^
@@ -562,35 +562,35 @@ This is a example made up for the following INI file:
 
 .. code-block:: rst
 
-  Outside their sections, references to keys and values must be complete: :cfg:val:`[server]os=linux`, :cfg:key:`[server@linux]distro`
+  Outside their sections, references to properties and values must be complete: :cfg:val:`[server]os=linux`, :cfg:prop:`[server@linux]distro`
 
   Otherwise the ``common`` section will be assumed.
 
   .. cfg:sec:: server/<name>
 
-    A key or value's section can be omitted from references within their sections: :cfg:key:`os`, :cfg:val:`os=windows`
+    A property or value's section can be omitted from references within their sections: :cfg:prop:`os`, :cfg:val:`os=windows`
 
-    .. cfg:key:: os=windows|linux
+    .. cfg:prop:: os=windows|linux
       :required:
 
-      A value's key can be omitted from references within their keys: :cfg:val:`linux`
+      A value's property can be omitted from references within their properties: :cfg:val:`linux`
 
       .. cfg:val:: windows
 
-        Implied titles will be shortened within their scopes: :cfg:key:`[server]os`, :cfg:val:`[server]os=windows`
+        Implied titles will be shortened within their scopes: :cfg:prop:`[server]os`, :cfg:val:`[server]os=windows`
 
       .. cfg:val:: linux
 
-        Sections with discriminators require them in the reference targets: :cfg:sec:`server@linux`, :cfg:key:`[server@linux]distro`
+        Sections with discriminators require them in the reference targets: :cfg:sec:`server@linux`, :cfg:prop:`[server@linux]distro`
 
   .. cfg:sec:: server@linux/<name>
 
-    .. cfg:key:: distro=<name>
+    .. cfg:prop:: distro=<name>
       :default: ``Ubuntu``
 
 Turns into:
 
-  Outside their sections, references to keys and values must be complete: :cfg:val:`[server]os=linux`, :cfg:key:`[server@linux]distro`
+  Outside their sections, references to properties and values must be complete: :cfg:val:`[server]os=linux`, :cfg:prop:`[server@linux]distro`
 
   Otherwise the ``common`` section will be assumed.
 
@@ -598,32 +598,32 @@ Turns into:
     :no-contents-entry:
     :no-index-entry:
 
-    A key or value's section can be omitted from references within their sections: :cfg:key:`os`, :cfg:val:`os=windows`
+    A property or value's section can be omitted from references within their sections: :cfg:prop:`os`, :cfg:val:`os=windows`
 
-    .. cfg:key:: os=windows|linux
+    .. cfg:prop:: os=windows|linux
       :required:
       :no-contents-entry:
       :no-index-entry:
 
-      A value's key can be omitted from references within their keys: :cfg:val:`linux`
+      A value's property can be omitted from references within their properties: :cfg:val:`linux`
 
       .. cfg:val:: windows
         :no-contents-entry:
         :no-index-entry:
 
-        Implied titles will be shortened within their scopes: :cfg:key:`[server]os`, :cfg:val:`[server]os=windows`
+        Implied titles will be shortened within their scopes: :cfg:prop:`[server]os`, :cfg:val:`[server]os=windows`
 
       .. cfg:val:: linux
         :no-contents-entry:
         :no-index-entry:
 
-        Sections with discriminators require them in the reference targets: :cfg:sec:`server@linux`, :cfg:key:`[server@linux]distro`
+        Sections with discriminators require them in the reference targets: :cfg:sec:`server@linux`, :cfg:prop:`[server@linux]distro`
 
   .. cfg:sec:: server@linux/<name>
     :no-contents-entry:
     :no-index-entry:
 
-    .. cfg:key:: distro=<name>
+    .. cfg:prop:: distro=<name>
       :default: ``Ubuntu``
       :no-contents-entry:
       :no-index-entry:

--- a/docs/news.d/_releases/v3.27.0.rst
+++ b/docs/news.d/_releases/v3.27.0.rst
@@ -41,7 +41,7 @@ Fixes
 
 - Fixed a bug where compiling IDL with ``-Lc++11 -Gequality`` produced code outside of a namespace that didn't compile. (:ghpr:`4450`)
 
-- ``SedpLocalAddress`` now defaults to :cfg:key:`DCPSDefaultAddress` to behave like ``SpdpLocalAddress`` and ``local_address``. (:ghpr:`4451`)
+- ``SedpLocalAddress`` now defaults to :cfg:prop:`DCPSDefaultAddress` to behave like ``SpdpLocalAddress`` and ``local_address``. (:ghpr:`4451`)
 
 Notes
 =====

--- a/docs/sphinx_extensions/config_domain.py
+++ b/docs/sphinx_extensions/config_domain.py
@@ -224,8 +224,14 @@ class ConfigProp(CustomDomainObject):
         rst = ViewList()
 
         # Config store key
-        key = key_canonicalize(ctx.get(-2, 'sec_name'), ctx.get(-2, 'arguments'), ctx.get_name())
-        rst.append(f'| **Config store key**: ``{key}``', f'{__name__}', 1)
+        try:
+            key = key_canonicalize(
+                ctx.get(-2, 'sec_name'), ctx.get(-2, 'arguments'), ctx.get_name())
+            rst.append(f'| :ref:`Config store key <config-store-keys>`: ``{key}``',
+                f'{__name__}', 1)
+        except Exception as e:
+            e = ValueError(f'Something went wrong with key_canonicalize: {e}')
+            ConfigDomain.logger.warning(e, location=self.get_location())
 
         # :required: flag
         required = 'required' in self.options

--- a/docs/sphinx_extensions/config_domain.py
+++ b/docs/sphinx_extensions/config_domain.py
@@ -91,7 +91,7 @@ class ConfigSection(CustomDomainObject):
             r'(' + id_re + r'(?:@' + id_re + r')?)(?:/(.*))?', sig, self)
         sec_name, sec_disc = parse_section_name(name)
         ctx.push(self, name, f'[{name}]',
-            sec_name=sec_name, sec_disc=sec_name, arguments=arguments, keys=[])
+            sec_name=sec_name, sec_disc=sec_name, arguments=arguments, props=[])
         return (sec_name, sec_disc, arguments)
 
     def create_signode(self, ctx, name, signode, sec_name, sec_disc, arguments):
@@ -106,19 +106,19 @@ class ConfigSection(CustomDomainObject):
             signode += addnodes.desc_annotation(text, text)
 
 
-# cfg:key =====================================================================
+# cfg:prop ====================================================================
 
-key_name_re = id_re + r'(?:\.' + id_re + r')*'
-key_re = r'(?:\[(?P<sec>' + section_re + r')\])?(?P<key_name>' + key_name_re + r')'
-
-
-def parse_key_name(full_name, node=None):
-    return parse(ConfigKey._full_name, key_re, full_name, node,
-        'sec', 'sec_name', 'sec_disc', 'key_name')
+prop_name_re = id_re + r'(?:\.' + id_re + r')*'
+prop_re = r'(?:\[(?P<sec>' + section_re + r')\])?(?P<prop_name>' + prop_name_re + r')'
 
 
-def key_text(sec_name, sec_disc, key_name, insert=''):
-    text = key_name + insert
+def parse_prop_name(full_name, node=None):
+    return parse(ConfigProp._full_name, prop_re, full_name, node,
+        'sec', 'sec_name', 'sec_disc', 'prop_name')
+
+
+def prop_text(sec_name, sec_disc, prop_name, insert=''):
+    text = prop_name + insert
     if sec_name is not None:
         text = section_text(sec_name, sec_disc, ' ' + text)
     return text
@@ -139,30 +139,30 @@ def name_canonicalize(name):
     return name.strip('_').upper()
 
 
-def key_canonicalize(sec_name, sec_args, key_name):
+def key_canonicalize(sec_name, sec_args, prop_name):
     sec = name_canonicalize(sec_name)
     if sec_args:
         sec += '_' + sec_args
-    return sec + '_' + name_canonicalize(key_name)
+    return sec + '_' + name_canonicalize(prop_name)
 
 
-class ConfigKeyRefRole(XRefRole):
+class ConfigPropRefRole(XRefRole):
     def process_link(self, env: BuildEnvironment, refnode: Element,
                      has_explicit_title: bool, title: str, target: str) -> tuple[str, str]:
         ctx = ContextWrapper(env, 'cfg')
         target = target.strip()
 
         # Normalize target for the current scope
-        sec, sec_name, sec_disc, key_name = parse_key_name(target, self)
+        sec, sec_name, sec_disc, prop_name = parse_prop_name(target, self)
         scope_kind = len(ctx.stack)
         if sec is not None:
-            # [sec]key anywhere
+            # [sec]prop anywhere
             pass
         elif scope_kind == 0 and sec is None:
-            # Assume key outside section should be in [common]
+            # Assume prop outside section should be in [common]
             target = f'[common]{target}'
         elif scope_kind >= 1:
-            # key anywhere in a section
+            # prop anywhere in a section
             prefix = ctx.get_full_name(0)
             target = f'{prefix}{target}'
         else:
@@ -171,45 +171,46 @@ class ConfigKeyRefRole(XRefRole):
 
         if not has_explicit_title:
             # Reparse target and hide parts of title that are in the current scope
-            sec, sec_name, sec_disc, key_name = parse_key_name(target, self)
+            sec, sec_name, sec_disc, prop_name = parse_prop_name(target, self)
             scope = ctx.get_all_names()
             scope = scope + [None] * (2 - len(scope))
             if scope[0] == sec:
                 sec_name = None
 
-            title = key_text(sec_name, sec_disc, key_name)
+            title = prop_text(sec_name, sec_disc, prop_name)
 
         return title, target
 
 
 @ConfigDomain.add_type
-class ConfigKey(CustomDomainObject):
+class ConfigProp(CustomDomainObject):
     option_spec: OptionSpec = CustomDomainObject.option_spec.copy()
     option_spec.update({
         'required': directives.flag,
         'default': directives.unchanged,
     })
 
-    our_name = 'key'
+    our_name = 'prop'
     our_parent_required = True
     our_parent_type = ConfigSection
-    our_ref_role_type = ConfigKeyRefRole
+    our_ref_role_type = ConfigPropRefRole
 
     def get_index_text(self, name, full_name):
-        sec, sec_name, sec_disc, key = parse_key_name(full_name)
-        return f'{key} (config key)'
+        sec, sec_name, sec_disc, prop = parse_prop_name(full_name)
+        return f'{prop} (config property)'
 
     def parse_sig(self, ctx, sig):
-        name, arguments = parse(self._full_name, r'(' + key_name_re + r')(?:=(.*))?', sig, self)
+        name, arguments = parse(self._full_name, r'(' + prop_name_re + r')(?:=(.*))?', sig, self)
         sec = ctx.get_full_name()
         ctx.push(self, name, f'{sec}{name}', arguments=arguments)
-        sec_ctx = ctx.get(-2, 'keys')
+        sec_ctx = ctx.get(-2, 'props')
         if sec_ctx is not None:
             sec_ctx.append((name, self.get_location()))
         return (arguments,)
 
     def create_signode(self, ctx, name, signode, arguments):
         signode += addnodes.desc_name(name, name)
+        print(ctx.get(-2, 'sec_name'), name)
         if arguments is not None:
             text = '=' + arguments
             signode += addnodes.desc_addname(text, text)
@@ -246,18 +247,18 @@ class ConfigKey(CustomDomainObject):
 
 value_sep = '='
 value_sep_re = re.escape(value_sep)
-value_re = r'(?:(?P<key>' + key_re + r')' + value_sep_re + r')?(?P<val_name>' + id_re + r')'
+value_re = r'(?:(?P<prop>' + prop_re + r')' + value_sep_re + r')?(?P<val_name>' + id_re + r')'
 
 
 def parse_value_name(full_name, node=None):
     return parse(ConfigValue._full_name, value_re, full_name, node,
-        'sec', 'sec_name', 'sec_disc', 'key', 'key_name', 'val_name')
+        'sec', 'sec_name', 'sec_disc', 'prop', 'prop_name', 'val_name')
 
 
-def value_text(sec_name, sec_disc, key_name, val_name):
+def value_text(sec_name, sec_disc, prop_name, val_name):
     text = val_name
-    if key_name is not None:
-        text = key_text(sec_name, sec_disc, key_name, value_sep + text)
+    if prop_name is not None:
+        text = prop_text(sec_name, sec_disc, prop_name, value_sep + text)
     return text
 
 
@@ -268,19 +269,19 @@ class ConfigValueRefRole(XRefRole):
         target = target.strip()
 
         # Normalize target for the current scope
-        sec, sec_name, sec_disc, key, key_name, val_name = parse_value_name(target, self)
+        sec, sec_name, sec_disc, prop, prop_name, val_name = parse_value_name(target, self)
         scope_kind = len(ctx.stack)
         if sec is not None:
-            # [sec]key=val anywhere
+            # [sec]prop=val anywhere
             pass
         elif scope_kind == 0 and sec is None:
-            # key=val outside section
+            # prop=val outside section
             target = f'[common]{target}'
-        elif scope_kind >= 1 and key is not None:
-            # key=val anywhere in a section
+        elif scope_kind >= 1 and prop is not None:
+            # prop=val anywhere in a section
             target = ctx.get_full_name(0) + target
-        elif scope_kind >= 2 and key is None:
-            # val anywhere in a key
+        elif scope_kind >= 2 and prop is None:
+            # val anywhere in a prop
             target = ctx.get_full_name(1) + value_sep + target
         else:
             ConfigDomain.logger.warning(f'{repr(target)} is an invalid target here',
@@ -288,15 +289,15 @@ class ConfigValueRefRole(XRefRole):
 
         if not has_explicit_title:
             # Reparse target and hide parts of title that are in the current scope
-            sec, sec_name, sec_disc, key, key_name, val_name = parse_value_name(target, self)
+            sec, sec_name, sec_disc, prop, prop_name, val_name = parse_value_name(target, self)
             scope = ctx.get_all_names()
             scope = scope + [None] * (3 - len(scope))
             if scope[0] == sec:
                 sec_name = None
-                if scope[1] == key_name:
-                    key_name = None
+                if scope[1] == prop_name:
+                    prop_name = None
 
-            title = value_text(sec_name, sec_disc, key_name, val_name)
+            title = value_text(sec_name, sec_disc, prop_name, val_name)
 
         return title, target
 
@@ -305,7 +306,7 @@ class ConfigValueRefRole(XRefRole):
 class ConfigValue(CustomDomainObject):
     our_name = 'val'
     our_parent_required = True
-    our_parent_type = ConfigKey
+    our_parent_type = ConfigProp
     our_ref_role_type = ConfigValueRefRole
 
     def run(self):
@@ -315,7 +316,7 @@ class ConfigValue(CustomDomainObject):
         return super().run()
 
     def get_index_text(self, name, full_name):
-        sec, sec_name, sec_disc, key, key_name, val_name = parse_value_name(full_name, self)
+        sec, sec_name, sec_disc, prop, prop_name, val_name = parse_value_name(full_name, self)
         return f'{val_name} (config value)'
 
     def parse_sig(self, ctx, sig):
@@ -345,6 +346,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
         'parallel_write_safe': True,
     }
 
+
 class TestConfigDomain(unittest.TestCase):
 
     def test_parse_section_name(self):
@@ -357,9 +359,9 @@ class TestConfigDomain(unittest.TestCase):
         for ref, expected in cases.items():
             self.assertEqual(parse_section_name(ref), expected)
 
-    def test_parse_key_name(self):
+    def test_parse_prop_name(self):
         cases = {
-            # sec, sec_name, sec_disc, key_name
+            # sec, sec_name, sec_disc, prop_name
             'kn': (None, None, None, 'kn'),
             'kn.a.b.c': (None, None, None, 'kn.a.b.c'),
             '[sn]kn': ('sn', 'sn', None, 'kn'),
@@ -369,11 +371,11 @@ class TestConfigDomain(unittest.TestCase):
         }
 
         for ref, expected in cases.items():
-            self.assertEqual(parse_key_name(ref), expected, f'On key {repr(ref)}')
+            self.assertEqual(parse_prop_name(ref), expected, f'On prop {repr(ref)}')
 
     def test_parse_value_name(self):
         cases = {
-            # sec, sec_name, sec_disc, key, key_name, val_name
+            # sec, sec_name, sec_disc, prop, prop_name, val_name
             'vn': (None, None, None, None, None, 'vn'),
             'kn=vn': (None, None, None, 'kn', 'kn', 'vn'),
             'kn.a.b.c=vn': (None, None, None, 'kn.a.b.c', 'kn.a.b.c', 'vn'),

--- a/docs/sphinx_extensions/custom_domain.py
+++ b/docs/sphinx_extensions/custom_domain.py
@@ -187,15 +187,16 @@ class CustomDomain(Domain):
     label = None
     logger = None
 
-    object_types = {
-    }
-    directives = {
-    }
-    roles = {
-    }
-    initial_data: dict[str, dict[tuple[str, str], str]] = {
-        'objects': {},  # fullname -> docname, objtype
-    }
+    def __init_subclass__(cls):
+        cls.object_types = {
+        }
+        cls.directives = {
+        }
+        cls.roles = {
+        }
+        cls.initial_data = {
+            'objects': {},  # fullname -> docname, objtype
+        }
 
     @property
     def objects(self) -> dict[tuple[str, str], tuple[str, str]]:


### PR DESCRIPTION
Prompted by this comment: https://github.com/OpenDDS/OpenDDS/pull/4556#discussion_r1550398101

This is to avoid confusion with config store keys, which are basically the same thing, but it comes across as strange in the documentation to use the same term. This is mostly internal to the configuration domain code and usage, but has some references in the documentation.

Also:
- Linked configuration store key name to explanation of what the config store is.
- Fixed a bug in the shared domain code for CMake and configuration because I renamed `:cfg:key` to `:cfg:prop:` and it then seemed to be confusing `:cfg:prop:` for `:cmake:prop:` definitions and vice versa. This was because the Python classes for the two domains were sharing members they should not have.