### PR TITLE
Removed the "expand" section of rapidjson.mpb

### DIFF
--- a/MPC/config/rapidjson.mpb
+++ b/MPC/config/rapidjson.mpb
@@ -1,10 +1,5 @@
 project {
   avoids += no_rapidjson
-
-  expand(RAPIDJSON_ROOT) {
-    $RAPIDJSON_ROOT
-    $(DDS_ROOT)/tools/rapidjson
-  }
   includes += $(RAPIDJSON_ROOT)/include
   macros   += OPENDDS_RAPIDJSON
 }


### PR DESCRIPTION
Expanding the variable here is useful because it provides a default value when RAPIDJSON_ROOT is not set in the environment.

However, it always results in makefiles that hard-code the expansion value (absolute path to rapidjson, may be in DDS_ROOT).

With this change, if the MPC feature no_rapidjson is 0 then the RAPIDJSON_ROOT environment variable needs to be set either by the configure script or manually.