### PR TITLE
cmake: ignore the not-used targets when building with just the host tools

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -82,6 +82,10 @@ jobs:
         path: OpenDDS/build/ACE_TAO
     - name: Install xerces
       run: sudo apt-get -y install libxerces-c-dev
+    - uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: "3.23"
+        ninjaVersion: "latest"
     - name: Configure
       run: |
         cd OpenDDS
@@ -170,7 +174,7 @@ jobs:
         path: OpenDDS/build/ACE_TAO
     - uses: lukka/get-cmake@latest
       with:
-        cmakeVersion: "3.23"
+        cmakeVersion: "latest"
         ninjaVersion: "latest"
     - name: Configure
       run: |
@@ -217,7 +221,7 @@ jobs:
         add-to-path: false
     - uses: lukka/get-cmake@latest
       with:
-        cmakeVersion: "3.23"
+        cmakeVersion: "3.24"
         ninjaVersion: "latest"
     - name: Configure Host Tools
       run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -168,8 +168,10 @@ jobs:
       with:
         repository: DOCGroup/ACE_TAO
         path: OpenDDS/build/ACE_TAO
-    - name: Install Ninja
-      run: sudo apt-get -y install ninja-build
+    - uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: "3.23"
+        ninjaVersion: "latest"
     - name: Configure
       run: |
         cd OpenDDS
@@ -213,8 +215,10 @@ jobs:
       with:
         ndk-version: r25c
         add-to-path: false
-    - name: Install Ninja
-      run: sudo apt-get -y install ninja-build
+    - uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: "3.23"
+        ninjaVersion: "latest"
     - name: Configure Host Tools
       run: |
         cd OpenDDS
@@ -315,6 +319,10 @@ jobs:
       with:
         vcpkgGitCommitId: '${{ env.VCPKG_GIT_COMMIT }}'
         runVcpkgInstall: true
+    - uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: "3.23"
+        ninjaVersion: "latest"
     - name: Checkout OpenDDS
       uses: actions/checkout@v4
       with:

--- a/cmake/build_ace_tao.cmake
+++ b/cmake/build_ace_tao.cmake
@@ -36,11 +36,12 @@ execute_process(
 
 # Get the C++ standard OpenDDS is going to be built with. We are going to force
 # the ACE/TAO build to use the same standard.
-set(_opendds_idl_std "$<TARGET_PROPERTY:opendds_idl,CXX_STANDARD>")
-if(NOT OPENDDS_JUST_BUILD_HOST_TOOLS)
-  set(_opendds_dcps_std "$<TARGET_PROPERTY:OpenDDS_Dcps,CXX_STANDARD>")
+if(TARGET OpenDDS_Dcps)
+  set(_opendds_std_target OpenDDS_Dcps)
+else()
+  set(_opendds_std_target opendds_idl)
 endif()
-set(_opendds_std "$<IF:$<TARGET_EXISTS:OpenDDS_Dcps>,${_opendds_dcps_std},${_opendds_idl_std}>")
+set(_opendds_std "$<TARGET_PROPERTY:${_opendds_std_target},CXX_STANDARD>")
 
 set(_build_cmd "${CMAKE_COMMAND}" -E env "ACE_ROOT=${OPENDDS_ACE}" "TAO_ROOT=${OPENDDS_TAO}")
 if(_OPENDDS_XERCES3_FOR_ACE)

--- a/cmake/build_ace_tao.cmake
+++ b/cmake/build_ace_tao.cmake
@@ -37,7 +37,9 @@ execute_process(
 # Get the C++ standard OpenDDS is going to be built with. We are going to force
 # the ACE/TAO build to use the same standard.
 set(_opendds_idl_std "$<TARGET_PROPERTY:opendds_idl,CXX_STANDARD>")
-set(_opendds_dcps_std "$<TARGET_PROPERTY:OpenDDS_Dcps,CXX_STANDARD>")
+if(NOT OPENDDS_JUST_BUILD_HOST_TOOLS)
+  set(_opendds_dcps_std "$<TARGET_PROPERTY:OpenDDS_Dcps,CXX_STANDARD>")
+endif()
 set(_opendds_std "$<IF:$<TARGET_EXISTS:OpenDDS_Dcps>,${_opendds_dcps_std},${_opendds_idl_std}>")
 
 set(_build_cmd "${CMAKE_COMMAND}" -E env "ACE_ROOT=${OPENDDS_ACE}" "TAO_ROOT=${OPENDDS_TAO}")

--- a/cmake/build_ace_tao.cmake
+++ b/cmake/build_ace_tao.cmake
@@ -1,5 +1,6 @@
 include(ExternalProject)
 
+set(_opendds_std_target OpenDDS_Dcps)
 if(OPENDDS_JUST_BUILD_HOST_TOOLS)
   set(ws "${OPENDDS_BUILD_DIR}/host-tools.mwc")
   file(WRITE "${ws}"
@@ -10,7 +11,12 @@ if(OPENDDS_JUST_BUILD_HOST_TOOLS)
     "}\n"
   )
   list(APPEND _OPENDDS_CONFIGURE_ACE_TAO_ARGS "--workspace-file=${ws}")
+  set(_opendds_std_target opendds_idl)
 endif()
+
+# Get the C++ standard OpenDDS is going to be built with. We are going to force
+# the ACE/TAO build to use the same standard.
+set(_opendds_std "$<TARGET_PROPERTY:${_opendds_std_target},CXX_STANDARD>")
 
 find_package(Perl REQUIRED)
 if(OPENDDS_STATIC)
@@ -33,15 +39,6 @@ execute_process(
   COMMAND_ECHO STDOUT
   COMMAND_ERROR_IS_FATAL ANY
 )
-
-# Get the C++ standard OpenDDS is going to be built with. We are going to force
-# the ACE/TAO build to use the same standard.
-if(TARGET OpenDDS_Dcps)
-  set(_opendds_std_target OpenDDS_Dcps)
-else()
-  set(_opendds_std_target opendds_idl)
-endif()
-set(_opendds_std "$<TARGET_PROPERTY:${_opendds_std_target},CXX_STANDARD>")
 
 set(_build_cmd "${CMAKE_COMMAND}" -E env "ACE_ROOT=${OPENDDS_ACE}" "TAO_ROOT=${OPENDDS_TAO}")
 if(_OPENDDS_XERCES3_FOR_ACE)

--- a/docs/news.d/cmake_just_build_host_tools.rst
+++ b/docs/news.d/cmake_just_build_host_tools.rst
@@ -1,0 +1,7 @@
+.. news-prs: 4646
+
+.. news-start-section: Platform Support and Dependencies
+.. news-start-section: Building with CMake
+- Fixed :ghissue:`configure error <4645>` when using :cmake:var:`OPENDDS_JUST_BUILD_HOST_TOOLS` with CMake <3.28.
+.. news-end-section
+.. news-end-section


### PR DESCRIPTION
should fix #4645

Tested on Debian 12