### PR TITLE
`gov_gen` uses openssl API incorrectly

### DIFF
--- a/docs/news.d/gov-gen.rst
+++ b/docs/news.d/gov-gen.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4591
+
+.. news-start-section: Fixes
+- Fixed incorrect usage of OpenSSL in ``gov_gen`` application.
+.. news-end-section

--- a/tests/security/attributes/gov_gen.cpp
+++ b/tests/security/attributes/gov_gen.cpp
@@ -403,7 +403,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     return EXIT_FAILURE;
   }
 
-  PKCS7* p7 = PKCS7_sign(cert, key, NULL, NULL, PKCS7_TEXT | PKCS7_DETACHED);
+  PKCS7* p7 = PKCS7_sign(cert, key, NULL, mem, PKCS7_TEXT | PKCS7_DETACHED | PKCS7_STREAM);
   if (!p7) {
     std::cerr << "ERROR: could not sign" << std::endl;
     print_ssl_error();
@@ -418,7 +418,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 
   }
 
-  if (!SMIME_write_PKCS7(out, p7, mem, PKCS7_TEXT | PKCS7_DETACHED)) {
+  if (!SMIME_write_PKCS7(out, p7, mem, PKCS7_TEXT | PKCS7_DETACHED | PKCS7_STREAM)) {
     std::cerr << "ERROR: could not write " << outpath << std::endl;
     print_ssl_error();
     return EXIT_FAILURE;


### PR DESCRIPTION
Problem
-------

The `gov_gen` application generates governance files for testing and signs them with openssl.  `gov_gen` has a bug on Debian 12.5 (openssl 3.0.11) where a null argument is passed.

Solution
--------

Pass `mem` as the "in"" parameter and use `PKCS7_STREAM`.