### PR TITLE
"reallocating primary receive buffer" shows up too often

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -185,9 +185,7 @@ RtpsUdpReceiveStrategy::handle_input(ACE_HANDLE fd)
   // If newly selected buffer index still has a reference count, we'll need to allocate a new one for the read
   if (receive_buffers_[INDEX]->data_block()->reference_count() > 1) {
 
-    if (log_level >= LogLevel::Info) {
-      ACE_DEBUG((LM_INFO, "(%P|%t) INFO: RtpsUdpReceiveStrategy::handle_input: reallocating primary receive buffer based on reference count\n"));
-    }
+    VDBG_LVL((LM_DEBUG, "(%P|%t) DBG: RtpsUdpReceiveStrategy::handle_input: reallocating primary receive buffer based on reference count\n"), 5);
 
     ACE_DES_FREE(
       receive_buffers_[INDEX],

--- a/docs/news.d/reallocating-buffer.rst
+++ b/docs/news.d/reallocating-buffer.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4810
+
+.. news-start-section: Fixes
+- Change "reallocating primary receive buffer" to transport debug logging level 3
+.. news-end-section

--- a/docs/news.d/tag-type-separator.rst
+++ b/docs/news.d/tag-type-separator.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4800
+
+.. news-start-section: Fixes
+- Change the tag type separator in ``opendds_idl`` to allow underscores in identifiers.
+.. news-end-section


### PR DESCRIPTION
Problem
-------

The "reallocating primary receive buffer" log message shows up under the Info log level.  There are a number of reasons why the receive buffer needs to be reallocated and none of them warrant concern from users.

Solution
--------

Move to transport logging.