### PR TITLE
MetaStruct conversion of wchar is compiler dependent

### DIFF
--- a/dds/DCPS/FilterEvaluator.cpp
+++ b/dds/DCPS/FilterEvaluator.cpp
@@ -629,6 +629,10 @@ Value::Value(const std::string& s, bool conversion_preferred)
 {}
 
 #ifdef DDS_HAS_WCHAR
+Value::Value(ACE_OutputCDR::from_wchar wc, bool conversion_preferred)
+  : type_(VAL_INT), i_(wc.val_), conversion_preferred_(conversion_preferred)
+{}
+
 Value::Value(const std::wstring& s, bool conversion_preferred)
   : type_(VAL_STRING), s_(ACE_OS::strdup(ACE_Wide_To_Ascii(s.c_str()).char_rep()))
   , conversion_preferred_(conversion_preferred)

--- a/dds/DCPS/FilterEvaluator.h
+++ b/dds/DCPS/FilterEvaluator.h
@@ -50,6 +50,7 @@ struct OpenDDS_Dcps_Export Value {
   Value(const char* s, bool conversion_preferred = false);
   Value(const std::string& s, bool conversion_preferred = false);
 #ifdef DDS_HAS_WCHAR
+  Value(ACE_OutputCDR::from_wchar wc, bool conversion_preferred = false);
   Value(const std::wstring& s, bool conversion_preferred = false);
 #endif
   Value(const TAO::String_Manager& s, bool conversion_preferred = false);

--- a/dds/idl/metaclass_generator.cpp
+++ b/dds/idl/metaclass_generator.cpp
@@ -58,6 +58,17 @@ namespace {
           prefix += "static_cast<int>(";
         }
         suffix = use_cxx11 ? "()))" : ")";
+      } else if (cls & CL_PRIMITIVE) {
+        AST_Type* const actual = resolveActualType(field->field_type());
+        const AST_PredefinedType::PredefinedType pt =
+          dynamic_cast<AST_PredefinedType*>(actual)->pt();
+        if (use_cxx11) {
+          suffix += "()";
+        }
+        if (pt == AST_PredefinedType::PT_wchar) {
+          prefix = "ACE_OutputCDR::from_wchar(" + prefix;
+          suffix += ")";
+        }
       } else if (use_cxx11) {
         suffix += "()";
       }


### PR DESCRIPTION
Problem
-------

The `Value` class used for `MetaStruct` has various constructors based on integer size and sign.  When constructing a `Value` from a wchar, different compilers make different choices.

Solution
--------

Provide explicit support for wchar conversion.