### PR TITLE
Environment variables are not processed immediately

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -568,6 +568,7 @@ void Service_Participant::parse_env(const String& p)
       const String key = q.substr(0, pos);
       const String value = q.substr(pos + 1);
       config_store_->set(key.c_str(), value);
+      config_reader_listener_->on_data_available(config_reader_);
     }
   }
 }


### PR DESCRIPTION
Problem
-------

Environment variables are not processed immediately by the Service Participant.  For many configuration keys, this is irrelevant.  For others, like those processed in
`Service_Participant::ConfigReaderListener::on_data_available`, it applies the configuration immediately.

A related problem is that if there are no arguments or configuration file, then the configuration from environment variables is not applied.  This prevents an "environment variable only" configuration from working properly.

Solution
--------

Invoke the listener after each environment variable is processed.