### PR TITLE
More Predictable Port Usage in RTPS

### DIFF
--- a/dds/DCPS/ConfigStoreImpl.h
+++ b/dds/DCPS/ConfigStoreImpl.h
@@ -166,14 +166,14 @@ public:
   StringList get(const char* key,
                  const StringList& value) const;
 
-  template<typename T>
+  template<typename T, size_t count>
   T get(const char* key,
         T value,
-        const EnumList<T> decoder[])
+        const EnumList<T> (&decoder)[count])
   {
     bool found = false;
     String value_as_string;
-    for (size_t idx = 0; decoder[idx].name; ++idx) {
+    for (size_t idx = 0; idx < count; ++idx) {
       if (decoder[idx].value == value) {
         value_as_string = decoder[idx].name;
         found = true;
@@ -188,7 +188,7 @@ public:
     }
 
     const String actual = get(key, value_as_string);
-    for (size_t idx = 0; decoder[idx].name; ++idx) {
+    for (size_t idx = 0; idx < count; ++idx) {
       if (decoder[idx].name == actual) {
         return decoder[idx].value;
       }
@@ -204,14 +204,14 @@ public:
     return value;
   }
 
-  template<typename T>
+  template<typename T, size_t count>
   void set(const char* key,
            T value,
-           const EnumList<T> decoder[])
+           const EnumList<T> (&decoder)[count])
   {
     bool found = false;
     String value_as_string;
-    for (size_t idx = 0; decoder[idx].name; ++idx) {
+    for (size_t idx = 0; idx < count; ++idx) {
       if (decoder[idx].value == value) {
         value_as_string = decoder[idx].name;
         found = true;
@@ -232,15 +232,15 @@ public:
     set(key, value_as_string);
   }
 
-  template<typename T>
+  template<typename T, size_t count>
   void set(const char* key,
            const String& value,
-           const EnumList<T> decoder[])
+           const EnumList<T> (&decoder)[count])
   {
     bool found = false;
     // Sanity check.
     String value_as_string;
-    for (size_t idx = 0; decoder[idx].name; ++idx) {
+    for (size_t idx = 0; idx < count; ++idx) {
       if (value == decoder[idx].name) {
         set(key, value);
         found = true;

--- a/dds/DCPS/NetworkAddress.cpp
+++ b/dds/DCPS/NetworkAddress.cpp
@@ -8,7 +8,6 @@
 #include "NetworkAddress.h"
 
 #include "Hash.h"
-#include "LogAddr.h"
 
 #include <cstring>
 

--- a/dds/DCPS/RTPS/MessageUtils.h
+++ b/dds/DCPS/RTPS/MessageUtils.h
@@ -237,6 +237,38 @@ handle_to_octets(DDS::Security::NativeCryptoHandle handle)
 }
 #endif
 
+// Default values for spec-defined parameters for determining what ports RTPS
+// uses.
+const DDS::UInt16 default_port_base = 7400; // (PB)
+const DDS::UInt16 default_domain_gain = 250; // (DG)
+const DDS::UInt16 default_part_gain = 2; // (PG)
+const DDS::UInt16 default_spdp_multicast_offset = 0; // (D0)
+const DDS::UInt16 default_spdp_unicast_offset = 10; // (D1)
+const DDS::UInt16 default_user_multicast_offset = 1; // (D2)
+const DDS::UInt16 default_user_unicast_offset = 11; // (D3)
+
+// Default values for OpenDDS-specific parameters for determining what ports
+// RTPS uses.
+const DDS::UInt16 default_sedp_multicast_offset = 2; // (DX)
+const DDS::UInt16 default_sedp_unicast_offset = 12; // (DY)
+
+OpenDDS_Rtps_Export
+bool get_rtps_port(DDS::UInt16& port_result, const char* what,
+  DDS::UInt16 port_base, DDS::UInt16 offset,
+  DDS::UInt16 domain, DDS::UInt16 domain_gain,
+  DDS::UInt16 part = 0, DDS::UInt16 part_gain = 0);
+
+enum PortMode {
+  PortMode_System,
+  PortMode_Probe
+};
+
+OpenDDS_Rtps_Export
+PortMode get_port_mode(const String& key, PortMode default_value);
+
+OpenDDS_Rtps_Export
+void set_port_mode(const String& key, PortMode value);
+
 } // namespace RTPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
@@ -59,23 +59,37 @@ public:
   DCPS::TimeDuration lease_extension() const;
   void lease_extension(const DCPS::TimeDuration& period);
 
-  u_short pb() const;
-  void pb(u_short port_base);
+  PortMode spdp_port_mode() const;
+  void spdp_port_mode(PortMode value);
 
-  u_short dg() const;
-  void dg(u_short domain_gain);
+  PortMode sedp_port_mode() const;
+  void sedp_port_mode(PortMode value);
 
-  u_short pg() const;
-  void pg(u_short participant_gain);
+  DDS::UInt16 pb() const;
+  void pb(DDS::UInt16 port_base);
 
-  u_short d0() const;
-  void d0(u_short offset_zero);
+  DDS::UInt16 dg() const;
+  void dg(DDS::UInt16 domain_gain);
 
-  u_short d1() const;
-  void d1(u_short offset_one);
+  DDS::UInt16 pg() const;
+  void pg(DDS::UInt16 participant_gain);
 
-  u_short dx() const;
-  void dx(u_short offset_two);
+  DDS::UInt16 d0() const;
+  void d0(DDS::UInt16 spdp_multicast_offset);
+
+  DDS::UInt16 d1() const;
+  void d1(DDS::UInt16 spdp_unicast_offset);
+
+  DDS::UInt16 dx() const;
+  void dx(DDS::UInt16 sedp_multicast_offset);
+
+  DDS::UInt16 dy() const;
+  void dy(DDS::UInt16 sedp_unicast_offset);
+
+  bool spdp_multicast_port(DDS::UInt16& port, DDS::UInt16 domain) const;
+  bool spdp_unicast_port(DDS::UInt16& port, DDS::UInt16 domain, DDS::UInt16 part) const;
+  bool sedp_multicast_port(DDS::UInt16& port, DDS::UInt16 domain) const;
+  bool sedp_unicast_port(DDS::UInt16& port, DDS::UInt16 domain, DDS::UInt16 part) const;
 
   unsigned char ttl() const;
   void ttl(unsigned char time_to_live);
@@ -89,11 +103,17 @@ public:
   DCPS::NetworkAddress sedp_local_address() const;
   void sedp_local_address(const DCPS::NetworkAddress& mi);
 
+  bool sedp_unicast_address(
+    DCPS::NetworkAddress& addr, DDS::DomainId_t domain, DDS::UInt16 part_id) const;
+
   DCPS::NetworkAddress sedp_advertised_local_address() const;
   void sedp_advertised_local_address(const DCPS::NetworkAddress& mi);
 
   DCPS::NetworkAddress spdp_local_address() const;
   void spdp_local_address(const DCPS::NetworkAddress& mi);
+
+  bool spdp_unicast_address(DCPS::NetworkAddress& addr, bool& fixed_port,
+    DDS::DomainId_t domain, DDS::UInt16 part_id) const;
 
   bool sedp_multicast() const;
   void sedp_multicast(bool sm);
@@ -104,17 +124,24 @@ public:
   DCPS::NetworkAddress default_multicast_group(DDS::DomainId_t domain) const;
   void default_multicast_group(const DCPS::NetworkAddress& group);
 
-  u_short port_common(DDS::DomainId_t domain) const;
+  bool spdp_multicast_address(DCPS::NetworkAddress& addr, DDS::DomainId_t domain) const;
+  void spdp_multicast_address(const DCPS::NetworkAddress& addr);
 
-  DCPS::NetworkAddress multicast_address(u_short port_common,
-                                         DDS::DomainId_t domain) const;
+  bool sedp_multicast_address(DCPS::NetworkAddress& addr, DDS::DomainId_t domain) const;
+  void sedp_multicast_address(const DCPS::NetworkAddress& addr);
 
 #ifdef ACE_HAS_IPV6
   DCPS::NetworkAddress ipv6_spdp_local_address() const;
   void ipv6_spdp_local_address(const DCPS::NetworkAddress& mi);
 
+  bool ipv6_spdp_unicast_address(DCPS::NetworkAddress& addr, bool& fixed_port,
+    DDS::DomainId_t domain, DDS::UInt16 part_id) const;
+
   DCPS::NetworkAddress ipv6_sedp_local_address() const;
   void ipv6_sedp_local_address(const DCPS::NetworkAddress& mi);
+
+  bool ipv6_sedp_unicast_address(
+    DCPS::NetworkAddress& addr, DDS::DomainId_t domain, DDS::UInt16 part_id) const;
 
   DCPS::NetworkAddress ipv6_sedp_advertised_local_address() const;
   void ipv6_sedp_advertised_local_address(const DCPS::NetworkAddress& mi);
@@ -122,9 +149,14 @@ public:
   DCPS::NetworkAddress ipv6_default_multicast_group() const;
   void ipv6_default_multicast_group(const DCPS::NetworkAddress& group);
 
-  DCPS::NetworkAddress ipv6_multicast_address(u_short port_common) const;
+  bool ipv6_spdp_multicast_address(DCPS::NetworkAddress& addr, DDS::DomainId_t domain) const;
+  void ipv6_spdp_multicast_address(const DCPS::NetworkAddress& addr);
+
+  bool ipv6_sedp_multicast_address(DCPS::NetworkAddress& addr, DDS::DomainId_t domain) const;
+  void ipv6_sedp_multicast_address(const DCPS::NetworkAddress& addr);
 #endif
 
+  // TODO: Deprecated, remove in OpenDDS 4
   bool spdp_request_random_port() const;
   void spdp_request_random_port(bool f);
 

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -320,6 +320,10 @@ public:
   DDS::ReturnCode_t init(const DCPS::GUID_t& guid,
                          const RtpsDiscovery& disco,
                          DDS::DomainId_t domainId,
+                         DDS::UInt16 ipv4_participant_port_id,
+#ifdef ACE_HAS_IPV6
+                         DDS::UInt16 ipv6_participant_port_id,
+#endif
                          XTypes::TypeLookupService_rch tls);
 
 #ifdef OPENDDS_SECURITY

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -245,6 +245,10 @@ Spdp::Spdp(DDS::DomainId_t domain,
   , guid_(guid)
   , participant_discovered_at_(MonotonicTimePoint::now().to_monotonic_time())
   , is_application_participant_(false)
+  , ipv4_participant_port_id_(0)
+#ifdef ACE_HAS_IPV6
+  , ipv6_participant_port_id_(0)
+#endif
   , tport_(DCPS::make_rch<SpdpTransport>(rchandle_from(this)))
   , initialized_flag_(false)
   , eh_shutdown_(false)
@@ -304,6 +308,10 @@ Spdp::Spdp(DDS::DomainId_t domain,
   , guid_(guid)
   , participant_discovered_at_(MonotonicTimePoint::now().to_monotonic_time())
   , is_application_participant_(false)
+  , ipv4_participant_port_id_(0)
+#ifdef ACE_HAS_IPV6
+  , ipv6_participant_port_id_(0)
+#endif
   , tport_(DCPS::make_rch<SpdpTransport>(rchandle_from(this)))
   , initialized_flag_(false)
   , eh_shutdown_(false)
@@ -2177,7 +2185,11 @@ Spdp::init_bit(DCPS::RcHandle<DCPS::BitSubscriber> bit_subscriber)
   bit_subscriber_ = bit_subscriber;
 
   // Defer initilization until we have the bit subscriber.
-  sedp_->init(guid_, *disco_, domain_, type_lookup_service_);
+  sedp_->init(guid_, *disco_, domain_, ipv4_participant_port_id_,
+#ifdef ACE_HAS_IPV6
+    ipv6_participant_port_id_,
+#endif
+    type_lookup_service_);
   tport_->open(sedp_->reactor_task(), sedp_->job_queue());
 
 #ifdef OPENDDS_SECURITY
@@ -2350,38 +2362,35 @@ Spdp::SpdpTransport::SpdpTransport(DCPS::RcHandle<Spdp> outer)
 #ifdef ACE_HAS_MAC_OSX
   multicast_socket_.opts(ACE_SOCK_Dgram_Mcast::OPT_BINDADDR_NO |
                          ACE_SOCK_Dgram_Mcast::DEFOPT_NULLIFACE);
-#ifdef ACE_HAS_IPV6
+#  ifdef ACE_HAS_IPV6
   multicast_ipv6_socket_.opts(ACE_SOCK_Dgram_Mcast::OPT_BINDADDR_NO |
                               ACE_SOCK_Dgram_Mcast::DEFOPT_NULLIFACE);
-#endif
+#  endif
 #endif
 
   multicast_interface_ = outer->disco_->multicast_interface();
 
-  const u_short port_common = outer->config_->port_common(outer->domain_);
-  multicast_address_ = outer->config_->multicast_address(port_common, outer->domain_);
-
-#ifdef ACE_HAS_IPV6
-  multicast_ipv6_address_ = outer->config_->ipv6_multicast_address(port_common);
-#endif
-
+  if (!outer->config_->spdp_multicast_address(multicast_address_, outer->domain_)) {
+    throw std::runtime_error("failed to get valid multicast IPv4 address for SPDP");
+  }
   send_addrs_.insert(multicast_address_);
 #ifdef ACE_HAS_IPV6
+  if (!outer->config_->ipv6_spdp_multicast_address(multicast_ipv6_address_, outer->domain_)) {
+    throw std::runtime_error("failed to get valid multicast IPv4 address for SPDP");
+  }
   send_addrs_.insert(multicast_ipv6_address_);
 #endif
 
   const DCPS::NetworkAddressSet addrs = outer->config_->spdp_send_addrs();
   send_addrs_.insert(addrs.begin(), addrs.end());
 
-  u_short participantId = 0;
-
 #ifdef OPENDDS_SAFETY_PROFILE
-  const u_short startingParticipantId = participantId;
+  const DDS::UInt16 startingParticipantId = outer->ipv4_participant_port_id_;
 #endif
 
-  const u_short max_part_id = 119; // RTPS 2.5 9.6.2.3
-  while (!open_unicast_socket(port_common, participantId)) {
-    if (participantId == max_part_id && log_level >= LogLevel::Warning) {
+  const DDS::UInt16 max_part_id = 119; // RTPS 2.5 9.6.2.3
+  while (!open_unicast_socket(outer->ipv4_participant_port_id_)) {
+    if (outer->ipv4_participant_port_id_ == max_part_id && log_level >= LogLevel::Warning) {
       ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: Spdp::SpdpTransport: "
         "participant id is going above max %u allowed by RTPS spec\n", max_part_id));
       // As long as it doesn't result in an invalid port, going past this
@@ -2389,24 +2398,24 @@ Spdp::SpdpTransport::SpdpTransport(DCPS::RcHandle<Spdp> outer)
       // limited number of ports at its disposal. Also another implementation
       // could use this as a hard limit, but that's much less of a concern.
     }
-    ++participantId;
+    ++outer->ipv4_participant_port_id_;
   }
-#ifdef ACE_HAS_IPV6
-  u_short port = uni_port_;
 
-  while (!open_unicast_ipv6_socket(port)) {
-    ++port;
+#ifdef ACE_HAS_IPV6
+  outer->ipv6_participant_port_id_ = outer->ipv4_participant_port_id_;
+  while (!open_unicast_ipv6_socket(outer->ipv6_participant_port_id_)) {
+    ++outer->ipv6_participant_port_id_;
   }
 #endif
 
 #ifdef OPENDDS_SAFETY_PROFILE
-  if (participantId > startingParticipantId && ACE_OS::getpid() == -1) {
+  if (outer->ipv4_participant_port_id_ > startingParticipantId && ACE_OS::getpid() == -1) {
     // Since pids are not available, use the fact that we had to increment
     // participantId to modify the GUID's pid bytes.  This avoids GUID conflicts
     // between processes on the same host which start at the same time
     // (resulting in the same seed value for the random number generator).
-    hdr_.guidPrefix[8] = static_cast<CORBA::Octet>(participantId >> 8);
-    hdr_.guidPrefix[9] = static_cast<CORBA::Octet>(participantId & 0xFF);
+    hdr_.guidPrefix[8] = static_cast<CORBA::Octet>(outer->ipv4_participant_port_id_ >> 8);
+    hdr_.guidPrefix[9] = static_cast<CORBA::Octet>(outer->ipv4_participant_port_id_ & 0xFF);
     outer->guid_.guidPrefix[8] = hdr_.guidPrefix[8];
     outer->guid_.guidPrefix[9] = hdr_.guidPrefix[9];
   }
@@ -3401,31 +3410,18 @@ Spdp::signal_liveliness(DDS::LivelinessQosPolicyKind kind)
 }
 
 bool
-Spdp::SpdpTransport::open_unicast_socket(u_short port_common,
-                                         u_short participant_id)
+Spdp::SpdpTransport::open_unicast_socket(DDS::UInt16 participant_id)
 {
   DCPS::RcHandle<Spdp> outer = outer_.lock();
   if (!outer) {
     throw std::runtime_error("couldn't get Spdp");
   }
 
-  DCPS::NetworkAddress local_addr = outer->config_->spdp_local_address();
-  const bool fixed_port = local_addr.get_port_number();
-
-  if (fixed_port) {
-    uni_port_ = local_addr.get_port_number();
-  } else if (!outer->config_->spdp_request_random_port()) {
-    const ACE_UINT32 port = static_cast<ACE_UINT32>(port_common) + outer->config_->d1() +
-      outer->config_->pg() * participant_id;
-    if (port > 65535) {
-      if (log_level >= LogLevel::Error) {
-        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_socket: "
-                   "port %u is too high\n", port));
-      }
-      throw std::runtime_error("failed to open unicast port for SPDP (port too high)");
-    }
-    uni_port_ = static_cast<unsigned short>(port);
-    local_addr.set_port_number(uni_port_);
+  DCPS::NetworkAddress local_addr;
+  bool fixed_port;
+  if (!outer->config_->spdp_unicast_address(
+        local_addr, fixed_port, outer->domain_, participant_id)) {
+    throw std::runtime_error("failed to get valid unicast IPv4 address for SPDP");
   }
 
   if (unicast_socket_.open(local_addr.to_addr(), PF_INET) != 0) {
@@ -3435,170 +3431,138 @@ Spdp::SpdpTransport::open_unicast_socket(u_short port_common,
                    "failed to open %C %p.\n",
                    LogAddr(local_addr).c_str(), ACE_TEXT("ACE_SOCK_Dgram::open")));
       }
-      throw std::runtime_error("failed to open unicast port for SPDP");
+      throw std::runtime_error("failed to open fixed unicast IPv4 port for SPDP");
     }
     if (DCPS::DCPS_debug_level > 3) {
       ACE_DEBUG((LM_DEBUG,
-                 ACE_TEXT("(%P|%t) Spdp::SpdpTransport::open_unicast_socket() - ")
-                 ACE_TEXT("failed to open %C %p.  ")
-                 ACE_TEXT("Trying next participantId...\n"),
-                 DCPS::LogAddr(local_addr).c_str(), ACE_TEXT("ACE_SOCK_Dgram::open")));
+                 "(%P|%t) Spdp::SpdpTransport::open_unicast_socket: "
+                 "failed to open %C %p, trying next participant ID...\n",
+                 LogAddr(local_addr).c_str(), ACE_TEXT("ACE_SOCK_Dgram::open")));
     }
     return false;
   }
 
-  if (!fixed_port && outer->config_->spdp_request_random_port()) {
-    ACE_INET_Addr addr;
-    if (unicast_socket_.get_local_addr(addr) == 0) {
-      uni_port_ = addr.get_port_number();
-    }
-  }
-
-  if (DCPS::DCPS_debug_level > 3) {
-    ACE_DEBUG((LM_INFO,
-               ACE_TEXT("(%P|%t) Spdp::SpdpTransport::open_unicast_socket() - ")
-               ACE_TEXT("opened unicast socket on port %d\n"),
-               uni_port_));
-  }
-
-  if (!DCPS::set_socket_multicast_ttl(unicast_socket_, outer->config_->ttl())) {
-    if (DCPS::DCPS_debug_level > 0) {
-      ACE_ERROR((LM_ERROR,
-                ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_socket() - ")
-                ACE_TEXT("failed to set TTL value to %d ")
-                ACE_TEXT("for port:%hu %p\n"),
-                outer->config_->ttl(), uni_port_, ACE_TEXT("DCPS::set_socket_multicast_ttl:")));
-    }
-    throw std::runtime_error("failed to set TTL");
-  }
-
-  const int send_buffer_size = outer->config()->send_buffer_size();
-  if (send_buffer_size > 0) {
-    if (unicast_socket_.set_option(SOL_SOCKET,
-                                   SO_SNDBUF,
-                                   (void *) &send_buffer_size,
-                                   sizeof(send_buffer_size)) < 0
-        && errno != ENOTSUP) {
-      if (DCPS::DCPS_debug_level > 0) {
-        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_socket() - failed to set the send buffer size to %d errno %m\n"), send_buffer_size));
-      }
-      throw std::runtime_error("failed to set send buffer size");
-    }
-  }
-
-  const int recv_buffer_size = outer->config()->recv_buffer_size();
-  if (recv_buffer_size > 0) {
-    if (unicast_socket_.set_option(SOL_SOCKET,
-                                   SO_RCVBUF,
-                                   (void *) &recv_buffer_size,
-                                   sizeof(recv_buffer_size)) < 0
-        && errno != ENOTSUP) {
-      if (DCPS::DCPS_debug_level > 0) {
-        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_socket() - failed to set the recv buffer size to %d errno %m\n"), recv_buffer_size));
-      }
-      throw std::runtime_error("failed to set recv buffer size");
-    }
-  }
-
-#ifdef ACE_RECVPKTINFO
-  int sockopt = 1;
-  if (unicast_socket_.set_option(IPPROTO_IP, ACE_RECVPKTINFO, &sockopt, sizeof sockopt) == -1) {
-    ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_socket: set_option: %m\n")), false);
-  }
-#endif
+  set_unicast_socket_opts(outer, unicast_socket_, uni_port_);
 
   return true;
 }
 
-#ifdef ACE_HAS_IPV6
-bool
-Spdp::SpdpTransport::open_unicast_ipv6_socket(u_short port)
+namespace {
+  template <typename T>
+  bool set_sock_opt(ACE_SOCK_Dgram& sock,
+    int level, int option, T value, bool ignore_notsup = false)
+  {
+    if (sock.set_option(level, option, (void*) &value, sizeof(T)) < 0) {
+      return ignore_notsup && errno == ENOTSUP;
+    }
+    return true;
+  }
+}
+
+void Spdp::SpdpTransport::set_unicast_socket_opts(
+  DCPS::RcHandle<Spdp>& outer, ACE_SOCK_Dgram& sock, DDS::UInt16& port)
 {
-  DCPS::RcHandle<Spdp> outer = outer_.lock();
-  if (!outer) return false;
-
-  DCPS::NetworkAddress local_addr = outer->config_->ipv6_spdp_local_address();
-  const bool fixed_port = local_addr.get_port_number();
-
-  if (fixed_port) {
-    ipv6_uni_port_ = local_addr.get_port_number();
-  } else {
-    ipv6_uni_port_ = port;
-    local_addr.set_port_number(ipv6_uni_port_);
+  ACE_INET_Addr addr;
+  if (sock.get_local_addr(addr) != 0) {
+    throw std::runtime_error("failed to get address from socket");
   }
-
-  if (unicast_ipv6_socket_.open(local_addr.to_addr(), PF_INET6) != 0) {
-    if (fixed_port) {
-      if (DCPS::DCPS_debug_level > 0) {
-        ACE_ERROR((LM_ERROR,
-                  ACE_TEXT("(%P|%t) Spdp::SpdpTransport::open_unicast_ipv6_socket() - ")
-                  ACE_TEXT("failed to open %C %p.\n"),
-                  DCPS::LogAddr(local_addr).c_str(), ACE_TEXT("ACE_SOCK_Dgram::open")));
-      }
-      throw std::runtime_error("failed to open ipv6 unicast port for SPDP");
-    }
-    if (DCPS::DCPS_debug_level > 3) {
-      ACE_DEBUG((LM_WARNING,
-                 ACE_TEXT("(%P|%t) Spdp::SpdpTransport::open_unicast_ipv6_socket() - ")
-                 ACE_TEXT("failed to open %C %p.  ")
-                 ACE_TEXT("Trying next port...\n"),
-                 DCPS::LogAddr(local_addr).c_str(), ACE_TEXT("ACE_SOCK_Dgram::open")));
-    }
-    return false;
-  }
+  port = addr.get_port_number();
+  const bool ipv6 =
+#ifdef ACE_HAS_IPV6
+    addr.get_type () == AF_INET6;
+#else
+    false;
+#endif
 
   if (DCPS::DCPS_debug_level > 3) {
-    ACE_DEBUG((LM_INFO,
-               ACE_TEXT("(%P|%t) Spdp::SpdpTransport::open_unicast_ipv6_socket() - ")
-               ACE_TEXT("opened unicast ipv6 socket on port %d\n"),
-               ipv6_uni_port_));
+    ACE_DEBUG((LM_DEBUG,
+               "(%P|%t) Spdp::SpdpTransport::set_unicast_socket_opts: "
+               "opened %C unicast socket %d on port %d\n",
+               ipv6 ? "IPv6" : "IPv4", sock.get_handle(), port));
   }
 
-  if (!DCPS::set_socket_multicast_ttl(unicast_ipv6_socket_, outer->config_->ttl())) {
-    if (DCPS::DCPS_debug_level > 0) {
+  if (!DCPS::set_socket_multicast_ttl(sock, outer->config_->ttl())) {
+    if (log_level >= LogLevel::Error) {
       ACE_ERROR((LM_ERROR,
-                ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_ipv6_socket() - ")
-                ACE_TEXT("failed to set TTL value to %d ")
-                ACE_TEXT("for port:%hu %p\n"),
-                outer->config_->ttl(), ipv6_uni_port_, ACE_TEXT("DCPS::set_socket_multicast_ttl:")));
+                 "(%P|%t) ERROR: Spdp::SpdpTransport::set_unicast_socket_opts: "
+                 "failed to set TTL value to %d for port:%hu %p\n",
+                 outer->config_->ttl(), port, ACE_TEXT("DCPS::set_socket_multicast_ttl:")));
     }
     throw std::runtime_error("failed to set TTL");
   }
 
   const int send_buffer_size = outer->config()->send_buffer_size();
-  if (send_buffer_size > 0) {
-    if (unicast_ipv6_socket_.set_option(SOL_SOCKET,
-                                        SO_SNDBUF,
-                                        (void *) &send_buffer_size,
-                                        sizeof(send_buffer_size)) < 0
-        && errno != ENOTSUP) {
-      if (DCPS::DCPS_debug_level > 0) {
-        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_ipv6_socket() - failed to set the send buffer size to %d errno %m\n"), send_buffer_size));
-      }
-      throw std::runtime_error("failed to set send buffer size");
+  if (send_buffer_size > 0 && !set_sock_opt(sock, SOL_SOCKET, SO_SNDBUF, send_buffer_size, true)) {
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Spdp::SpdpTransport::set_unicast_socket_opts: "
+        "failed to set the send buffer size to %d: %m\n", send_buffer_size));
     }
+    throw std::runtime_error("failed to set send buffer size");
   }
 
   const int recv_buffer_size = outer->config()->recv_buffer_size();
-  if (recv_buffer_size > 0) {
-    if (unicast_ipv6_socket_.set_option(SOL_SOCKET,
-                                        SO_RCVBUF,
-                                        (void *) &recv_buffer_size,
-                                        sizeof(recv_buffer_size)) < 0
-        && errno != ENOTSUP) {
-      if (DCPS::DCPS_debug_level > 0) {
-        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_ipv6_socket() - failed to set the recv buffer size to %d errno %m\n"), recv_buffer_size));
-      }
-      throw std::runtime_error("failed to set recv buffer size");
+  if (recv_buffer_size > 0 && !set_sock_opt(sock, SOL_SOCKET, SO_RCVBUF, recv_buffer_size, true)) {
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Spdp::SpdpTransport::set_unicast_socket_opts: "
+        "failed to set the recv buffer size to %d: %m\n", recv_buffer_size));
     }
+    throw std::runtime_error("failed to set recv buffer size");
   }
 
+  bool success = true;
+  if (ipv6) {
 #ifdef ACE_RECVPKTINFO6
-  int sockopt = 1;
-  if (unicast_ipv6_socket_.set_option(IPPROTO_IPV6, ACE_RECVPKTINFO6, &sockopt, sizeof sockopt) == -1) {
-    ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_ipv6_socket: set_option: %m\n")), false);
-  }
+    success = set_sock_opt(sock, IPPROTO_IPV6, ACE_RECVPKTINFO6, 1);
 #endif
+  } else {
+#ifdef ACE_RECVPKTINFO
+    success = set_sock_opt(sock, IPPROTO_IP, ACE_RECVPKTINFO, 1);
+#endif
+  }
+  if (!success) {
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Spdp::SpdpTransport::set_unicast_socket_opts: "
+        "failed to set RECVPKTINFO: %m\n"));
+    }
+    throw std::runtime_error("failed to set RECVPKTINFO");
+  }
+}
+
+#ifdef ACE_HAS_IPV6
+bool
+Spdp::SpdpTransport::open_unicast_ipv6_socket(DDS::UInt16 participant_id)
+{
+  DCPS::RcHandle<Spdp> outer = outer_.lock();
+  if (!outer) {
+    throw std::runtime_error("couldn't get Spdp");
+  }
+
+  DCPS::NetworkAddress local_addr;
+  bool fixed_port;
+  if (!outer->config_->spdp_unicast_address(
+        local_addr, fixed_port, outer->domain_, participant_id)) {
+    throw std::runtime_error("failed to get valid unicast IPv4 address for SPDP");
+  }
+
+  if (unicast_ipv6_socket_.open(local_addr.to_addr(), PF_INET6) != 0) {
+    if (fixed_port) {
+      if (log_level >= LogLevel::Error) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Spdp::SpdpTransport::open_unicast_ipv6_socket: "
+                   "failed to open %C %p.\n",
+                   LogAddr(local_addr).c_str(), ACE_TEXT("ACE_SOCK_Dgram::open")));
+      }
+      throw std::runtime_error("failed to open fixed unicast IPv6 port for SPDP");
+    }
+    if (DCPS::DCPS_debug_level > 3) {
+      ACE_DEBUG((LM_DEBUG,
+                 "(%P|%t) Spdp::SpdpTransport::open_unicast_ipv6_socket: "
+                 "failed to open %C %p, trying next participant ID...\n",
+                 LogAddr(local_addr).c_str(), ACE_TEXT("ACE_SOCK_Dgram::open")));
+    }
+    return false;
+  }
+
+  set_unicast_socket_opts(outer, unicast_ipv6_socket_, ipv6_uni_port_);
 
   return true;
 }

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -403,6 +403,10 @@ private:
   DCPS::GUID_t guid_;
   const DCPS::MonotonicTime_t participant_discovered_at_;
   bool is_application_participant_;
+  DDS::UInt16 ipv4_participant_port_id_;
+#ifdef ACE_HAS_IPV6
+  DDS::UInt16 ipv6_participant_port_id_;
+#endif
 
   void data_received(const DataSubmessage& data, const ParameterList& plist, const DCPS::NetworkAddress& from);
 
@@ -491,9 +495,10 @@ private:
     ssize_t send(const DCPS::NetworkAddress& addr);
     void close(const DCPS::ReactorTask_rch& reactor_task);
     void dispose_unregister();
-    bool open_unicast_socket(u_short port_common, u_short participant_id);
+    void set_unicast_socket_opts(DCPS::RcHandle<Spdp>& outer, ACE_SOCK_Dgram& sock, DDS::UInt16& port);
+    bool open_unicast_socket(DDS::UInt16 participant_id);
 #ifdef ACE_HAS_IPV6
-    bool open_unicast_ipv6_socket(u_short port);
+    bool open_unicast_ipv6_socket(DDS::UInt16 participant_id);
 #endif
 
     void on_data_available(DCPS::RcHandle<DCPS::InternalDataReader<DCPS::NetworkInterfaceAddress> > reader);
@@ -515,13 +520,13 @@ private:
     UserTagSubmessage user_tag_;
     DataSubmessage data_;
     DCPS::SequenceNumber seq_;
-    u_short uni_port_;
+    DDS::UInt16 uni_port_;
     ACE_SOCK_Dgram unicast_socket_;
     OPENDDS_STRING multicast_interface_;
     DCPS::NetworkAddress multicast_address_;
     ACE_SOCK_Dgram_Mcast multicast_socket_;
 #ifdef ACE_HAS_IPV6
-    u_short ipv6_uni_port_;
+    DDS::UInt16 ipv6_uni_port_;
     ACE_SOCK_Dgram unicast_ipv6_socket_;
     OPENDDS_STRING multicast_ipv6_interface_;
     DCPS::NetworkAddress multicast_ipv6_address_;

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -2288,8 +2288,7 @@ namespace {
     {
       { Service_Participant::Encoding_Normal, "Normal" },
       { Service_Participant::Encoding_WriteOldFormat, "WriteOldFormat" },
-      { Service_Participant::Encoding_ReadOldFormat, "ReadOldFormat" },
-      { Service_Participant::Encoding_Normal, 0 }
+      { Service_Participant::Encoding_ReadOldFormat, "ReadOldFormat" }
     };
 }
 

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -1657,56 +1657,50 @@ namespace {
   const EnumList<DDS::DurabilityQosPolicyKind> durability_kinds[] =
     {
       { DDS::VOLATILE_DURABILITY_QOS, "VOLATILE" },
-      { DDS::TRANSIENT_LOCAL_DURABILITY_QOS, "TRANSIENT_LOCAL" },
+      { DDS::TRANSIENT_LOCAL_DURABILITY_QOS, "TRANSIENT_LOCAL" }
 #ifndef OPENDDS_NO_PERSISTENCE_PROFILE
+      ,
       { DDS::TRANSIENT_DURABILITY_QOS, "TRANSIENT" },
-      { DDS::PERSISTENT_DURABILITY_QOS, "PERSISTENT" },
+      { DDS::PERSISTENT_DURABILITY_QOS, "PERSISTENT" }
 #endif
-      { static_cast<DDS::DurabilityQosPolicyKind>(0), 0 }
     };
 
   const EnumList<DDS::LivelinessQosPolicyKind> liveliness_kinds[] =
     {
       { DDS::AUTOMATIC_LIVELINESS_QOS, "AUTOMATIC" },
       { DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS, "MANUAL_BY_TOPIC" },
-      { DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, "MANUAL_BY_PARTICIPANT" },
-      { static_cast<DDS::LivelinessQosPolicyKind>(0), 0 }
+      { DDS::MANUAL_BY_PARTICIPANT_LIVELINESS_QOS, "MANUAL_BY_PARTICIPANT" }
     };
 
   const EnumList<DDS::ReliabilityQosPolicyKind> reliability_kinds[] =
     {
       { DDS::BEST_EFFORT_RELIABILITY_QOS, "BEST_EFFORT" },
-      { DDS::RELIABLE_RELIABILITY_QOS, "RELIABLE" },
-      { static_cast<DDS::ReliabilityQosPolicyKind>(0), 0 }
+      { DDS::RELIABLE_RELIABILITY_QOS, "RELIABLE" }
     };
 
   const EnumList<DDS::DestinationOrderQosPolicyKind> destination_order_kinds[] =
     {
       { DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS, "BY_RECEPTION_TIMESTAMP" },
-      { DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS, "BY_SOURCE_TIMESTAMP" },
-      { static_cast<DDS::DestinationOrderQosPolicyKind>(0), 0 }
+      { DDS::BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS, "BY_SOURCE_TIMESTAMP" }
     };
 
   const EnumList<DDS::HistoryQosPolicyKind> history_kinds[] =
     {
       { DDS::KEEP_ALL_HISTORY_QOS, "KEEP_ALL" },
-      { DDS::KEEP_LAST_HISTORY_QOS, "KEEP_LAST" },
-      { static_cast<DDS::HistoryQosPolicyKind>(0), 0 }
+      { DDS::KEEP_LAST_HISTORY_QOS, "KEEP_LAST" }
     };
 
   const EnumList<DDS::OwnershipQosPolicyKind> ownership_kinds[] =
     {
       { DDS::SHARED_OWNERSHIP_QOS, "SHARED" },
-      { DDS::EXCLUSIVE_OWNERSHIP_QOS, "EXCLUSIVE" },
-      { static_cast<DDS::OwnershipQosPolicyKind>(0), 0 }
+      { DDS::EXCLUSIVE_OWNERSHIP_QOS, "EXCLUSIVE" }
     };
 
   const EnumList<DDS::PresentationQosPolicyAccessScopeKind> access_scope_kinds[] =
     {
       { DDS::INSTANCE_PRESENTATION_QOS, "INSTANCE" },
       { DDS::TOPIC_PRESENTATION_QOS, "TOPIC" },
-      { DDS::GROUP_PRESENTATION_QOS, "GROUP" },
-      { static_cast<DDS::PresentationQosPolicyAccessScopeKind>(0), 0 }
+      { DDS::GROUP_PRESENTATION_QOS, "GROUP" }
     };
 
   enum Type {
@@ -1716,8 +1710,7 @@ namespace {
   const EnumList<Type> type_kinds[] =
     {
       { Reader, "reader" },
-      { Writer, "writer" },
-      { static_cast<Type>(0), 0 }
+      { Writer, "writer" }
     };
 
 }

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -817,7 +817,7 @@ Configuring for InfoRepo Discovery
 ..
     Sect<7.3.2>
 
-This section describes the configuration properties for the :ref:`inforepo-disc`.
+This section describes the configuration properties for :ref:`inforepo-disc`.
 Assume for example that the :ref:`inforepo` is started on a host and port of ``myhost.mydomain.com:12345``.
 Applications can make their OpenDDS participants aware of how to find this service through command line options or by reading a configuration file.
 
@@ -1014,7 +1014,7 @@ Configuring for RTPS Discovery
 ..
     Sect<7.3.3>
 
-This section describes the configuration properties for the :ref:`rtps-disc`.
+This section describes the configuration properties for :ref:`rtps-disc`.
 The RTPS specification gives the following simple description that forms the basis for the discovery approach used by OpenDDS and the two different protocols used to accomplish the discovery operations.
 The excerpt from the :omgspec:`rtps:8.5.1` is as follows:
 

--- a/tests/Utils/GtestRc.h
+++ b/tests/Utils/GtestRc.h
@@ -2,6 +2,7 @@
 #define OPENDDS_TEST_GTEST_RC_H
 
 #include <dds/DCPS/DCPS_Utils.h>
+#include <dds/DCPS/LogAddr.h>
 
 #include <gtest/gtest.h>
 
@@ -20,9 +21,30 @@ inline ::testing::AssertionResult retcodes_equal(
     "    Which is: " << OpenDDS::DCPS::retcode_to_string(b) << "\n";
 }
 
-#define EXPECT_RC_EQ(A, B) EXPECT_PRED_FORMAT2(retcodes_equal, (A), (B))
-#define ASSERT_RC_EQ(A, B) ASSERT_PRED_FORMAT2(retcodes_equal, (A), (B))
-#define EXPECT_RC_OK(VALUE) EXPECT_RC_EQ(::DDS::RETCODE_OK, (VALUE))
-#define ASSERT_RC_OK(VALUE) ASSERT_RC_EQ(::DDS::RETCODE_OK, (VALUE))
+#define EXPECT_RC_EQ(A, B) EXPECT_PRED_FORMAT2(retcodes_equal, A, B)
+#define ASSERT_RC_EQ(A, B) ASSERT_PRED_FORMAT2(retcodes_equal, A, B)
+#define EXPECT_RC_OK(VALUE) EXPECT_RC_EQ(::DDS::RETCODE_OK, VALUE)
+#define ASSERT_RC_OK(VALUE) ASSERT_RC_EQ(::DDS::RETCODE_OK, VALUE)
+
+inline ::testing::AssertionResult addr_equal(
+  const char* a_expr, const char* b_expr,
+  const OpenDDS::DCPS::NetworkAddress& a, const OpenDDS::DCPS::NetworkAddress& b)
+{
+  const OpenDDS::DCPS::LogAddr ala(a);
+  const OpenDDS::DCPS::LogAddr bla(b);
+  if (ala.str() == bla.str()) {
+    return ::testing::AssertionSuccess();
+  }
+
+  return ::testing::AssertionFailure() <<
+    "Expected equality of these values:\n"
+    "  " << a_expr << "\n"
+    "    Which is: " << ala.str() << "\n"
+    "  " << b_expr << "\n"
+    "    Which is: " << bla.str() << "\n";
+}
+
+#define EXPECT_ADDR_EQ(A, B) EXPECT_PRED_FORMAT2(addr_equal, A, B)
+#define ASSERT_ADDR_EQ(A, B) ASSERT_PRED_FORMAT2(addr_equal, A, B)
 
 #endif

--- a/tests/unit-tests/dds/DCPS/ConfigStoreImpl.cpp
+++ b/tests/unit-tests/dds/DCPS/ConfigStoreImpl.cpp
@@ -252,8 +252,7 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_Enum)
     {
       { ALPHA, "alpha" },
       { BETA, "beta" },
-      { GAMMA, "gamma" },
-      { static_cast<MyConfigStoreEnum>(0), 0 }
+      { GAMMA, "gamma" }
     };
 
   ConfigTopic_rch topic = make_rch<ConfigTopic>();

--- a/tests/unit-tests/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -1,0 +1,477 @@
+#include <tests/Utils/GtestRc.h>
+
+#include <dds/DCPS/RTPS/RtpsDiscoveryConfig.h>
+
+using namespace OpenDDS::RTPS;
+using namespace OpenDDS::DCPS;
+
+namespace {
+  struct AddressTest {
+    RcHandle<ConfigStoreImpl> store;
+    RtpsDiscoveryConfig rtps;
+    NetworkAddress addr;
+    bool fixed;
+
+    AddressTest()
+    : store(make_rch<ConfigStoreImpl>(TheServiceParticipant->config_topic()))
+    , rtps("ADDRESS_TEST")
+    , addr()
+    , fixed(false)
+    {
+      store->unset_section(rtps.config_prefix());
+    }
+
+    ~AddressTest()
+    {
+      store->unset_section(rtps.config_prefix());
+    }
+  };
+}
+
+TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, sedp_unicast_address)
+{
+  {
+    AddressTest t;
+    ASSERT_TRUE(t.rtps.sedp_unicast_address(t.addr, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress());
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_port_mode(PortMode_System);
+    ASSERT_TRUE(t.rtps.sedp_unicast_address(t.addr, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress());
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_port_mode(PortMode_Probe);
+    ASSERT_TRUE(t.rtps.sedp_unicast_address(t.addr, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7662, "0.0.0.0"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_port_mode(PortMode_Probe);
+    ASSERT_TRUE(t.rtps.sedp_unicast_address(t.addr, 1, 3));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7668, "0.0.0.0"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_port_mode(PortMode_Probe);
+    t.rtps.pb(7500);
+    t.rtps.dg(260);
+    t.rtps.pg(3);
+    t.rtps.dy(8);
+    ASSERT_TRUE(t.rtps.sedp_unicast_address(t.addr, 1, 3));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7777, "0.0.0.0"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_port_mode(PortMode_Probe);
+    t.rtps.pb(9999);
+    t.rtps.dg(9999);
+    t.rtps.pg(9999);
+    t.rtps.dy(9999);
+    LogRestore lr;
+    log_level.set(LogLevel::None);
+    ASSERT_FALSE(t.rtps.sedp_unicast_address(t.addr, 9999, 9999));
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_local_address(NetworkAddress(1234, "1.2.3.4"));
+    ASSERT_TRUE(t.rtps.sedp_unicast_address(t.addr, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(1234, "1.2.3.4"));
+    EXPECT_FALSE(t.fixed);
+  }
+}
+
+TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, spdp_unicast_address)
+{
+  {
+    AddressTest t;
+    ASSERT_TRUE(t.rtps.spdp_unicast_address(t.addr, t.fixed, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7660, "0.0.0.0"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.spdp_port_mode(PortMode_Probe);
+    ASSERT_TRUE(t.rtps.spdp_unicast_address(t.addr, t.fixed, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7660, "0.0.0.0"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+
+  {
+    AddressTest t;
+    t.rtps.spdp_port_mode(PortMode_System);
+    ASSERT_TRUE(t.rtps.spdp_unicast_address(t.addr, t.fixed, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress());
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.spdp_port_mode(PortMode_Probe);
+    ASSERT_TRUE(t.rtps.spdp_unicast_address(t.addr, t.fixed, 1, 3));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7666, "0.0.0.0"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.spdp_port_mode(PortMode_Probe);
+    t.rtps.pb(7500);
+    t.rtps.dg(260);
+    t.rtps.pg(3);
+    t.rtps.d1(8);
+    ASSERT_TRUE(t.rtps.spdp_unicast_address(t.addr, t.fixed, 1, 3));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7777, "0.0.0.0"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.spdp_port_mode(PortMode_Probe);
+    t.rtps.pb(9999);
+    t.rtps.dg(9999);
+    t.rtps.pg(9999);
+    t.rtps.d1(9999);
+    LogRestore lr;
+    log_level.set(LogLevel::None);
+    ASSERT_FALSE(t.rtps.spdp_unicast_address(t.addr, t.fixed, 9999, 9999));
+  }
+
+  {
+    AddressTest t;
+    t.rtps.spdp_local_address(NetworkAddress(1234, "1.2.3.4"));
+    ASSERT_TRUE(t.rtps.spdp_unicast_address(t.addr, t.fixed, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(1234, "1.2.3.4"));
+    EXPECT_TRUE(t.fixed);
+  }
+}
+
+TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, spdp_multicast_address)
+{
+  {
+    AddressTest t;
+    ASSERT_TRUE(t.rtps.spdp_multicast_address(t.addr, 1));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7650, "239.255.0.1"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    ASSERT_TRUE(t.rtps.spdp_multicast_address(t.addr, 2));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7900, "239.255.0.1"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.pb(7500);
+    t.rtps.dg(260);
+    t.rtps.d0(17);
+    ASSERT_TRUE(t.rtps.spdp_multicast_address(t.addr, 1));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7777, "239.255.0.1"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.pb(9999);
+    t.rtps.dg(9999);
+    t.rtps.d0(9999);
+    LogRestore lr;
+    log_level.set(LogLevel::None);
+    ASSERT_FALSE(t.rtps.spdp_multicast_address(t.addr, 9999));
+  }
+
+  {
+    AddressTest t;
+    t.rtps.spdp_multicast_address(NetworkAddress(1234, "1.2.3.4"));
+    ASSERT_TRUE(t.rtps.spdp_multicast_address(t.addr, 1));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(1234, "1.2.3.4"));
+    EXPECT_FALSE(t.fixed);
+  }
+}
+
+TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, sedp_multicast_address)
+{
+  {
+    AddressTest t;
+    ASSERT_TRUE(t.rtps.sedp_multicast_address(t.addr, 1));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7652, "239.255.0.1"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    ASSERT_TRUE(t.rtps.sedp_multicast_address(t.addr, 2));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7902, "239.255.0.1"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.pb(7500);
+    t.rtps.dg(260);
+    t.rtps.dx(17);
+    ASSERT_TRUE(t.rtps.sedp_multicast_address(t.addr, 1));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7777, "239.255.0.1"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.pb(9999);
+    t.rtps.dg(9999);
+    t.rtps.dx(9999);
+    LogRestore lr;
+    log_level.set(LogLevel::None);
+    ASSERT_FALSE(t.rtps.sedp_multicast_address(t.addr, 9999));
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_multicast_address(NetworkAddress(1234, "1.2.3.4"));
+    ASSERT_TRUE(t.rtps.sedp_multicast_address(t.addr, 1));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(1234, "1.2.3.4"));
+    EXPECT_FALSE(t.fixed);
+  }
+}
+
+#ifdef ACE_HAS_IPV6
+TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, ipv6_sedp_unicast_address)
+{
+  {
+    AddressTest t;
+    ASSERT_TRUE(t.rtps.ipv6_sedp_unicast_address(t.addr, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress());
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_port_mode(PortMode_System);
+    ASSERT_TRUE(t.rtps.ipv6_sedp_unicast_address(t.addr, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress());
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_port_mode(PortMode_Probe);
+    ASSERT_TRUE(t.rtps.ipv6_sedp_unicast_address(t.addr, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7662, "[::]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_port_mode(PortMode_Probe);
+    ASSERT_TRUE(t.rtps.ipv6_sedp_unicast_address(t.addr, 1, 3));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7668, "[::]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_port_mode(PortMode_Probe);
+    t.rtps.pb(7500);
+    t.rtps.dg(260);
+    t.rtps.pg(3);
+    t.rtps.dy(8);
+    ASSERT_TRUE(t.rtps.ipv6_sedp_unicast_address(t.addr, 1, 3));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7777, "[::]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_port_mode(PortMode_Probe);
+    t.rtps.pb(9999);
+    t.rtps.dg(9999);
+    t.rtps.pg(9999);
+    t.rtps.dy(9999);
+    LogRestore lr;
+    log_level.set(LogLevel::None);
+    ASSERT_FALSE(t.rtps.ipv6_sedp_unicast_address(t.addr, 9999, 9999));
+  }
+
+  {
+    AddressTest t;
+    t.rtps.sedp_local_address(NetworkAddress(1234, "[1:2:3:4]"));
+    ASSERT_TRUE(t.rtps.ipv6_sedp_unicast_address(t.addr, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(1234, "[1:2:3:4]"));
+    EXPECT_FALSE(t.fixed);
+  }
+}
+
+TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, ipv6_spdp_unicast_address)
+{
+  {
+    AddressTest t;
+    ASSERT_TRUE(t.rtps.ipv6_spdp_unicast_address(t.addr, t.fixed, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7660, "[::]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.spdp_port_mode(PortMode_Probe);
+    ASSERT_TRUE(t.rtps.ipv6_spdp_unicast_address(t.addr, t.fixed, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7660, "[::]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+
+  {
+    AddressTest t;
+    t.rtps.spdp_port_mode(PortMode_System);
+    ASSERT_TRUE(t.rtps.ipv6_spdp_unicast_address(t.addr, t.fixed, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress());
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.spdp_port_mode(PortMode_Probe);
+    ASSERT_TRUE(t.rtps.ipv6_spdp_unicast_address(t.addr, t.fixed, 1, 3));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7666, "[::]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.spdp_port_mode(PortMode_Probe);
+    t.rtps.pb(7500);
+    t.rtps.dg(260);
+    t.rtps.pg(3);
+    t.rtps.d1(8);
+    ASSERT_TRUE(t.rtps.ipv6_spdp_unicast_address(t.addr, t.fixed, 1, 3));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7777, "[::]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.spdp_port_mode(PortMode_Probe);
+    t.rtps.pb(9999);
+    t.rtps.dg(9999);
+    t.rtps.pg(9999);
+    t.rtps.d1(9999);
+    LogRestore lr;
+    log_level.set(LogLevel::None);
+    ASSERT_FALSE(t.rtps.ipv6_spdp_unicast_address(t.addr, t.fixed, 9999, 9999));
+  }
+
+  {
+    AddressTest t;
+    t.rtps.spdp_local_address(NetworkAddress(1234, "[1:2:3:4]"));
+    ASSERT_TRUE(t.rtps.ipv6_spdp_unicast_address(t.addr, t.fixed, 1, 0));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(1234, "[1:2:3:4]"));
+    EXPECT_TRUE(t.fixed);
+  }
+}
+
+TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, ipv6_spdp_multicast_address)
+{
+  {
+    AddressTest t;
+    ASSERT_TRUE(t.rtps.ipv6_spdp_multicast_address(t.addr, 1));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7650, "[FF03::1]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    ASSERT_TRUE(t.rtps.ipv6_spdp_multicast_address(t.addr, 2));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7900, "[FF03::1]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.pb(7500);
+    t.rtps.dg(260);
+    t.rtps.d0(17);
+    ASSERT_TRUE(t.rtps.ipv6_spdp_multicast_address(t.addr, 1));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7777, "[FF03::1]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.pb(9999);
+    t.rtps.dg(9999);
+    t.rtps.d0(9999);
+    LogRestore lr;
+    log_level.set(LogLevel::None);
+    ASSERT_FALSE(t.rtps.ipv6_spdp_multicast_address(t.addr, 9999));
+  }
+
+  {
+    AddressTest t;
+    t.rtps.ipv6_spdp_multicast_address(NetworkAddress(1234, "[1:2:3:4]"));
+    ASSERT_TRUE(t.rtps.ipv6_spdp_multicast_address(t.addr, 1));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(1234, "[1:2:3:4]"));
+    EXPECT_FALSE(t.fixed);
+  }
+}
+
+TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, ipv6_sedp_multicast_address)
+{
+  {
+    AddressTest t;
+    ASSERT_TRUE(t.rtps.ipv6_sedp_multicast_address(t.addr, 1));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7652, "[FF03::1]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    ASSERT_TRUE(t.rtps.ipv6_sedp_multicast_address(t.addr, 2));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7902, "[FF03::1]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.pb(7500);
+    t.rtps.dg(260);
+    t.rtps.dx(17);
+    ASSERT_TRUE(t.rtps.ipv6_sedp_multicast_address(t.addr, 1));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(7777, "[FF03::1]"));
+    EXPECT_FALSE(t.fixed);
+  }
+
+  {
+    AddressTest t;
+    t.rtps.pb(9999);
+    t.rtps.dg(9999);
+    t.rtps.dx(9999);
+    LogRestore lr;
+    log_level.set(LogLevel::None);
+    ASSERT_FALSE(t.rtps.ipv6_sedp_multicast_address(t.addr, 9999));
+  }
+
+  {
+    AddressTest t;
+    t.rtps.ipv6_sedp_multicast_address(NetworkAddress(1234, "[1:2:3:4]"));
+    ASSERT_TRUE(t.rtps.ipv6_sedp_multicast_address(t.addr, 1));
+    EXPECT_ADDR_EQ(t.addr, NetworkAddress(1234, "[1:2:3:4]"));
+    EXPECT_FALSE(t.fixed);
+  }
+}
+#endif


### PR DESCRIPTION
- Added `SedpPortMode=probe` to make it make it possible to predict what ports the unicast SEDP sockets use.
- Added `SpdpPortMode` which deprecates `SpdpRequestRandomPort`.
- Added `SpdpMulticastAddress`, `Ipv4SpdpMulticastAddress`, `SedpMulticastAddress`, and `Ipv4SedpMulticastAddress` to set the multicast addresses and ports separately on SPDP and SEDP.
- Calculated ports are now checked if they would overflow.
- Remove need for sentinel in `EnumList` arrays for `ConfigStore`.