### PR TITLE
Fixed-size structs don't compile with Java

### DIFF
--- a/docs/news.d/java-fixed-size-structs.rst
+++ b/docs/news.d/java-fixed-size-structs.rst
@@ -1,0 +1,6 @@
+.. news-prs: 4752
+
+.. news-start-section: Fixes
+- Fixed code generation for fixed-size structs in Java that caused compilation errors.
+
+.. news-end-section

--- a/java/idl2jni/codegen/be_global.cpp
+++ b/java/idl2jni/codegen/be_global.cpp
@@ -139,19 +139,19 @@ BE_GlobalData::open_streams(const char *filename)
     BE_abort();
   }
 
-  string filebase(filename);
-  filebase.erase(filebase.rfind('.'));
-  size_t idx = filebase.find_last_of("/\\"); // allow either slash
+  filebase_ = filename;
+  filebase_.erase(filebase_.rfind('.'));
+  size_t idx = filebase_.find_last_of("/\\"); // allow either slash
   if (idx != string::npos) {
-    filebase = filebase.substr(idx + 1);
+    filebase_ = filebase_.substr(idx + 1);
   }
 
-  stub_header_name_ = (filebase + "JC.h").c_str();
-  stub_impl_name_ = (filebase + "JC.cpp").c_str();
+  stub_header_name_ = (filebase_ + "JC.h").c_str();
+  stub_impl_name_ = (filebase_ + "JC.cpp").c_str();
 
   if (this->do_server_side()) {
-    skel_header_name_ = (filebase + "JS.h").c_str();
-    skel_impl_name_ = (filebase + "JS.cpp").c_str();
+    skel_header_name_ = (filebase_ + "JS.h").c_str();
+    skel_impl_name_ = (filebase_ + "JS.cpp").c_str();
   }
 }
 

--- a/java/idl2jni/codegen/be_global.h
+++ b/java/idl2jni/codegen/be_global.h
@@ -43,6 +43,8 @@ public:
   const char *filename() const;
   void filename(const char *fname);
 
+  const std::string& filebase() const { return filebase_; }
+
   bool do_included_files() const;
 
   bool do_server_side() const;
@@ -105,6 +107,7 @@ public:
 private:
   const char *filename_;
   // Name of the IDL file we are processing.
+  std::string filebase_;
 
   bool do_server_side_;
 

--- a/java/idl2jni/codegen/im_jni.cpp
+++ b/java/idl2jni/codegen/im_jni.cpp
@@ -484,6 +484,23 @@ bool isSSU(AST_Type *t)  //sequence, struct, union
     return false;
   }
 }
+
+bool isInterface(AST_Type *t)
+{
+  if (t->node_type() == AST_Decl::NT_typedef) {
+    AST_Typedef *td = dynamic_cast<AST_Typedef*>(t);
+    t = td->primitive_base_type();
+  }
+
+  switch (t->node_type()) {
+  case AST_Decl::NT_interface:
+  case AST_Decl::NT_interface_fwd:
+    return true;
+  default:
+    return false;
+  }
+}
+
 }
 
 bool idl_mapping_jni::gen_enum(UTL_ScopedName *name,
@@ -1306,26 +1323,27 @@ void write_native_operation(UTL_ScopedName *name, const char *javaStub,
   // for the JavaPeer (local interfaces only)
   string ret_jsig = "V", jniFn = "Void", tao_ret = "void",
     tao_retval, tao_retconv, array_cast;
+  AST_Type* op_return_type = op->return_type();
 
   if (!op->void_return_type()) {
-    ret = idl_mapping_jni::type(op->return_type());
-    retval = idl_mapping_jni::taoType(op->return_type());
-    tao_ret = idl_mapping_jni::taoParam(op->return_type(),
+    ret = idl_mapping_jni::type(op_return_type);
+    retval = idl_mapping_jni::taoType(op_return_type);
+    tao_ret = idl_mapping_jni::taoParam(op_return_type,
                                         AST_Argument::dir_IN /*ignored*/, true);
     tao_retval = ret;
-    jniFn = idl_mapping_jni::jniFnName(op->return_type());
-    ret_jsig = idl_mapping_jni::jvmSignature(op->return_type());
+    jniFn = idl_mapping_jni::jniFnName(op_return_type);
+    ret_jsig = idl_mapping_jni::jvmSignature(op_return_type);
     string suffix, extra_type, extra_init, extra_retn;
-    bool is_array = isArray(op->return_type()),
-                    is_objref = isObjref(op->return_type());
+    bool is_array = isArray(op_return_type),
+                    is_objref = isObjref(op_return_type);
 
-    if (is_array || op->return_type()->size_type() != AST_Type::FIXED) {
+    if (is_array || op_return_type->size_type() != AST_Type::FIXED) {
       if (!is_array && !is_objref) suffix = ".in ()";
 
       if (is_array) {
         extra_type = "_forany";
         retval = append_forany(retval);
-      } else if (isSSU(op->return_type())) {
+      } else if (isSSU(op_return_type)) {
         extra_type = "_var";
         extra_init = " = new " + retval;
         retval = append_var(retval);
@@ -1343,13 +1361,13 @@ void write_native_operation(UTL_ScopedName *name, const char *javaStub,
     tao_retconv = "  return _j_ret;\n";
     ret_exception = "  return 0;\n";
 
-    if (!isPrimitive(op->return_type())) {
+    if (!isPrimitive(op_return_type)) {
       retconv =
         "      " + ret + " _j_ret = 0;\n"
         "      copyToJava (_jni, _j_ret, _c_ret" + suffix + ", true);\n"
         "      return _j_ret;\n";
       tao_retconv =
-        "  " + idl_mapping_jni::taoType(op->return_type()) + extra_type
+        "  " + idl_mapping_jni::taoType(op_return_type) + extra_type
         + " _c_ret" + extra_init + ";\n"
         "  copyToCxx (_jni, _c_ret, _j_ret);\n"
         "  return _c_ret" + extra_retn + ";\n";
@@ -1418,7 +1436,16 @@ void write_native_operation(UTL_ScopedName *name, const char *javaStub,
       " (" << tao_args << ")\n"
       "{\n";
     if (hidden) {
-      be_global->stub_impl_ << ret_exception;
+      if (isPrimitive(op_return_type) ||
+          (isSSU(op_return_type) && op_return_type->size_type() == AST_Type::VARIABLE) ||
+          isInterface(op_return_type)) {
+        be_global->stub_impl_ << "  " << tao_ret << " x = 0;\n";
+      } else {
+        be_global->add_include((be_global->filebase() + "Impl.h").c_str());
+        be_global->stub_impl_ << "  " << tao_ret << " x;\n";
+        be_global->stub_impl_ << "  OpenDDS::DCPS::set_default(x);\n";
+      }
+      be_global->stub_impl_ << "  return x;\n";
     } else {
       be_global->stub_impl_ <<
         "  JNIThreadAttacher _jta (jvm_, cl_);\n"

--- a/java/tests/complex_idl/Complex_Idl.idl
+++ b/java/tests/complex_idl/Complex_Idl.idl
@@ -36,4 +36,16 @@ module Complex_Idl {
         @key long id;
         DataUnion payload;
     };
+
+    struct Position {
+        double x;
+        double y;
+        double z;
+    };
+
+    @topic
+    struct TimePosition {
+        @key long time;
+        Position pos;
+    };
 };


### PR DESCRIPTION
Problem
-------

A topic type that has fixed size results in compilation errors in the generated code.

Solution
--------

Extend `idl2jni` to stub out return values for fixed-size structs.