### PR TITLE
GitHub Actions: ACE 7 is no longer used

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3163,7 +3163,7 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  ACE_TAO_u20_ace7_j_qt_ws_sec:
+  ACE_TAO_u20_acem_j_qt_ws_sec:
 
     runs-on: ubuntu-20.04
 
@@ -3239,11 +3239,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  build_u20_ace7_j_qt_ws_sec:
+  build_u20_acem_j_qt_ws_sec:
 
     runs-on: ubuntu-20.04
 
-    needs: ACE_TAO_u20_ace7_j_qt_ws_sec
+    needs: ACE_TAO_u20_acem_j_qt_ws_sec
 
     steps:
     - name: update apt
@@ -3263,13 +3263,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v4
       with:
-        name: ACE_TAO_u20_ace7_j_qt_ws_sec_artifact
+        name: ACE_TAO_u20_acem_j_qt_ws_sec_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u20_ace7_j_qt_ws_sec.tar.xz
+        tar xvfJ ACE_TAO_u20_acem_j_qt_ws_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v4
       with:
@@ -3329,11 +3329,11 @@ jobs:
         name: ${{ github.job }}_artifact
         path: ${{ github.job }}.tar.xz
 
-  test_u20_ace7_j_qt_ws_sec:
+  test_u20_acem_j_qt_ws_sec:
 
     runs-on: ubuntu-20.04
 
-    needs: build_u20_ace7_j_qt_ws_sec
+    needs: build_u20_acem_j_qt_ws_sec
 
     permissions:
       contents: read
@@ -3362,13 +3362,13 @@ jobs:
     - name: download ACE_TAO artifact
       uses: actions/download-artifact@v4
       with:
-        name: ACE_TAO_u20_ace7_j_qt_ws_sec_artifact
+        name: ACE_TAO_u20_acem_j_qt_ws_sec_artifact
         path: ACE_TAO
     - name: extract ACE_TAO artifact
       shell: bash
       run: |
         cd ACE_TAO
-        tar xvfJ ACE_TAO_u20_ace7_j_qt_ws_sec.tar.xz
+        tar xvfJ ACE_TAO_u20_acem_j_qt_ws_sec.tar.xz
     - name: checkout OpenDDS
       uses: actions/checkout@v4
       with:
@@ -3377,13 +3377,13 @@ jobs:
     - name: download OpenDDS artifact
       uses: actions/download-artifact@v4
       with:
-        name: build_u20_ace7_j_qt_ws_sec_artifact
+        name: build_u20_acem_j_qt_ws_sec_artifact
         path: OpenDDS
     - name: extract OpenDDS artifact
       shell: bash
       run: |
         cd OpenDDS
-        tar xvfJ build_u20_ace7_j_qt_ws_sec.tar.xz
+        tar xvfJ build_u20_acem_j_qt_ws_sec.tar.xz
     - name: check build configuration
       shell: bash
       run: |

--- a/docs/internal/github_actions.rst
+++ b/docs/internal/github_actions.rst
@@ -53,7 +53,7 @@ Build Options
 * v1 - enables versioned namespace
 * cpp03 - ``--std=c++03``
 * j/j<N> - Java version default/N
-* ace7 - uses ace7tao3 rather than ace6tao2
+* acem - uses ACE_TAO's master branch instead of ace6tao2
 * xer0 - disables xerces
 * qt - enables ``--qt``
 * ws - enables ``--wireshark``


### PR DESCRIPTION
Updated build names to match