### PR TITLE
Post 3.28.0 Release Script Improvements

### DIFF
--- a/.github/workflows/update-ace-tao.yml
+++ b/.github/workflows/update-ace-tao.yml
@@ -31,28 +31,37 @@ jobs:
       run: |
         cd OpenDDS
         GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}} perl tools/scripts/gitrelease.pl --update-ace-tao
-        # Help make the title and message for commit and PR
-        perl tools/scripts/modules/ini.pm acetao.ini --join ', ' '.*/version' > ../acevers
-        echo "ACEVERS=$(cat ../acevers)" >> $GITHUB_ENV
-        perl tools/scripts/modules/ini.pm acetao.ini --join ', ' '.*/url' > ../acevers_urls
-        echo "ACEVERS_URLS=$(cat ../acevers_urls)" >> $GITHUB_ENV
+        prefix="$GITHUB_WORKSPACE/update-ace-tao-"
+        commit_msg="${prefix}commit.md"
+        # Only commit and make a PR if the release script recognized a change
+        # from both master and workflows/update-ace-tao if it exists.
+        if [ -f "${commit_msg}" ]
+        then
+          echo "CREATE_PULL_REQUEST=true" >> $GITHUB_ENV
+          # create-pull-request can commit for us, but manually commit here so
+          # we can use file input for the commit message.
+          #   https://github.com/peter-evans/create-pull-request/issues/2864
+          git config user.name GitHub
+          git config user.email noreply@github.com
+          git add --all
+          git commit --file "${commit_msg}" \
+            --author "${{github.actor}} <${{github.actor}}@users.noreply.github.com>"
+          echo "PR_TITLE=$(cat ${prefix}pr-title.md)" >> $GITHUB_ENV
+          echo "PR_BODY_FILE=${prefix}pr-body.md" >> $GITHUB_ENV
+        else
+          echo "CREATE_PULL_REQUEST=false" >> $GITHUB_ENV
+        fi
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v6
+      if: env.CREATE_PULL_REQUEST == 'true'
       id: cpr
       with:
         path: OpenDDS
         token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: |
-          Update ACE/TAO to ${{env.ACEVERS}}
-
-          The releases are ${{env.ACEVERS_URLS}}
-        committer: GitHub <noreply@github.com>
-        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-        signoff: false
         branch: workflows/update-ace-tao
         delete-branch: true
-        title: Update ACE/TAO to ${{env.ACEVERS}}
-        body: "Releases: ${{env.ACEVERS_URLS}}"
+        title: ${{env.PR_TITLE}}
+        body-path: ${{env.PR_BODY_FILE}}
         labels: |
           dependencies
     - name: Check outputs

--- a/acetao.ini
+++ b/acetao.ini
@@ -1,8 +1,10 @@
 # This file contains the common info for ACE/TAO releases. Insead of editing
 # this directly, run:
-#   GITHUB_TOKEN=... ./tools/scripts/gitrelease.pl --update-ace-tao
+#   tools/scripts/gitrelease.pl --update-ace-tao
 
 [ace6tao2]
+hold=0
+desc=ACE 6/TAO 2
 version=6.5.20
 repo=https://github.com/DOCGroup/ACE_TAO.git
 branch=ace6tao2
@@ -18,6 +20,8 @@ tar.bz2-url=https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-6_5_
 tar.bz2-md5=2551d7d445456bcb316fe5e9a4b514ea
 
 [ace7tao3]
+hold=1
+desc=ACE 7/TAO 3
 version=7.1.3
 repo=https://github.com/DOCGroup/ACE_TAO.git
 branch=master

--- a/tools/scripts/modules/misc_utils.pm
+++ b/tools/scripts/modules/misc_utils.pm
@@ -6,18 +6,33 @@ use warnings;
 require Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(
+  get_trace
+  just_trace
   trace
 );
 
-sub trace {
-  my $i = 0;
-  my $msg = "ERROR: " . join('', @_) . "\n";
+sub get_trace {
+  my $prefix = shift();
+  my $offset = shift();
+  $prefix = "$prefix: " if ($prefix);
+
+  my $i = $offset;
+  my $msg = $prefix . join('', @_) . "\n";
   while (my @call = (caller($i++))) {
     my @next = caller($i);
     my $from = @next ? $next[3] : 'main';
-    $msg .= "ERROR: STACK TRACE[" . ($i - 1) . "] $call[1]:$call[2] in $from\n";
+    $msg .= $prefix . "STACK TRACE[" . ($i - 1) . "] $call[1]:$call[2] in $from\n";
   }
-  die($msg);
+
+  return $msg;
+}
+
+sub just_trace {
+  print STDERR (get_trace('ERROR', 1, @_));
+}
+
+sub trace {
+  die(get_trace('ERROR', 1, @_));
 }
 
 1;


### PR DESCRIPTION
- Fixed an issue with uploading RTPS interop test to the OMG repo.
- Update ACE/TAO Workflow:
  - Try to make it so it won't force push a new commit every time it runs but the PR hasn't been merged yet.
  - Generate a news fragment so the ACE/TAO update will be announced and users can see the ACE/TAO changes.
  - Try to improve the commit message and PR title and body so says which ACE/TAO was updated. Right now it always lists both.
- Made `run_command` more useful when non-zero exit statuses are not considered errors.