### PR TITLE
Fixed Cross-compiled Builds Using Java

### DIFF
--- a/configure
+++ b/configure
@@ -1233,6 +1233,8 @@ sub default_features {
     push(@feat, 'ipv6=1') if $opts{'ipv6'};
     my @normalized = map {/=/ ? $_ : "$_=1"} @features;
     push(@feat, @normalized) if @normalized;
+  } elsif ($opts{'java'}) {
+    push(@feat, 'java=1');
   }
   return @feat;
 }

--- a/docs/news.d/cross-java.rst
+++ b/docs/news.d/cross-java.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4763
+
+.. news-start-section: Fixes
+- Fixed cross-compiled builds using Java
+.. news-end-section


### PR DESCRIPTION
I took these lines out from the configure script for some reason in https://github.com/OpenDDS/OpenDDS/pull/4611. Without them the host build doesn't include idl2jni.