### PR TITLE
MAX_SPDP_SEQUENCE_MSG_RESET_CHECK lacks an "s"

### DIFF
--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -151,8 +151,8 @@ public:
   DCPS::TimeDuration auth_resend_period() const { return config_->auth_resend_period(); }
   void auth_resend_period(const DCPS::TimeDuration& x) { config_->auth_resend_period(x); }
 
-  u_short max_spdp_sequence_msg_reset_check() const { return config_->max_spdp_sequence_msg_reset_check(); }
-  void max_spdp_sequence_msg_reset_check(u_short reset_value) { config_->max_spdp_sequence_msg_reset_check(reset_value); }
+  u_short max_spdp_sequence_msg_reset_checks() const { return config_->max_spdp_sequence_msg_reset_checks(); }
+  void max_spdp_sequence_msg_reset_checks(u_short reset_value) { config_->max_spdp_sequence_msg_reset_checks(reset_value); }
 
   bool rtps_relay_only() const { return config_->rtps_relay_only(); }
   void rtps_relay_only_now(bool f);

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -713,16 +713,16 @@ RtpsDiscoveryConfig::auth_resend_period(const DCPS::TimeDuration& x)
 }
 
 u_short
-RtpsDiscoveryConfig::max_spdp_sequence_msg_reset_check() const
+RtpsDiscoveryConfig::max_spdp_sequence_msg_reset_checks() const
 {
-  return TheServiceParticipant->config_store()->get_uint32(config_key("MAX_SPDP_SEQUENCE_MSG_RESET_CHECK").c_str(),
+  return TheServiceParticipant->config_store()->get_uint32(config_key("MAX_SPDP_SEQUENCE_MSG_RESET_CHECKS").c_str(),
                                                            3);
 }
 
 void
-RtpsDiscoveryConfig::max_spdp_sequence_msg_reset_check(u_short reset_value)
+RtpsDiscoveryConfig::max_spdp_sequence_msg_reset_checks(u_short reset_value)
 {
-  TheServiceParticipant->config_store()->set_uint32(config_key("MAX_SPDP_SEQUENCE_MSG_RESET_CHECK").c_str(),
+  TheServiceParticipant->config_store()->set_uint32(config_key("MAX_SPDP_SEQUENCE_MSG_RESET_CHECKS").c_str(),
                                                     reset_value);
 }
 

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
@@ -167,8 +167,8 @@ public:
   DCPS::TimeDuration auth_resend_period() const;
   void auth_resend_period(const DCPS::TimeDuration& x);
 
-  u_short max_spdp_sequence_msg_reset_check() const;
-  void max_spdp_sequence_msg_reset_check(u_short reset_value);
+  u_short max_spdp_sequence_msg_reset_checks() const;
+  void max_spdp_sequence_msg_reset_checks(u_short reset_value);
 
   DCPS::NetworkAddress spdp_rtps_relay_address() const;
   void spdp_rtps_relay_address(const DCPS::NetworkAddress& address);

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -235,7 +235,7 @@ Spdp::Spdp(DDS::DomainId_t domain,
   , lease_duration_(disco_->config()->lease_duration())
   , lease_extension_(disco_->config()->lease_extension())
   , max_lease_duration_(disco_->config()->max_lease_duration())
-  , max_spdp_sequence_msg_reset_check_(disco->config()->max_spdp_sequence_msg_reset_check())
+  , max_spdp_sequence_msg_reset_checks_(disco->config()->max_spdp_sequence_msg_reset_checks())
   , check_source_ip_(disco->config()->check_source_ip())
   , undirected_spdp_(disco->config()->undirected_spdp())
 #if OPENDDS_CONFIG_SECURITY
@@ -300,7 +300,7 @@ Spdp::Spdp(DDS::DomainId_t domain,
   , lease_duration_(disco_->config()->lease_duration())
   , lease_extension_(disco_->config()->lease_extension())
   , max_lease_duration_(disco_->config()->max_lease_duration())
-  , max_spdp_sequence_msg_reset_check_(disco->config()->max_spdp_sequence_msg_reset_check())
+  , max_spdp_sequence_msg_reset_checks_(disco->config()->max_spdp_sequence_msg_reset_checks())
   , check_source_ip_(disco->config()->check_source_ip())
   , undirected_spdp_(disco->config()->undirected_spdp())
   , max_participants_in_authentication_(disco->config()->max_participants_in_authentication())
@@ -1042,7 +1042,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
       process_location_updates_i(iter, "valid SPDP", secure_part_user_data());
 #endif
     // Else a reset has occurred and check if we should remove the participant
-    } else if (iter->second.seq_reset_count_ >= max_spdp_sequence_msg_reset_check_) {
+    } else if (iter->second.seq_reset_count_ >= max_spdp_sequence_msg_reset_checks_) {
 #if OPENDDS_CONFIG_SECURITY
       purge_handshake_deadlines(iter);
 #endif

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -387,7 +387,7 @@ private:
   const DCPS::TimeDuration lease_duration_;
   const DCPS::TimeDuration lease_extension_;
   const DCPS::TimeDuration max_lease_duration_;
-  const u_short max_spdp_sequence_msg_reset_check_;
+  const u_short max_spdp_sequence_msg_reset_checks_;
   const bool check_source_ip_;
   const bool undirected_spdp_;
 #if OPENDDS_CONFIG_SECURITY

--- a/docs/news.d/msg_reset_checks.rst
+++ b/docs/news.d/msg_reset_checks.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4696
+
+.. news-start-section: Fixes
+- :cfg:prop:`[rtps_discovery]MaxSpdpSequenceMsgResetChecks` is recognized again.
+.. news-end-section


### PR DESCRIPTION
Problem
-------

The config store reads `MAX_SPDP_SEQUENCE_MSG_RESET_CHECK` instead of `MAX_SPDP_SEQUENCE_MSG_RESET_CHECKS`.

Solution
--------

Add an "s".

Notes
-----

Introduced in #4361.

This may explain Thrasher test failures which use this feature.