### PR TITLE
Fix Locator Memory Leak in RTPS/UDP Transport

### DIFF
--- a/dds/DCPS/RTPS/DiscoveredEntities.h
+++ b/dds/DCPS/RTPS/DiscoveredEntities.h
@@ -106,8 +106,7 @@ struct DiscoveredParticipant {
     , participant_tokens_sent_(false)
 #endif
   {
-    const DCPS::GUID_t guid = DCPS::make_part_guid(p.participantProxy.guidPrefix);
-    assign(location_data_.guid, guid);
+    assign(location_data_.guid, make_part_guid());
     location_data_.location = 0;
     location_data_.change_mask = 0;
     location_data_.local_timestamp.sec = 0;
@@ -206,6 +205,21 @@ struct DiscoveredParticipant {
     return pdata_.dataKind == Security::DPDK_ENHANCED || pdata_.dataKind == Security::DPDK_SECURE;
   }
 #endif
+
+  const DCPS::GuidPrefix_t& prefix() const
+  {
+    return pdata_.participantProxy.guidPrefix;
+  }
+
+  DCPS::GUID_t make_guid(const DCPS::EntityId_t& entity) const
+  {
+    return DCPS::make_id(prefix(), entity);
+  }
+
+  DCPS::GUID_t make_part_guid() const
+  {
+    return DCPS::make_part_guid(prefix());
+  }
 };
 
 struct DiscoveredSubscription : DCPS::PoolAllocationBase {

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -1088,54 +1088,58 @@ Sedp::associate(DiscoveredParticipant& participant
   const BuiltinEndpointSet_t remote_available = participant.pdata_.participantProxy.availableBuiltinEndpoints;
   const BuiltinEndpointQos_t& beq = participant.pdata_.participantProxy.builtinEndpointQos;
 
+  static const int rel_dur = AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE;
+  const int part_mesg = AC_REMOTE_DURABLE |
+    ((beq & BEST_EFFORT_PARTICIPANT_MESSAGE_DATA_READER) ? AC_EMPTY : AC_REMOTE_RELIABLE);
+
   // See RTPS v2.1 section 8.5.5.1
   if ((local_available & DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR) &&
       (remote_available & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER)) {
     BuiltinAssociationRecord record(publications_reader_,
-                                    make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER),
-                                    AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE);
+                                    participant.make_guid(ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER),
+                                    rel_dur);
     participant.builtin_pending_records_.push_back(record);
   }
   if ((local_available & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR) &&
       (remote_available & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER)) {
     BuiltinAssociationRecord record(subscriptions_reader_,
-                                    make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER),
-                                    AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE);
+                                    participant.make_guid(ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER),
+                                    rel_dur);
     participant.builtin_pending_records_.push_back(record);
   }
   if ((local_available & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER) &&
       (remote_available & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER)) {
     BuiltinAssociationRecord record(participant_message_reader_,
-                                    make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER),
-                                    AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE);
+                                    participant.make_guid(ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_WRITER),
+                                    rel_dur);
     participant.builtin_pending_records_.push_back(record);
   }
 
   if ((local_available & BUILTIN_ENDPOINT_TYPE_LOOKUP_REQUEST_DATA_READER) &&
       (remote_available & BUILTIN_ENDPOINT_TYPE_LOOKUP_REQUEST_DATA_WRITER)) {
     BuiltinAssociationRecord record(type_lookup_request_reader_,
-                                    make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_TL_SVC_REQ_WRITER),
+                                    participant.make_guid(ENTITYID_TL_SVC_REQ_WRITER),
                                     AC_REMOTE_RELIABLE);
     participant.builtin_pending_records_.push_back(record);
   }
   if ((local_available & BUILTIN_ENDPOINT_TYPE_LOOKUP_REQUEST_DATA_WRITER) &&
       (remote_available & BUILTIN_ENDPOINT_TYPE_LOOKUP_REQUEST_DATA_READER)) {
     BuiltinAssociationRecord record(type_lookup_request_writer_,
-                                    make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_TL_SVC_REQ_READER),
+                                    participant.make_guid(ENTITYID_TL_SVC_REQ_READER),
                                     AC_REMOTE_RELIABLE);
     participant.builtin_pending_records_.push_back(record);
   }
   if ((local_available & BUILTIN_ENDPOINT_TYPE_LOOKUP_REPLY_DATA_READER) &&
       (remote_available & BUILTIN_ENDPOINT_TYPE_LOOKUP_REPLY_DATA_WRITER)) {
     BuiltinAssociationRecord record(type_lookup_reply_reader_,
-                                    make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_TL_SVC_REPLY_WRITER),
+                                    participant.make_guid(ENTITYID_TL_SVC_REPLY_WRITER),
                                     AC_REMOTE_RELIABLE);
     participant.builtin_pending_records_.push_back(record);
   }
   if ((local_available & BUILTIN_ENDPOINT_TYPE_LOOKUP_REPLY_DATA_WRITER) &&
       (remote_available & BUILTIN_ENDPOINT_TYPE_LOOKUP_REPLY_DATA_READER)) {
     BuiltinAssociationRecord record(type_lookup_reply_writer_,
-                                    make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_TL_SVC_REPLY_READER),
+                                    participant.make_guid(ENTITYID_TL_SVC_REPLY_READER),
                                     AC_REMOTE_RELIABLE);
     participant.builtin_pending_records_.push_back(record);
   }
@@ -1143,22 +1147,22 @@ Sedp::associate(DiscoveredParticipant& participant
   if ((local_available & DISC_BUILTIN_ENDPOINT_PUBLICATION_ANNOUNCER) &&
       (remote_available & DISC_BUILTIN_ENDPOINT_PUBLICATION_DETECTOR)) {
     BuiltinAssociationRecord record(publications_writer_,
-                                    make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER),
-                                    AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE);
+                                    participant.make_guid(ENTITYID_SEDP_BUILTIN_PUBLICATIONS_READER),
+                                    rel_dur);
     participant.builtin_pending_records_.push_back(record);
   }
   if ((local_available & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_ANNOUNCER) &&
       (remote_available & DISC_BUILTIN_ENDPOINT_SUBSCRIPTION_DETECTOR)) {
     BuiltinAssociationRecord record(subscriptions_writer_,
-                                    make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER),
-                                    AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE);
+                                    participant.make_guid(ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_READER),
+                                    rel_dur);
     participant.builtin_pending_records_.push_back(record);
   }
   if ((local_available & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER) &&
       (remote_available & BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_READER)) {
     BuiltinAssociationRecord record(participant_message_writer_,
-                                    make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER),
-                                    ((beq & BEST_EFFORT_PARTICIPANT_MESSAGE_DATA_READER) ? AC_EMPTY : AC_REMOTE_RELIABLE) | AC_REMOTE_DURABLE);
+                                    participant.make_guid(ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_READER),
+                                    part_mesg);
     participant.builtin_pending_records_.push_back(record);
   }
 
@@ -1171,10 +1175,15 @@ Sedp::associate(DiscoveredParticipant& participant
     const ExtendedBuiltinEndpointSet_t local_available_extended = spdp_.available_extended_builtin_endpoints();
     const ExtendedBuiltinEndpointSet_t remote_available_extended = participant.pdata_.participantProxy.availableExtendedBuiltinEndpoints;
 
+    const int send_token_if_disc_protected = AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE |
+      (participant_sec_attr.is_discovery_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY);
+    const int send_token_if_live_protected = AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE |
+      (participant_sec_attr.is_liveliness_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY);
+
     if ((local_available & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER) &&
         (remote_available & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER)) {
       BuiltinAssociationRecord record(participant_stateless_message_reader_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER),
+                                      participant.make_guid(ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_WRITER),
                                       AC_EMPTY);
       participant.builtin_pending_records_.push_back(record);
     }
@@ -1182,7 +1191,7 @@ Sedp::associate(DiscoveredParticipant& participant
     if ((local_available & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_WRITER) &&
         (remote_available & BUILTIN_PARTICIPANT_STATELESS_MESSAGE_READER)) {
       BuiltinAssociationRecord record(participant_stateless_message_writer_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER),
+                                      participant.make_guid(ENTITYID_P2P_BUILTIN_PARTICIPANT_STATELESS_READER),
                                       AC_EMPTY);
       participant.builtin_pending_records_.push_back(record);
     }
@@ -1190,14 +1199,14 @@ Sedp::associate(DiscoveredParticipant& participant
     if ((local_available & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER) &&
         (remote_available & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER)) {
       BuiltinAssociationRecord record(participant_volatile_message_secure_reader_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER),
+                                      participant.make_guid(ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER),
                                       AC_REMOTE_RELIABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE);
       participant.builtin_pending_records_.push_back(record);
     }
     if ((local_available & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER) &&
         (remote_available & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER)) {
       BuiltinAssociationRecord record(participant_volatile_message_secure_writer_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER),
+                                      participant.make_guid(ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER),
                                       AC_REMOTE_RELIABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE);
       participant.builtin_pending_records_.push_back(record);
     }
@@ -1205,87 +1214,87 @@ Sedp::associate(DiscoveredParticipant& participant
     if ((local_available & BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER) &&
         (remote_available & BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER)) {
       BuiltinAssociationRecord record(participant_message_secure_reader_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER),
-                                      AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE | (participant_sec_attr.is_liveliness_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY));
+                                      participant.make_guid(ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER),
+                                      rel_dur | send_token_if_live_protected);
       participant.builtin_pending_records_.push_back(record);
     }
     if ((local_available & SPDP_BUILTIN_PARTICIPANT_SECURE_READER) &&
         (remote_available & SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER)) {
       BuiltinAssociationRecord record(dcps_participant_secure_reader_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER),
-                                      AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE | (participant_sec_attr.is_discovery_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY));
+                                      participant.make_guid(ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_WRITER),
+                                      rel_dur | send_token_if_disc_protected);
       participant.builtin_pending_records_.push_back(record);
     }
     if ((local_available & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER) &&
         (remote_available & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER)) {
       BuiltinAssociationRecord record(publications_secure_reader_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER),
-                                      AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE | (participant_sec_attr.is_discovery_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY));
+                                      participant.make_guid(ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER),
+                                      rel_dur | send_token_if_disc_protected);
       participant.builtin_pending_records_.push_back(record);
     }
     if ((local_available & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER) &&
         (remote_available & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER)) {
       BuiltinAssociationRecord record(subscriptions_secure_reader_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER),
-                                      AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE | (participant_sec_attr.is_discovery_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY));
+                                      participant.make_guid(ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER),
+                                      rel_dur | send_token_if_disc_protected);
       participant.builtin_pending_records_.push_back(record);
     }
 
     if ((local_available_extended & TYPE_LOOKUP_SERVICE_REQUEST_SECURE_READER) &&
         (remote_available_extended & TYPE_LOOKUP_SERVICE_REQUEST_SECURE_WRITER)) {
       BuiltinAssociationRecord record(type_lookup_request_secure_reader_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_TL_SVC_REQ_SECURE_WRITER),
-                                      AC_REMOTE_RELIABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE | (participant_sec_attr.is_discovery_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY));
+                                      participant.make_guid(ENTITYID_TL_SVC_REQ_SECURE_WRITER),
+                                      AC_REMOTE_RELIABLE | send_token_if_disc_protected);
       participant.builtin_pending_records_.push_back(record);
     }
     if ((local_available_extended & TYPE_LOOKUP_SERVICE_REQUEST_SECURE_WRITER) &&
         (remote_available_extended & TYPE_LOOKUP_SERVICE_REQUEST_SECURE_READER)) {
       BuiltinAssociationRecord record(type_lookup_request_secure_writer_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_TL_SVC_REQ_SECURE_READER),
-                                      AC_REMOTE_RELIABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE | (participant_sec_attr.is_discovery_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY));
+                                      participant.make_guid(ENTITYID_TL_SVC_REQ_SECURE_READER),
+                                      AC_REMOTE_RELIABLE | send_token_if_disc_protected);
       participant.builtin_pending_records_.push_back(record);
     }
     if ((local_available_extended & TYPE_LOOKUP_SERVICE_REPLY_SECURE_READER) &&
         (remote_available_extended & TYPE_LOOKUP_SERVICE_REPLY_SECURE_WRITER)) {
       BuiltinAssociationRecord record(type_lookup_reply_secure_reader_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_TL_SVC_REPLY_SECURE_WRITER),
-                                      AC_REMOTE_RELIABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE | (participant_sec_attr.is_discovery_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY));
+                                      participant.make_guid(ENTITYID_TL_SVC_REPLY_SECURE_WRITER),
+                                      AC_REMOTE_RELIABLE | send_token_if_disc_protected);
       participant.builtin_pending_records_.push_back(record);
     }
     if ((local_available_extended & TYPE_LOOKUP_SERVICE_REPLY_SECURE_WRITER) &&
         (remote_available_extended & TYPE_LOOKUP_SERVICE_REPLY_SECURE_READER)) {
       BuiltinAssociationRecord record(type_lookup_reply_secure_writer_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_TL_SVC_REPLY_SECURE_READER),
-                                      AC_REMOTE_RELIABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE | (participant_sec_attr.is_discovery_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY));
+                                      participant.make_guid(ENTITYID_TL_SVC_REPLY_SECURE_READER),
+                                      AC_REMOTE_RELIABLE | send_token_if_disc_protected);
       participant.builtin_pending_records_.push_back(record);
     }
 
     if ((local_available & BUILTIN_PARTICIPANT_MESSAGE_SECURE_WRITER) &&
         (remote_available & BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER)) {
       BuiltinAssociationRecord record(participant_message_secure_writer_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER),
-                                      ((beq & BEST_EFFORT_PARTICIPANT_MESSAGE_DATA_READER) ? AC_EMPTY : AC_REMOTE_RELIABLE) | AC_REMOTE_DURABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE | (participant_sec_attr.is_liveliness_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY));
+                                      participant.make_guid(ENTITYID_P2P_BUILTIN_PARTICIPANT_MESSAGE_SECURE_READER),
+                                      part_mesg | send_token_if_live_protected);
       participant.builtin_pending_records_.push_back(record);
     }
     if ((local_available & SPDP_BUILTIN_PARTICIPANT_SECURE_WRITER) &&
         (remote_available & SPDP_BUILTIN_PARTICIPANT_SECURE_READER)) {
       BuiltinAssociationRecord record(dcps_participant_secure_writer_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER),
-                                      AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE | (participant_sec_attr.is_discovery_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY));
+                                      participant.make_guid(ENTITYID_SPDP_RELIABLE_BUILTIN_PARTICIPANT_SECURE_READER),
+                                      rel_dur | send_token_if_disc_protected);
       participant.builtin_pending_records_.push_back(record);
     }
     if ((local_available & SEDP_BUILTIN_PUBLICATIONS_SECURE_WRITER) &&
         (remote_available & SEDP_BUILTIN_PUBLICATIONS_SECURE_READER)) {
       BuiltinAssociationRecord record(publications_secure_writer_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER),
-                                      AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE | (participant_sec_attr.is_discovery_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY));
+                                      participant.make_guid(ENTITYID_SEDP_BUILTIN_PUBLICATIONS_SECURE_READER),
+                                      rel_dur | send_token_if_disc_protected);
       participant.builtin_pending_records_.push_back(record);
     }
     if ((local_available & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_WRITER) &&
         (remote_available & SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER)) {
       BuiltinAssociationRecord record(subscriptions_secure_writer_,
-                                      make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER),
-                                      AC_REMOTE_RELIABLE | AC_REMOTE_DURABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE | (participant_sec_attr.is_discovery_protected ? AC_SEND_LOCAL_TOKEN : AC_EMPTY));
+                                      participant.make_guid(ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_SECURE_READER),
+                                      rel_dur | send_token_if_disc_protected);
       participant.builtin_pending_records_.push_back(record);
     }
   }
@@ -1293,7 +1302,7 @@ Sedp::associate(DiscoveredParticipant& participant
 
   if (spdp_.shutting_down()) { return; }
 
-  associated_participants_.insert(make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_PARTICIPANT));
+  associated_participants_.insert(participant.make_part_guid());
 
   process_association_records_i(participant);
 }
@@ -1383,8 +1392,8 @@ void Sedp::disassociate_volatile(DiscoveredParticipant& participant)
 {
   const GUID_t local_writer = make_id(participant_id_, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER);
   const GUID_t local_reader = make_id(participant_id_, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER);
-  const GUID_t remote_writer = make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER);
-  const GUID_t remote_reader = make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER);
+  const GUID_t remote_writer = participant.make_guid(ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER);
+  const GUID_t remote_reader = participant.make_guid(ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER);
 
   for (DiscoveredParticipant::BuiltinAssociationRecords::iterator pos = participant.builtin_pending_records_.begin(),
          limit = participant.builtin_pending_records_.end(); pos != limit;) {
@@ -1429,29 +1438,16 @@ void Sedp::associate_volatile(DiscoveredParticipant& participant)
   if ((local_available & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER) &&
       (remote_available & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER)) {
     BuiltinAssociationRecord record(participant_volatile_message_secure_reader_,
-                                    make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER),
+                                    participant.make_guid(ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_WRITER),
                                     AC_REMOTE_RELIABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE);
     participant.builtin_pending_records_.push_back(record);
   }
   if ((local_available & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_WRITER) &&
       (remote_available & BUILTIN_PARTICIPANT_VOLATILE_MESSAGE_SECURE_READER)) {
     BuiltinAssociationRecord record(participant_volatile_message_secure_writer_,
-                                    make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER),
+                                    participant.make_guid(ENTITYID_P2P_BUILTIN_PARTICIPANT_VOLATILE_SECURE_READER),
                                     AC_REMOTE_RELIABLE | AC_GENERATE_REMOTE_MATCHED_CRYPTO_HANDLE);
     participant.builtin_pending_records_.push_back(record);
-  }
-}
-#endif
-
-#if OPENDDS_CONFIG_SECURITY
-
-void disassociate_helper_extended(DDS::Security::ExtendedBuiltinEndpointSet_t& extended_associated_endpoints,
-                                  const CORBA::ULong flags, const DCPS::GUID_t& id, const EntityId_t& ent,
-                                  DCPS::TransportClient& client)
-{
-  if (extended_associated_endpoints & flags) {
-    client.disassociate(make_id(id, ent));
-    extended_associated_endpoints &= ~flags;
   }
 }
 
@@ -1580,7 +1576,7 @@ Sedp::send_builtin_crypto_tokens(const DCPS::GUID_t& remoteId)
 void
 Sedp::disassociate(DiscoveredParticipant& participant)
 {
-  const GUID_t part = make_id(participant.pdata_.participantProxy.guidPrefix, ENTITYID_PARTICIPANT);
+  const GUID_t part = participant.make_part_guid();
 
   associated_participants_.erase(part);
 
@@ -3188,7 +3184,8 @@ Sedp::signal_liveliness_secure(DDS::LivelinessQosPolicyKind kind)
 }
 #endif
 
-DCPS::WeakRcHandle<ICE::Endpoint> Sedp::get_ice_endpoint() {
+DCPS::WeakRcHandle<ICE::Endpoint> Sedp::get_ice_endpoint()
+{
   return transport_inst_->get_ice_endpoint(get_domain_id(), 0);
 }
 
@@ -3571,14 +3568,13 @@ Sedp::DiscoveryWriter::write_unregister_dispose(const GUID_t& rid, CORBA::UShort
   DCPS::EncapsulationHeader encap;
   if (from_encoding(encap, sedp_encoding, DCPS::MUTABLE) &&
       serializer << encap && serializer << plist) {
-    // Send
     write_control_msg(OPENDDS_MOVE_NS::move(payload), size, DCPS::DISPOSE_UNREGISTER_INSTANCE);
     return DDS::RETCODE_OK;
   } else {
-    // Error
-    ACE_ERROR((LM_ERROR,
-               ACE_TEXT("(%P|%t) ERROR: Sedp::Writer::write_unregister_dispose")
-               ACE_TEXT(" - Failed to serialize RTPS control message\n")));
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Sedp::Writer::write_unregister_dispose: "
+                 "Failed to serialize RTPS control message\n"));
+    }
     return DDS::RETCODE_ERROR;
   }
 }

--- a/dds/DCPS/transport/framework/DataLink.cpp
+++ b/dds/DCPS/transport/framework/DataLink.cpp
@@ -509,8 +509,8 @@ DataLink::peer_ids(const GUID_t& local_id) const
 /// with a simultaneous call (in another thread) to one of this
 /// DataLink's make_reservation() methods.
 void
-DataLink::release_reservations(GUID_t remote_id, GUID_t local_id,
-                               DataLinkSetMap& released_locals)
+DataLink::release_reservations(const GUID_t& remote_id, const GUID_t& local_id,
+                               DataLinkSetMap* released_locals)
 {
   DBG_ENTRY_LVL("DataLink", "release_reservations", 6);
 
@@ -550,11 +550,13 @@ DataLink::release_reservations(GUID_t remote_id, GUID_t local_id,
     }
     RepoIdSet& ris = assoc_by_local_[local_id].associated_;
     if (ris.size() == 1) {
-      DataLinkSet_rch& links = released_locals[local_id];
-      if (links.is_nil()) {
-        links = make_rch<DataLinkSet>();
+      if (released_locals) {
+        DataLinkSet_rch& links = (*released_locals)[local_id];
+        if (links.is_nil()) {
+          links = make_rch<DataLinkSet>();
+        }
+        links->insert_link(rchandle_from(this));
       }
-      links->insert_link(rchandle_from(this));
       assoc_by_local_.erase(local_id);
     } else {
       ris.erase(remote_id);

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -128,9 +128,9 @@ public:
   /// make_reservation() methods.  All we know is that the supplied
   /// GUID_t is considered to be a remote id.  It could be a
   /// remote subscriber or a remote publisher.
-  void release_reservations(GUID_t          remote_id,
-                            GUID_t          local_id,
-                            DataLinkSetMap& released_locals);
+  void release_reservations(const GUID_t& remote_id,
+                            const GUID_t& local_id,
+                            DataLinkSetMap* released_locals = 0);
 
   void schedule_delayed_release();
 

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -768,7 +768,7 @@ TransportClient::disassociate(const GUID_t& peerId)
   }
 
   OPENDDS_ASSERT(guid_ != GUID_UNKNOWN);
-  link->release_reservations(peerId, guid_, released);
+  link->release_reservations(peerId, guid_, &released);
 
   if (!released.empty()) {
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -957,14 +957,14 @@ RtpsUdpDataLink::release_reservations_i(const GUID_t& remote_id,
     RemoteInfoMap::iterator pos = locators_.find(remote_id);
     if (pos != locators_.end()) {
       OPENDDS_ASSERT(pos->second.ref_count_ > 0);
-
-      --pos->second.ref_count_;
-      if (pos->second.ref_count_ == 0) {
+      if (--pos->second.ref_count_ == 0) {
         locators_.erase(pos);
       }
     } else if (Transport_debug_level >= 4) {
-      ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::disassociated: "
-        "remote id %C does not have any locators\n", String(conv).c_str()));
+      g.release();
+      ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::release_reservations_i: "
+        "%C doesn't not have any locators with remote %C\n",
+        String(conv).c_str(), LogGuid(remote_id).c_str()));
     }
   }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -486,9 +486,9 @@ RtpsUdpDataLink::update_locators(const GUID_t& remote_id,
                                  bool requires_inline_qos,
                                  bool add_ref)
 {
-  const bool log_error = log_level >= LogLevel::Error;
-  if (log_error && unicast_addresses.empty() && multicast_addresses.empty()) {
-    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RtpsUdpDataLink::update_locators: "
+  const bool log_warn = log_level >= LogLevel::Warning;
+  if (log_warn && unicast_addresses.empty() && multicast_addresses.empty()) {
+    ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: RtpsUdpDataLink::update_locators: "
       "no addresses for %C\n", LogGuid(remote_id).c_str()));
   }
 
@@ -503,9 +503,9 @@ RtpsUdpDataLink::update_locators(const GUID_t& remote_id,
     RemoteInfoMap::iterator it = locators_.find(remote_id);
     locators_.find(remote_id);
     if (it == locators_.end()) {
-      if (log_error) {
+      if (log_warn) {
         g.release();
-        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RtpsUdpDataLink::update_locators: "
+        ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: RtpsUdpDataLink::update_locators: "
           "no existing locators to update for %C\n", LogGuid(remote_id).c_str()));
       }
       return;
@@ -513,9 +513,9 @@ RtpsUdpDataLink::update_locators(const GUID_t& remote_id,
     info = &it->second;
   }
 
-  const bool log = DCPS_debug_level >= 4;
-  const bool log_unicast_change = log && info->unicast_addrs_ != unicast_addresses;
-  const bool log_multicast_change = log && info->multicast_addrs_ != multicast_addresses;
+  const bool log_change = DCPS_debug_level >= 4;
+  const bool log_unicast_change = log_change && info->unicast_addrs_ != unicast_addresses;
+  const bool log_multicast_change = log_change && info->multicast_addrs_ != multicast_addresses;
   info->unicast_addrs_.swap(unicast_addresses);
   info->multicast_addrs_.swap(multicast_addresses);
   info->requires_inline_qos_ = requires_inline_qos;

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -45,7 +45,8 @@
 
 namespace {
 
-bool compare_and_update_counts(CORBA::Long incoming, CORBA::Long& existing) {
+bool compare_and_update_counts(CORBA::Long incoming, CORBA::Long& existing)
+{
   static const CORBA::Long ONE_QUARTER_MAX_POSITIVE = 0x20000000;
   static const CORBA::Long THREE_QUARTER_MAX_POSITIVE = 0x60000000;
   if (incoming <= existing &&
@@ -485,24 +486,41 @@ RtpsUdpDataLink::update_locators(const GUID_t& remote_id,
                                  bool requires_inline_qos,
                                  bool add_ref)
 {
-  if (unicast_addresses.empty() && multicast_addresses.empty()) {
-    if (DCPS_debug_level > 0) {
-      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: RtpsUdpDataLink::update_locators: no addresses for %C\n"), LogGuid(remote_id).c_str()));
-    }
+  const bool log_error = log_level >= LogLevel::Error;
+  if (log_error && unicast_addresses.empty() && multicast_addresses.empty()) {
+    ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RtpsUdpDataLink::update_locators: "
+      "no addresses for %C\n", LogGuid(remote_id).c_str()));
   }
 
   remove_locator_and_bundling_cache(remote_id);
 
   ACE_GUARD(ACE_Thread_Mutex, g, locators_lock_);
 
-  RemoteInfo& info = locators_[remote_id];
-  const bool log_unicast_change = DCPS_debug_level > 3 && info.unicast_addrs_ != unicast_addresses;
-  const bool log_multicast_change = DCPS_debug_level > 3 && info.multicast_addrs_ != multicast_addresses;
-  info.unicast_addrs_.swap(unicast_addresses);
-  info.multicast_addrs_.swap(multicast_addresses);
-  info.requires_inline_qos_ = requires_inline_qos;
+  RemoteInfo* info = 0;
   if (add_ref) {
-    ++info.ref_count_;
+    info = &locators_[remote_id];
+  } else {
+    RemoteInfoMap::iterator it = locators_.find(remote_id);
+    locators_.find(remote_id);
+    if (it == locators_.end()) {
+      if (log_error) {
+        g.release();
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RtpsUdpDataLink::update_locators: "
+          "no existing locators to update for %C\n", LogGuid(remote_id).c_str()));
+      }
+      return;
+    }
+    info = &it->second;
+  }
+
+  const bool log = DCPS_debug_level >= 4;
+  const bool log_unicast_change = log && info->unicast_addrs_ != unicast_addresses;
+  const bool log_multicast_change = log && info->multicast_addrs_ != multicast_addresses;
+  info->unicast_addrs_.swap(unicast_addresses);
+  info->multicast_addrs_.swap(multicast_addresses);
+  info->requires_inline_qos_ = requires_inline_qos;
+  if (add_ref) {
+    ++info->ref_count_;
   }
 
   g.release();
@@ -651,29 +669,6 @@ RtpsUdpDataLink::associated(const GUID_t& local_id, const GUID_t& remote_id,
   }
 
   return associated;
-}
-
-void
-RtpsUdpDataLink::disassociated(const GUID_t& local_id,
-                               const GUID_t& remote_id)
-{
-  release_reservations_i(remote_id, local_id);
-  remove_locator_and_bundling_cache(remote_id);
-  sq_.ignore_remote(remote_id);
-
-  ACE_GUARD(ACE_Thread_Mutex, g, locators_lock_);
-
-  RemoteInfoMap::iterator pos = locators_.find(remote_id);
-  if (pos != locators_.end()) {
-    OPENDDS_ASSERT(pos->second.ref_count_ > 0);
-
-    --pos->second.ref_count_;
-    if (pos->second.ref_count_ == 0) {
-      locators_.erase(pos);
-    }
-  } else if (Transport_debug_level > 3) {
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::disassociated: local id %C does not have any locators\n", LogGuid(local_id).c_str()));
-  }
 }
 
 void
@@ -955,6 +950,25 @@ RtpsUdpDataLink::release_reservations_i(const GUID_t& remote_id,
   }
 
   remove_locator_and_bundling_cache(remote_id);
+
+  {
+    ACE_GUARD(ACE_Thread_Mutex, g, locators_lock_);
+
+    RemoteInfoMap::iterator pos = locators_.find(remote_id);
+    if (pos != locators_.end()) {
+      OPENDDS_ASSERT(pos->second.ref_count_ > 0);
+
+      --pos->second.ref_count_;
+      if (pos->second.ref_count_ == 0) {
+        locators_.erase(pos);
+      }
+    } else if (Transport_debug_level >= 4) {
+      ACE_DEBUG((LM_DEBUG, "(%P|%t) RtpsUdpDataLink::disassociated: "
+        "remote id %C does not have any locators\n", String(conv).c_str()));
+    }
+  }
+
+  sq_.ignore_remote(remote_id);
 
   for (TqeVector::iterator drop_it = to_drop.begin(); drop_it != to_drop.end(); ++drop_it) {
     (*drop_it)->data_dropped(true);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -190,8 +190,6 @@ public:
                   const NetworkAddress& last_addr_hint,
                   bool requires_inline_qos);
 
-  void disassociated(const GUID_t& local, const GUID_t& remote);
-
   void register_for_reader(const GUID_t& writerid,
                            const GUID_t& readerid,
                            const NetworkAddressSet& addresses,
@@ -286,7 +284,7 @@ private:
     bool requires_inline_qos_;
     NetworkAddress last_recv_addr_;
     MonotonicTimePoint last_recv_time_;
-    size_t ref_count_;
+    DDS::UInt32 ref_count_;
     bool insert_recv_addr(NetworkAddressSet& aset) const;
   };
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -233,7 +233,7 @@ RtpsUdpTransport::stop_accepting_or_connecting(const TransportClient_wrch& clien
     if (link_) {
       TransportClient_rch c = client.lock();
       if (c) {
-        link_->disassociated(c->get_guid(), remote_id);
+        link_->release_reservations(c->get_guid(), remote_id);
       }
     }
   }

--- a/docs/news.d/rtps-udp-memory-leaks.rst
+++ b/docs/news.d/rtps-udp-memory-leaks.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4731
+
+.. news-start-section: Fixes
+- Fixed memory leak of remote locators in the RTPS/UDP transport.
+.. news-end-section

--- a/tools/rtpsrelay/GuidAddrSet.cpp
+++ b/tools/rtpsrelay/GuidAddrSet.cpp
@@ -26,8 +26,7 @@ GuidAddrSet::record_activity(const AddrPort& remote_address,
     auto result = remote_map_.insert(std::make_pair(remote, src_guid));
     if (result.second) {
       relay_stats_reporter_.remote_map_size(static_cast<uint32_t>(remote_map_.size()), now);
-    }
-    if (!result.second && result.first->second != src_guid) {
+    } else if (result.first->second != src_guid) {
       if (config_.log_activity()) {
         ACE_DEBUG((LM_INFO, ACE_TEXT("(%P|%t) INFO: GuidAddrSet::record_activity change detected %C -> %C\n"),
                    guid_to_string(result.first->second).c_str(),


### PR DESCRIPTION
Locators were not being cleaned up correctly because there were two functions for cleaning up after remotes in `RtpsUdpDataLink`. These changes merge those two functions.

Also:
- Don't create locator entries for unknown remotes in `RtpsUdpDataLink::update_locators`
- Change `RemoteInfo::ref_count_` from `size_t` to `DDS::UInt32` to save a bit of space in 64-bit builds. For example, if the RtpsRelay SEDP transport is serving 10,000 participants with a `RemoteInfo` for each participant's 12 remote builtin entities, then this saves almost half a megabyte of memory.
- Methods for getting GUIDs from `DiscoveredParticipant` to simplify code
- Remove an unused function in Sedp