### PR TITLE
Fix incorrect separator when generating tag type

### DIFF
--- a/dds/idl/metaclass_generator.cpp
+++ b/dds/idl/metaclass_generator.cpp
@@ -473,7 +473,7 @@ void generate_anon_fields(AST_Structure* node)
               post = "_forany";
             } else if (use_cxx11 && (elem_cls & (CL_ARRAY | CL_SEQUENCE))) {
               pre = "IDL::DistinctType<";
-              post = ", " + dds_generator::get_tag_name(dds_generator::scoped_helper(deepest_named_type(elem_orig)->name(), "_")) + ">";
+              post = ", " + dds_generator::get_tag_name(dds_generator::scoped_helper(deepest_named_type(elem_orig)->name(), "::")) + ">";
             }
             be_global->impl_ <<
               "    if (!gen_skip_over(ser, static_cast<" << pre << cxx_elem << post

--- a/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
+++ b/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
@@ -287,5 +287,5 @@ module Test_Module {
 };
 
 struct TestModuleStruct {
-  @id(1) sequence <Test_Module::A_Char100S> sequence_field;
+  @id(1) sequence<Test_Module::A_Char100S> sequence_field;
 };

--- a/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
+++ b/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
@@ -282,8 +282,7 @@ union B88 switch (long) {
 
 // Regression check that module and struct names containing '_' compile
 // correctly. https://github.com/OpenDDS/OpenDDS/pull/4800.
-module Test_Module
-{
+module Test_Module {
     typedef sequence<char, 100> A_Char100S;
 };
 

--- a/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
+++ b/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
@@ -283,9 +283,11 @@ union B88 switch (long) {
 // Regression check that module and struct names containing '_' compile
 // correctly. https://github.com/OpenDDS/OpenDDS/pull/4800.
 module Test_Module {
-    typedef sequence<char, 100> A_Char100S;
+  typedef sequence<char, 100> A_Char100S;
 };
 
+typedef sequence<Test_Module::A_Char100S> Sequence_Type;
+
 struct TestModuleStruct {
-  @id(1) sequence<Test_Module::A_Char100S> sequence_field;
+  @id(1) Sequence_Type sequence_field;
 };

--- a/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
+++ b/tests/DCPS/Compiler/idl_test1_lib/FooDef.idl
@@ -279,3 +279,14 @@ union B88 switch (long) {
   case 2: B43 b_85_2;
   case 3: B41 b_85_3;
 };
+
+// Regression check that module and struct names containing '_' compile
+// correctly. https://github.com/OpenDDS/OpenDDS/pull/4800.
+module Test_Module
+{
+    typedef sequence<char, 100> A_Char100S;
+};
+
+struct TestModuleStruct {
+  @id(1) sequence <Test_Module::A_Char100S> sequence_field;
+};


### PR DESCRIPTION
```
module Test_Module
{
    typedef sequence<char, 100> A_Char100S;
};

struct TestModuleStruct {
  @id(1) sequence <Test_Module::A_Char100S> sequence_field3;
};
```

generates code that does not compile (g++, Ubuntu Jammy, x64, OpenDDS/master e613d2995c4) :

```
/home/ultra/src/OpenDDS/tests/DCPS/Compiler/xcdr/mutable_types2TypeSupportImpl.cpp: In function ‘bool OpenDDS::DCPS::gen_skip_over(OpenDDS::DCPS::Serializer&, OpenDDS::DCPS::IDL::DistinctType<std::vector<std::vector<char> >, OpenDDS::DCPS::TestModuleStruct_AnonymousType_9sequence_9field3_9seq_tag>*)’:
/home/ultra/src/OpenDDS/tests/DCPS/Compiler/xcdr/mutable_types2TypeSupportImpl.cpp:7357:87: error: ‘Test_9Module_9A_9Char100S_tag’ was not declared in this scope; did you mean ‘Test_9Module_A_9Char100S_tag’?
 7357 | , static_cast<IDL::DistinctType< ::Test_Module::A_Char100S, Test_9Module_9A_9Char100S_tag>*>(0))) return false;
      |                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                             Test_9Module_A_9Char100S_tag
/home/ultra/src/OpenDDS/tests/DCPS/Compiler/xcdr/mutable_types2TypeSupportImpl.cpp:7357:116: error: template argument 2 is invalid
 7357 | pe< ::Test_Module::A_Char100S, Test_9Module_9A_9Char100S_tag>*>(0))) return false;
      |                                                             ^
```
This should obviously be a test case somewhere, but as a total newbie to OpenDDS I'm not sure where.