### PR TITLE
Address warnings

### DIFF
--- a/dds/DCPS/ConfigStoreImpl.cpp
+++ b/dds/DCPS/ConfigStoreImpl.cpp
@@ -75,11 +75,11 @@ String ConfigPair::canonicalize(const String& key)
         if (!retval.empty() && retval[retval.size() - 1] != '_') {
           retval += '_';
         }
-        retval += ACE_OS::ace_toupper(x);
+        retval += static_cast<char>(ACE_OS::ace_toupper(x));
         ++idx;
         continue;
       } else if (ACE_OS::ace_islower(x) && ACE_OS::ace_isupper(y)) {
-        retval += ACE_OS::ace_toupper(x);
+        retval += static_cast<char>(ACE_OS::ace_toupper(x));
         if (!retval.empty() && retval[retval.size() - 1] != '_') {
           retval += '_';
         }
@@ -90,7 +90,7 @@ String ConfigPair::canonicalize(const String& key)
 
     // Deal with non-punctuation.
     if (ACE_OS::ace_isalnum(x)) {
-      retval += ACE_OS::ace_toupper(x);
+      retval += static_cast<char>(ACE_OS::ace_toupper(x));
       ++idx;
       continue;
     }

--- a/dds/DCPS/InstanceState.inl
+++ b/dds/DCPS/InstanceState.inl
@@ -150,7 +150,8 @@ OpenDDS::DCPS::InstanceState::empty(bool value)
   // Manage the instance state due to the DataReader becoming empty
   // here.
   //
-  if ((empty_ = value) && release_pending_) {
+  empty_ = value;
+  if (empty_ && release_pending_) {
     return release_if_empty();
   } else {
     return false;

--- a/dds/DCPS/NetworkResource.h
+++ b/dds/DCPS/NetworkResource.h
@@ -120,10 +120,10 @@ inline void assign(DDS::OctetArray16& dest,
                    ACE_CDR::ULong ipv4addr_be)
 {
   std::memset(&dest[0], 0, 12);
-  dest[12] = ipv4addr_be >> 24;
-  dest[13] = ipv4addr_be >> 16;
-  dest[14] = ipv4addr_be >> 8;
-  dest[15] = ipv4addr_be;
+  dest[12] = static_cast<ACE_CDR::Octet>(ipv4addr_be >> 24);
+  dest[13] = static_cast<ACE_CDR::Octet>(ipv4addr_be >> 16);
+  dest[14] = static_cast<ACE_CDR::Octet>(ipv4addr_be >> 8);
+  dest[15] = static_cast<ACE_CDR::Octet>(ipv4addr_be);
 }
 
 inline void

--- a/dds/idl/metaclass_generator.cpp
+++ b/dds/idl/metaclass_generator.cpp
@@ -524,8 +524,8 @@ metaclass_generator::gen_typedef(AST_Typedef*, UTL_ScopedName* name,
   AST_Type* type, const char*)
 {
   AST_Array* arr = dynamic_cast<AST_Array*>(type);
-  AST_Sequence* seq = 0;
-  if (!arr && !(seq = dynamic_cast<AST_Sequence*>(type))) {
+  AST_Sequence* seq = dynamic_cast<AST_Sequence*>(type);
+  if (!arr && !seq) {
     return true;
   }
   const bool use_cxx11 = be_global->language_mapping() == BE_GlobalData::LANGMAP_CXX11;

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -1413,7 +1413,7 @@ typeobject_generator::generate_sequence_type_identifier(AST_Type* type, bool for
         OpenDDS::XTypes::TypeIdentifier complete_ti(OpenDDS::XTypes::TI_PLAIN_SEQUENCE_SMALL);
         complete_ti.seq_sdefn().header.equiv_kind = complete_ek;
         complete_ti.seq_sdefn().header.element_flags = cef;
-        complete_ti.seq_sdefn().bound = static_cast<OpenDDS::XTypes::SBound>bound;
+        complete_ti.seq_sdefn().bound = static_cast<OpenDDS::XTypes::SBound>(bound);
         complete_ti.seq_sdefn().element_identifier = complete_elem_ti;
 
         const TypeIdentifierPair ti_pair = {minimal_ti, complete_ti};

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -977,10 +977,10 @@ typeobject_generator::strong_connect(AST_Type* type, const std::string& anonymou
       // Compute the final type objects with the final type identifiers.
       for (List::const_iterator pos = scc.begin(); pos != scc.end(); ++pos) {
         generate_type_identifier(pos->type, true);
-        const OpenDDS::XTypes::TypeIdentifier& minimal_ti = hash_type_identifier_map_[pos->type].minimal;
-        const OpenDDS::XTypes::TypeIdentifier& complete_ti = hash_type_identifier_map_[pos->type].complete;
-        minimal_type_map_[minimal_ti] = type_object_map_[pos->type].minimal;
-        complete_type_map_[complete_ti] = type_object_map_[pos->type].complete;
+        const OpenDDS::XTypes::TypeIdentifier& minimal_tid = hash_type_identifier_map_[pos->type].minimal;
+        const OpenDDS::XTypes::TypeIdentifier& complete_tid = hash_type_identifier_map_[pos->type].complete;
+        minimal_type_map_[minimal_tid] = type_object_map_[pos->type].minimal;
+        complete_type_map_[complete_tid] = type_object_map_[pos->type].complete;
       }
     }
   }
@@ -1154,7 +1154,7 @@ typeobject_generator::generate_union_type_identifier(AST_Type* type)
 
   for (Fields::Iterator i = fields.begin(); i != fields.end(); ++i) {
     AST_UnionBranch* branch = dynamic_cast<AST_UnionBranch*>(*i);
-    const TryConstructFailAction trycon = be_global->try_construct(branch);
+    const TryConstructFailAction try_con = be_global->try_construct(branch);
 
     bool is_default = false;
     for (unsigned long j = 0; j < branch->label_list_length(); ++j) {
@@ -1167,7 +1167,7 @@ typeobject_generator::generate_union_type_identifier(AST_Type* type)
 
     OpenDDS::XTypes::MinimalUnionMember minimal_member;
     minimal_member.common.member_id = be_global->get_id(branch);
-    minimal_member.common.member_flags = try_construct_to_member_flag(trycon);
+    minimal_member.common.member_flags = try_construct_to_member_flag(try_con);
 
     if (is_default) {
       minimal_member.common.member_flags |= OpenDDS::XTypes::IS_DEFAULT;
@@ -1316,7 +1316,8 @@ typeobject_generator::generate_array_type_identifier(AST_Type* type, bool force_
       minimal_ti.array_sdefn().header.equiv_kind = minimal_ek;
       minimal_ti.array_sdefn().header.element_flags = cef;
       for (ACE_CDR::ULong dim = 0; dim != n->n_dims(); ++dim) {
-        minimal_ti.array_sdefn().array_bound_seq.append(n->dims()[dim]->ev()->u.ulval);
+        minimal_ti.array_sdefn().array_bound_seq.append(
+          static_cast<OpenDDS::XTypes::SBound>(n->dims()[dim]->ev()->u.ulval));
       }
       minimal_ti.array_sdefn().element_identifier = minimal_elem_ti;
 
@@ -1403,7 +1404,7 @@ typeobject_generator::generate_sequence_type_identifier(AST_Type* type, bool for
       OpenDDS::XTypes::TypeIdentifier minimal_ti(OpenDDS::XTypes::TI_PLAIN_SEQUENCE_SMALL);
       minimal_ti.seq_sdefn().header.equiv_kind = minimal_ek;
       minimal_ti.seq_sdefn().header.element_flags = cef;
-      minimal_ti.seq_sdefn().bound = bound;
+      minimal_ti.seq_sdefn().bound = static_cast<OpenDDS::XTypes::SBound>(bound);
       minimal_ti.seq_sdefn().element_identifier = minimal_elem_ti;
 
       if (minimal_ek == OpenDDS::XTypes::EK_BOTH) {
@@ -1412,7 +1413,7 @@ typeobject_generator::generate_sequence_type_identifier(AST_Type* type, bool for
         OpenDDS::XTypes::TypeIdentifier complete_ti(OpenDDS::XTypes::TI_PLAIN_SEQUENCE_SMALL);
         complete_ti.seq_sdefn().header.equiv_kind = complete_ek;
         complete_ti.seq_sdefn().header.element_flags = cef;
-        complete_ti.seq_sdefn().bound = bound;
+        complete_ti.seq_sdefn().bound = static_cast<OpenDDS::XTypes::SBound>bound;
         complete_ti.seq_sdefn().element_identifier = complete_elem_ti;
 
         const TypeIdentifierPair ti_pair = {minimal_ti, complete_ti};
@@ -1566,7 +1567,7 @@ typeobject_generator::generate_type_identifier(AST_Type* type, bool force_type_o
       ACE_CDR::ULong bound = n->max_size()->ev()->u.ulval;
       if (bound < 256) {
         OpenDDS::XTypes::TypeIdentifier ti(OpenDDS::XTypes::TI_STRING8_SMALL);
-        ti.string_sdefn().bound = bound;
+        ti.string_sdefn().bound = static_cast<OpenDDS::XTypes::SBound>(bound);
         fully_desc_type_identifier_map_[type] = ti;
       } else {
         OpenDDS::XTypes::TypeIdentifier ti(OpenDDS::XTypes::TI_STRING8_LARGE);
@@ -1582,7 +1583,7 @@ typeobject_generator::generate_type_identifier(AST_Type* type, bool force_type_o
       ACE_CDR::ULong bound = n->max_size()->ev()->u.ulval;
       if (bound < 256) {
         OpenDDS::XTypes::TypeIdentifier ti(OpenDDS::XTypes::TI_STRING16_SMALL);
-        ti.string_sdefn().bound = bound;
+        ti.string_sdefn().bound = static_cast<OpenDDS::XTypes::SBound>(bound);
         fully_desc_type_identifier_map_[type] = ti;
       } else {
         OpenDDS::XTypes::TypeIdentifier ti(OpenDDS::XTypes::TI_STRING16_LARGE);

--- a/java/idl2jni/codegen/be_produce.cpp
+++ b/java/idl2jni/codegen/be_produce.cpp
@@ -112,7 +112,7 @@ string to_macro(const char *fn)
   string ret = "IDL2JNI_GENERATED_";
 
   for (size_t i = 0; i < strlen(fn); ++i) {
-    ret += isalnum(fn[i]) ? toupper(fn[i]) : '_';
+    ret += isalnum(fn[i]) ? static_cast<char>(toupper(fn[i])) : '_';
   }
 
   return ret;

--- a/performance-tests/DCPS/SimpleLatency/raw_tcp/publisher/TestDriver.cpp
+++ b/performance-tests/DCPS/SimpleLatency/raw_tcp/publisher/TestDriver.cpp
@@ -100,7 +100,7 @@ TestDriver::parse_args(int& argc, ACE_TCHAR* argv[])
         throw TestException();
       }
 
-      data_size_ = tmp;
+      data_size_ = static_cast<char>(tmp);
     }
     // The '-s' option
     else if ((current_arg = arg_shifter.get_the_parameter(ACE_TEXT("-s")))) {

--- a/performance-tests/DCPS/SimpleLatency/raw_tcp/subscriber/TestDriver.cpp
+++ b/performance-tests/DCPS/SimpleLatency/raw_tcp/subscriber/TestDriver.cpp
@@ -102,7 +102,7 @@ TestDriver::parse_args(int& argc, ACE_TCHAR* argv[])
         throw TestException();
       }
 
-      data_size_ = tmp;
+      data_size_ = static_cast<char>(tmp);
     }
     // The '-s' option
     else if ((current_arg = arg_shifter.get_the_parameter(ACE_TEXT("-s")))) {

--- a/performance-tests/DCPS/TCPProfilingTest/raw_tcp/publisher/TestDriver.cpp
+++ b/performance-tests/DCPS/TCPProfilingTest/raw_tcp/publisher/TestDriver.cpp
@@ -69,7 +69,7 @@ TestDriver::parse_args(int& argc, ACE_TCHAR* argv[])
         throw TestException();
       }
 
-      publisher_id_ = tmp;
+      publisher_id_ = static_cast<char>(tmp);
     }
     // The '-n' option
     else if ((current_arg = arg_shifter.get_the_parameter(ACE_TEXT("-n")))) {
@@ -97,7 +97,7 @@ TestDriver::parse_args(int& argc, ACE_TCHAR* argv[])
         throw TestException();
       }
 
-      data_size_ = tmp;
+      data_size_ = static_cast<char>(tmp);
     }
     // A '-s' option
     else if ((current_arg = arg_shifter.get_the_parameter(ACE_TEXT("-s")))) {

--- a/performance-tests/DCPS/TCPProfilingTest/raw_tcp/subscriber/TestDriver.cpp
+++ b/performance-tests/DCPS/TCPProfilingTest/raw_tcp/subscriber/TestDriver.cpp
@@ -92,7 +92,7 @@ TestDriver::parse_args(int& argc, ACE_TCHAR* argv[])
         throw TestException();
       }
 
-      data_size_ = tmp;
+      data_size_ = static_cast<char>(tmp);
     }
     // A '-s' option
     else if ((current_arg = arg_shifter.get_the_parameter(ACE_TEXT("-s")))) {


### PR DESCRIPTION
This addresses most of the warnings that come from OpenDDS, except this warning in `dds/DCPS/Hash.cpp` that needs further look: `[build_m13_j_FM-1f: dds/DCPS/Hash.cpp#L135]
cast from 'const unsigned char *' to 'const MD5_u32plus *' (aka 'const unsigned int *') increases required alignment from 1 to 4 [-Wcast-align]`

The rest of the warnings come from ACE, TAO, and generated code by `tao_idl` which are the majority of all warnings.