### PR TITLE
Fix OMG-Related Link Checking Issues

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -8,6 +8,7 @@ import sys
 import os
 import venv
 import webbrowser
+import itertools
 from subprocess import check_call
 from shutil import rmtree
 from argparse import ArgumentParser
@@ -80,9 +81,9 @@ class DocEnv:
             self.venv_path.touch()
             self.rm_build()
 
-    def sphinx_build(self, builder, *args):
+    def sphinx_build(self, builder, *args, defines=[]):
         args = list(args)
-        for define in self.conf_defines:
+        for define in itertools.chain(self.conf_defines, defines):
             args.append('-D' + define)
         if self.debug:
             args.append('-vv')
@@ -118,7 +119,7 @@ class DocEnv:
     def do_strict(self):
         self.do(['test'], because_of='strict')
         self.sphinx_build('dummy', '-W')
-        self.sphinx_build('linkcheck')
+        self.sphinx_build('linkcheck', defines=['gen_all_omg_spec_links=False'])
         return None
 
     def do_html(self):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,8 +145,12 @@ linkcheck_ignore = [
     r'^https?://github\.com/.*#.+$',
     # Returns 403 for some reason
     r'^https?://docs\.github\.com/.*$',
+    r'^https://www.dds-foundation.org/.*$',
+    r'^https://www.corba.org/.*$',
     # UTF-8 decode errors (trying to parse PDF as HTML?), shouldn't check these anyways
     r'^https?://www\.omg\.org/spec/.*/PDF.*$',
+    # OMG Member link, will always redirect to a login page
+    r'https://issues.omg.org/browse/.*$'
 ]
 
 intersphinx_mapping = {

--- a/docs/sphinx_extensions/links.py
+++ b/docs/sphinx_extensions/links.py
@@ -375,7 +375,7 @@ class OmgSpecsDirective(SphinxDirective):
             p += nodes.literal('', spec_name)
             p += nodes.inline('', ')')
             spec_node += p
-            if 'debug-links' in self.options:
+            if 'debug-links' in self.options and not self.env.app.config.gen_all_omg_spec_links:
                 self.spec_sections(spec, spec_node, spec['sections'])
             specs_node += spec_node
         return [specs_node]
@@ -395,6 +395,7 @@ def setup(app):
     app.add_role('acetaorel', acetaorel_role)
 
     app.add_config_value('omg_specs', {}, 'env', types=[dict])
+    app.add_config_value('gen_all_omg_spec_links', True, 'env', types=[bool])
     app.add_role('omgissue', omgissue_role)
     app.add_role('omgspec', omgspec_role)
     app.add_directive("omgspecs", OmgSpecsDirective)


### PR DESCRIPTION
- Ignore `dds-foundation.org` and `corba.org`, which have been returning 403 for a while
- Ignore login redirect on spec issues
- Completely omit generating links to all the spec sections when running `linkcheck`