### PR TITLE
ValueDispatcher assumes pointer is KeyOnly

### DIFF
--- a/dds/DCPS/ValueDispatcher.h
+++ b/dds/DCPS/ValueDispatcher.h
@@ -20,6 +20,7 @@ namespace DCPS {
 struct OpenDDS_Dcps_Export ValueDispatcher {
   virtual ~ValueDispatcher() {}
 
+  // The void* is assumed to point to a value of type T (see template below).
   virtual void* new_value() const = 0;
   virtual void delete_value(void* data) const = 0;
 
@@ -55,7 +56,7 @@ struct ValueDispatcher_T : public virtual ValueDispatcher {
     case Sample::Full:
       return vread(value_reader, *static_cast<T*>(data));
     case Sample::KeyOnly:
-      return vread(value_reader, *static_cast<const KeyOnly<T>*>(data));
+      return vread(value_reader, KeyOnly<T>(*static_cast<T*>(data)));
     default:
       if (log_level >= LogLevel::Notice) {
         ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: ValueDispatcher_T<%C>::read:"
@@ -71,7 +72,7 @@ struct ValueDispatcher_T : public virtual ValueDispatcher {
     case Sample::Full:
       return vwrite(value_writer, *static_cast<const T*>(data));
     case Sample::KeyOnly:
-      return vwrite(value_writer, *static_cast<const KeyOnly<const T>*>(data));
+      return vwrite(value_writer, KeyOnly<const T>(*static_cast<const T*>(data)));
     default:
       if (log_level >= LogLevel::Notice) {
         ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: ValueDispatcher_T<%C>::write:"


### PR DESCRIPTION
Problem
-------

The ValueDispatcher code assumes the value indicated by the void* is a KeyOnly<T>*.  This is incorrect as the void* is a T*.

Solution
--------

Assume the void* is a T* and construct the KeyOnly.