### PR TITLE
Update char_literals Tests to Check for `wchar` Escape Sequence Support in tao_idl

### DIFF
--- a/tests/DCPS/Compiler/char_literals/test.idl
+++ b/tests/DCPS/Compiler/char_literals/test.idl
@@ -1,8 +1,14 @@
 #if defined __TAO_IDL_FEATURES
 #  include __TAO_IDL_FEATURES
 #  define WCHAR_DISC TAO_IDL_HAS_OCTET_AND_WCHAR_UNION_DISCS
+#  ifdef TAO_IDL_HAS_WCHAR_ESCAPE_SEQUENCES
+#    define WCHAR_ESC_SEQ TAO_IDL_HAS_WCHAR_ESCAPE_SEQUENCES
+#  endif
 #else
 #  define WCHAR_DISC 0
+#endif
+#ifndef WCHAR_ESC_SEQ
+#  define WCHAR_ESC_SEQ  0
 #endif
 
 const char c_a = 'a';
@@ -23,9 +29,12 @@ const char c_hex_1 = '\x1';
 const char c_hex_254 = '\xfe';
 
 @topic
+const char c_const = '*';
 union CharUnion switch (@key char) {
 case 'a':
   long a;
+case c_const:
+  long const_branch;
 case '\n':
   long newline;
 case '\t':
@@ -64,7 +73,7 @@ const string str_normal = "a\n \t \v \b \r \f \a \\ \? \' \"";
 const string str_values = "\377\x1\xfe\0";
 
 const wchar wc_a = L'a';
-/* TODO(iguessthislldo): See https://github.com/DOCGroup/ACE_TAO/issues/1284
+#if WCHAR_ESC_SEQ
 const wchar wc_newline = L'\n';
 const wchar wc_tab = L'\t';
 const wchar wc_vertical_tab = L'\v';
@@ -76,21 +85,20 @@ const wchar wc_backslash = L'\\';
 const wchar wc_question = L'\?';
 const wchar wc_single_quote = L'\'';
 const wchar wc_double_quote = L'\"';
-const wchar wc_oct_0 = L'\0';
-const wchar wc_oct_255 = L'\377';
-const wchar wc_hex_1 = L'\x1';
-const wchar wc_hex_254 = L'\xfe';
-*/
-// TODO(iguessthislldo): See https://github.com/DOCGroup/ACE_TAO/issues/1284#issuecomment-879455512
-#ifdef __OPENDDS_IDL
+#endif
+#if defined __OPENDDS_IDL || WCHAR_ESC_SEQ
 const wchar wc_u_escape = L'\u203C'; // (Double Exclamation Mark: ‼)
 #endif
 
 #if WCHAR_DISC
+const wchar wc_const = L'*';
 @topic
 union WcharUnion switch (@key wchar) {
 case L'a':
   long a;
+case wc_const:
+  long const_branch;
+#if WCHAR_ESC_SEQ
 case L'\n':
   long newline;
 case L'\t':
@@ -113,19 +121,12 @@ case L'\'':
   long single_quote;
 case L'\"':
   long double_quote;
-case L'\0':
-  long oct_0;
-case L'\377':
-  long oct_255;
-case L'\x1':
-  long hex_1;
-case L'\xfe':
-  long hex_254;
 case L'\u203C':
   long u_escape;
+#endif
 default:
   long defualt_member;
-}
+};
 #endif
 
 /* TODO(iguessthislldo): config-linux.h doesn't seem to have ACE_HAS_WCHAR


### PR DESCRIPTION
https://github.com/DOCGroup/ACE_TAO/pull/2244 sets `TAO_IDL_HAS_OCTET_AND_WCHAR_UNION_DISCS` to 1, but the char_literals wchar union contains all the escape sequences literals, which are not supported in TAO_IDL: https://github.com/DOCGroup/ACE_TAO/issues/1284. This changes it to check the planned macro name.

Also removed the hex and octet escape sequences for wchar, which are probably not indented to work with wchar.