### PR TITLE
Debugging output not available for Messenger test

### DIFF
--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -595,7 +595,7 @@ sub _process_common {
   my $self = shift;
   my $name = shift;
   my $params = shift;
-  my $debug_logging = $self->{dcps_log_level};
+  my $debug_logging = 1;
 
   if ($$params !~ /-DCPSLogLevel / && $self->{dcps_log_level}) {
     $$params .= " -DCPSLogLevel $self->{dcps_log_level}";


### PR DESCRIPTION
Problem
-------

Debugging is not turned on for the Messenger test.

Solution
--------

Turn on debugging.