### PR TITLE
Fix OMG Spec Links Page

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -118,11 +118,16 @@ class DocEnv:
 
     def do_strict(self):
         self.do(['test'], because_of='strict')
-        self.sphinx_build('dummy', '-W')
+        self.sphinx_build('dummy',
+            '--nitpicky',
+            '--fail-on-warning',
+            '--keep-going',
+            '--show-traceback',
+        )
         return None
 
     def do_linkcheck(self):
-        self.sphinx_build('linkcheck', defines=['gen_all_omg_spec_links=False'])
+        self.sphinx_build('linkcheck', defines=['gen_all_omg_spec_links=0'])
         return None
 
     def do_html(self):

--- a/docs/sphinx_extensions/links.py
+++ b/docs/sphinx_extensions/links.py
@@ -365,6 +365,7 @@ class OmgSpecsDirective(SphinxDirective):
             node += section_list
 
     def run(self):
+        debug_links = 'debug-links' in self.options and self.env.app.config.gen_all_omg_spec_links
         specs_node = nodes.bullet_list()
         for spec_name, spec in self.env.app.config.omg_specs.items():
             spec_node = nodes.list_item()
@@ -375,7 +376,7 @@ class OmgSpecsDirective(SphinxDirective):
             p += nodes.literal('', spec_name)
             p += nodes.inline('', ')')
             spec_node += p
-            if 'debug-links' in self.options and not self.env.app.config.gen_all_omg_spec_links:
+            if debug_links:
                 self.spec_sections(spec, spec_node, spec['sections'])
             specs_node += spec_node
         return [specs_node]


### PR DESCRIPTION
[This page](https://opendds.readthedocs.io/en/master/internal/omg_spec_links.html) is supposed to list links to all the sections in all the spec, not just the specs like it does now. It was causing a lot of unwanted output in the link checker, so I tried to make it conditional in https://github.com/OpenDDS/OpenDDS/pull/4669. Unfortunately it looks like I broke the page so it never lists all the possible spec section links. These changes fix that.

Also added `--nitpicky`, `--keep-going`, and `--show-traceback` to the `sphinx-build` command of `build.py strict` to make output more useful.