### PR TITLE
rtps_udp sends heartbeats when sending fragments

### DIFF
--- a/dds/DCPS/transport/framework/TransportSendStrategy.cpp
+++ b/dds/DCPS/transport/framework/TransportSendStrategy.cpp
@@ -81,7 +81,8 @@ TransportSendStrategy::TransportSendStrategy(
     transport_(transport),
     graceful_disconnecting_(false),
     link_released_(true),
-    send_buffer_(0)
+    send_buffer_(0),
+    is_sending_(GUID_UNKNOWN)
 {
   DBG_ENTRY_LVL("TransportSendStrategy","TransportSendStrategy",6);
 
@@ -1088,6 +1089,7 @@ TransportSendStrategy::send(TransportQueueElement* element, bool relink)
 
       // Loop for sending 'element', in fragments if needed
       bool first_pkt = true; // enter the loop 1st time through unconditionally
+      BeginEndSend bes(*this, element->publication_id());
       for (TransportQueueElement* next_fragment = 0;
            (first_pkt || next_fragment)
            && (mode_ == MODE_DIRECT || mode_ == MODE_TERMINATED);) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -1460,11 +1460,18 @@ RtpsUdpDataLink::RtpsWriter::send_heartbeats(const MonotonicTimePoint& /*now*/)
   }
 
   MetaSubmessageVec meta_submessages;
-  gather_heartbeats_i(meta_submessages);
+  const bool not_sending = !link->send_strategy()->is_sending(id_);
+  if (not_sending) {
+    gather_heartbeats_i(meta_submessages);
+  }
 
   if (!preassociation_readers_.empty() || !lagging_readers_.empty()) {
     heartbeat_->schedule(fallback_.get());
-    fallback_.advance();
+    if (not_sending) {
+      fallback_.advance();
+    } else {
+      fallback_.set(initial_fallback_);
+    }
   } else {
     fallback_.set(initial_fallback_);
   }

--- a/docs/news.d/heartbeat-fragmentation.rst
+++ b/docs/news.d/heartbeat-fragmentation.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4603
+
+.. news-start-section: Fixes
+- Do not send heartbeats during a fragmented send in ``rtps_udp``.
+.. news-end-section


### PR DESCRIPTION
Problem
-------

Suppose a writer has an agressive heartbeat period and then writes a sample that is highly fragmented.  It is possible (probable) that the heartbeat timer will go off before all fragments have been sent.  The reader can then nack fragments that haven't even been sent.  The writer would then resend the requested fragments.

Solution
--------

Before sending a heartbeat, check that the user is not in the middle of a send.

The solution does not make a change for resends due to reliability and/or durability.  The reason for this is that sending heartbeats and nack responses are mutually exclusive based on locking.