### PR TITLE
Revert "Add feature to disable include of OpenDDSConfig.h when compiling an IDL file"

### DIFF
--- a/MPC/config/dcps_optional_features.mpb
+++ b/MPC/config/dcps_optional_features.mpb
@@ -59,10 +59,5 @@ feature (!no_opendds_security) : taoidldefaults, dcps_ts_defaults {
   dcps_ts_flags += -DOPENDDS_SECURITY
 }
 
-feature (!openddsconfig_h_file) : taoidldefaults, dcps_ts_defaults {
-  idlflags += -DOPENDDS_IGNORE_OPENDDSCONFIG_H_FILE
-  dcps_ts_flags += -DOPENDDS_IGNORE_OPENDDSCONFIG_H_FILE
-}
-
 project: dcps_optional_bidir_giop {
 }


### PR DESCRIPTION
Reverts OpenDDS/OpenDDS#4671, the file really should be there, the new OpenDDSConfig header is the only place where OpenDDS features can be enabled safely