### PR TITLE
RtpsRelay tests don't have CheckSourceIp=false

### DIFF
--- a/tests/DCPS/RtpsRelay/Smoke/relay1.ini
+++ b/tests/DCPS/RtpsRelay/Smoke/relay1.ini
@@ -23,3 +23,4 @@ RtpsRelayOnly=1
 SedpMaxMessageSize=1400
 UndirectedSpdp=0
 PeriodicDirectedSpdp=1
+CheckSourceIp=false

--- a/tests/DCPS/RtpsRelay/Smoke/relay2.ini
+++ b/tests/DCPS/RtpsRelay/Smoke/relay2.ini
@@ -23,3 +23,4 @@ RtpsRelayOnly=1
 SedpMaxMessageSize=1400
 UndirectedSpdp=0
 PeriodicDirectedSpdp=1
+CheckSourceIp=false


### PR DESCRIPTION
Problem
-------

The RtpsRelay tests are a starting poing to users that want to use the RtpsRelay.  In any realistic deployment, the user must have `CheckSourceIp=false` in the configuration file.  Since the tests don't have this line, the user will have to learn "the hard way."

Solution
--------

Add `CheckSourceIp=false` to the configuration files.