### PR TITLE
`--mpcopts` values are split on spaces

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1870,7 +1870,7 @@ jobs:
           --tests \
           --security \
           --no-rapidjson \
-          --mpcopts="-features no_opendds_testing_features=0"
+          --features no_opendds_testing_features=0
     - name: check build configuration
       shell: bash
       run: |
@@ -5103,7 +5103,7 @@ jobs:
     - name: configure OpenDDS
       run: |
         cd OpenDDS
-        ./configure --features=uses_wchar=1 "--mpcopts=-features dds_suppress_anys=0" --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
+        ./configure --features=uses_wchar=1 --features dds_suppress_anys=0 --tests --security --rapidjson --ace=$GITHUB_WORKSPACE/ACE_TAO/ACE --mpc=$GITHUB_WORKSPACE/MPC
     - name: check build configuration
       shell: bash
       run: |
@@ -11037,7 +11037,7 @@ jobs:
       shell: cmd
       run: |
         cd /d C:\OpenDDS
-        configure --tests --java --no-built-in-topics --rapidjson --mpc=${{ github.workspace }}\MPC --xerces3="${{ env.VCPKG_INSTALLED_DIR }}\x86-windows" --mpcopts="-features no_opendds_testing_features=0"
+        configure --tests --java --no-built-in-topics --rapidjson --mpc=${{ github.workspace }}\MPC --xerces3="${{ env.VCPKG_INSTALLED_DIR }}\x86-windows" --features no_opendds_testing_features=0
     - name: check build configuration
       shell: cmd
       run: |

--- a/.github/workflows/ishapes.yml
+++ b/.github/workflows/ishapes.yml
@@ -92,9 +92,9 @@ jobs:
         cd OpenDDS
         perl configure --optimize --no-debug --static --tests ^
           "--qt=%VCPKG_INSTALLED_DIR%/x64-windows" ^
-          "--mpcopts=-value_template platforms=x64" ^
-          "--mpcopts=-value_template configurations=Release" ^
-          "--mpcopts=-value_template Release::runtime_library=MultiThreadedDLL"
+          "--mpc:value_template platforms=x64" ^
+          "--mpc:value_template configurations=Release" ^
+          "--mpc:value_template Release::runtime_library=MultiThreadedDLL"
         tools\scripts\show_build_config.pl
     - name: build
       shell: cmd

--- a/configure
+++ b/configure
@@ -226,7 +226,13 @@ my @specs = # Array of array-refs, each inner array is an option group which
     'configh=s@', 'Extra text for config.h',
     'macros=s@', 'Extra text for platform_macros.GNU',
     'features=s@', 'Extra text for default.features',
-    'mpcopts=s@', 'Extra command-line args for MPC',
+    'mpcopts=s@', 'Extra command-line args for MPC' .
+      $argIndent . 'This option can be given multiple times' .
+      $argIndent . 'Example: --mpcopts=-value_template --mpcopts=build_flags+="-Wall -Werror"',
+    '<usage>mpc:ARG VALUE', 'Extra command-line args for MPC' .
+      $argIndent . 'This option can be given multiple times' .
+      $argIndent . 'For example, --mpc:value_template build_flags+="-Wall -Werror" turns into' .
+      $argIndent . 'the following options for MPC: -value_template build_flags+="-Wall -Werror"',
     'boottime!', 'Use CLOCK_BOOTTIME for timers (no)',
    ],
    ['Optional dependencies for OpenDDS (disabled by default unless noted otherwise):',
@@ -330,6 +336,9 @@ EOT
             if ($optkey =~ /^\<hidden\>/) {
               return;
             }
+            if ($opt =~ /^\<usage\>(.*)$/) {
+              $optkey = $1;
+            }
             $optkey =~ s/^\<default\>(.*)$/\[no-\]$1/g;
             $optkey .= '...' if $opt =~ /s\@$/;
             my $pad = $argPadding - length $optkey;
@@ -346,6 +355,9 @@ sub parseArgs {
   my @default = ();
   iterate(sub {
             my ($group, $opt, $descr, $optkey) = @_;
+            if ($opt =~ /^\<usage\>/) {
+              return;
+            }
             if ($opt =~ /^<default>(.*)$/) {
               push @getopts, $1;
               $optkey =~ /^<default>(.*)$/;
@@ -365,9 +377,27 @@ sub parseArgs {
   }
 
   my $opts = {};
+  Getopt::Long::Configure('pass_through');
   GetOptions($opts, @getopts) or usage(1);
   usage(0) if $opts->{'help'};
   targetUsage(0) if $opts->{'target-help'};
+
+  while (@ARGV != 0) {
+    my $arg = shift(@ARGV);
+    if ($arg =~ /^--mpc:(.*)$/) {
+      my $key = $1;
+      if (@ARGV != 0) {
+        my $value = shift(@ARGV);
+        push(@{$opts->{'mpcopts'}}, '-' . $key, $value);
+      } else {
+        print "ERROR: $arg requires a value\n";
+        usage(1);
+      }
+    } else {
+      print "ERROR: unknown argument $arg\n";
+      usage(1);
+    }
+  }
 
   if ($opts->{'verbose'}) {
     print "Options:\n";
@@ -744,7 +774,7 @@ EOF
     }
     if ($opts{'std'}) {
       my $std = "stdcpp$cxx_std";
-      push(@{$opts{'mpcopts'}}, "-value_template LanguageStandard=$std");
+      push(@{$opts{'mpcopts'}}, '-value_template', "LanguageStandard=$std");
       print "Setting Visual C++ LanguageStandard to $std\n" if $opts{'verbose'};
       if ($opts{'std'} eq 'latest' || $cxx_std >= 17) {
         push(@{$opts{'features'}}, 'no_cxx17=0');
@@ -2421,9 +2451,7 @@ EOT
     push(@mwc_common_args, '-static');
   }
   if (defined $opts{'mpcopts'}) {
-    for my $i (@{$opts{'mpcopts'}}) {
-      push(@mwc_common_args, split(/ /, $i));
-    }
+    push(@mwc_common_args, @{$opts{'mpcopts'}});
   }
 
   my @feature_opts = ();

--- a/docs/news.d/mpcopts.rst
+++ b/docs/news.d/mpcopts.rst
@@ -1,0 +1,13 @@
+.. news-prs: 4574
+
+.. news-start-section: Removals
+- Values passed to the configure script via ``--mpcopts`` are no longer split on spaces.
+
+  - For example, ``./configure --mpcopts="-value_template build_flags+=-Wall -Werror"`` must now be written as ``./configure --mpcopts=-value_template --mpcopts="build_flags+=-Wall -Werror"``.
+.. news-end-section
+
+.. news-start-section: Additions
+- Add a ``configure`` script option for MPC options requiring a value.
+
+  - For example, ``./configure --mpc:value_template build_flags+="-Wall -Werror"``.
+.. news-end-section


### PR DESCRIPTION
Problem
-------

`--mpcopts` is a `configure` script option that accumulates additional options for MPC.  These values are split on spaces so `--mpcopts="-features no_opendds_testing_features=0"` results in two arguments to MPC: `-features` and `no_opendds_testing_features=0`.

This behavior complicates situations where one of the arguments to MPC contains spaces.  For example, `--mpcopts="-value_template build_flags+=-Wall -Werror" results in three arguments to MPC (and an error): `-value_template`, `build_flags+=Wall`, and `-Werror`.

Solution
--------

Remove the splitting functionality.

The examples above would now be written as
* `--mpcopts=-features --mpcopts=no_opendds_testing_features=0`
* `--mpcopts=-value_template --mpcopts=build_flags+="-Wall -Werror"`