### PR TITLE
Arguments to the Windows ishapes build are over-quoted

### DIFF
--- a/.github/workflows/ishapes.yml
+++ b/.github/workflows/ishapes.yml
@@ -92,9 +92,9 @@ jobs:
         cd OpenDDS
         perl configure --optimize --no-debug --static --tests ^
           "--qt=%VCPKG_INSTALLED_DIR%/x64-windows" ^
-          "--mpc:value_template platforms=x64" ^
-          "--mpc:value_template configurations=Release" ^
-          "--mpc:value_template Release::runtime_library=MultiThreadedDLL"
+          --mpc:value_template platforms=x64 ^
+          --mpc:value_template configurations=Release ^
+          --mpc:value_template Release::runtime_library=MultiThreadedDLL
         tools\scripts\show_build_config.pl
     - name: build
       shell: cmd


### PR DESCRIPTION
Problem
-------

The `--mpc` argument to the Windows ishapes contains the "value."

Solution
--------

Split the argument into a `--mpc` argument and a `key=value` pair.