### PR TITLE
Update GitHub Actions build for wireshark

### DIFF
--- a/.github/workflows/Wireshark_CMakePresets.json
+++ b/.github/workflows/Wireshark_CMakePresets.json
@@ -6,6 +6,7 @@
             "generator": "Ninja",
             "binaryDir": "$env{WIRESHARK_BUILD_DIR}",
             "cacheVariables": {
+                "BUILD_wireshark": "OFF",
                 "LEX_EXECUTABLE": "$env{WINFLEXBISON_ROOT}/bin/Debug/win_flex.exe"
             }
         }

--- a/.github/workflows/Wireshark_CMakePresets.json
+++ b/.github/workflows/Wireshark_CMakePresets.json
@@ -7,6 +7,8 @@
             "binaryDir": "$env{WIRESHARK_BUILD_DIR}",
             "cacheVariables": {
                 "BUILD_wireshark": "OFF",
+                "MAKENSIS_EXECUTABLE": "OFF",
+                "WIX_CANDLE_EXECUTABLE": "OFF",
                 "LEX_EXECUTABLE": "$env{WINFLEXBISON_ROOT}/bin/Debug/win_flex.exe"
             }
         }

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9618,17 +9618,6 @@ jobs:
       with:
         path: ${{ github.job }}.tar.xz
         key: c02_${{ github.job }}_${{ env.WIRESHARK_COMMIT }}_${{ env.COMPILER_VERSION }}
-    - name: setup for run-vcpkg
-      shell: bash
-      run: |
-        echo '{ "name": "opendds", "version-string": "github-actions", "dependencies": [ "qt5-winextras", "qt5-tools", "qt5-svg", "qt5-multimedia", "qt5-declarative" ] }' > vcpkg.json
-    - name: install vcpkg packages
-      if: steps.cache-artifact.outputs.cache-hit != 'true'
-      id: runvcpkg
-      uses: lukka/run-vcpkg@v11
-      with:
-        vcpkgGitCommitId: '${{ env.VCPKG_GIT_COMMIT }}'
-        runVcpkgInstall: true
     - name: checkout WinFlexBison
       if: steps.cache-artifact.outputs.cache-hit != 'true'
       uses: actions/checkout@v4


### PR DESCRIPTION
We can build the Wireshark libs without building the Qt GUI.  That allows us to skip downloading/building qt5.