### PR TITLE
RtpsRelay: updated handling of admission control queue

### DIFF
--- a/docs/news.d/relay-admission-rate-limit.rst
+++ b/docs/news.d/relay-admission-rate-limit.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4783
+
+.. news-start-section: Fixes
+- Corrected implmentation of :option:`RtpsRelay -AdmissionControlQueueSize` and :option:`RtpsRelay -AdmissionControlQueueDuration`
+.. news-end-section

--- a/tools/rtpsrelay/GuidAddrSet.h
+++ b/tools/rtpsrelay/GuidAddrSet.h
@@ -362,6 +362,11 @@ public:
       gas_.process_expirations(now);
     }
 
+    void maintain_admission_queue(const OpenDDS::DCPS::MonotonicTimePoint& now)
+    {
+      gas_.maintain_admission_queue(now);
+    }
+
     bool admitting() const
     {
       return gas_.admitting();
@@ -399,6 +404,8 @@ private:
                   const RelayHandler& handler);
 
   void process_expirations(const OpenDDS::DCPS::MonotonicTimePoint& now);
+
+  void maintain_admission_queue(const OpenDDS::DCPS::MonotonicTimePoint& now);
 
   bool admitting() const
   {

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -288,6 +288,7 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
   const auto msg_len = msg->length();
   {
     GuidAddrSet::Proxy proxy(guid_addr_set_);
+    proxy.maintain_admission_queue(now);
     proxy.process_expirations(now);
     if (!proxy.check_address(remote_address)) {
       stats_reporter_.ignored_message(msg_len, now, type);


### PR DESCRIPTION
For accurate rate limiting the relay needs to maintain this queue upon receipt of any valid message, not just those from new clients.