### PR TITLE
Updated ThreadStatusManager for iterative event handling

### DIFF
--- a/dds/DCPS/JobQueue.cpp
+++ b/dds/DCPS/JobQueue.cpp
@@ -23,7 +23,8 @@ JobQueue::JobQueue(ACE_Reactor* reactor)
 
 int JobQueue::handle_exception(ACE_HANDLE /*fd*/)
 {
-  ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
+  ThreadStatusManager& thread_status_manager = TheServiceParticipant->get_thread_status_manager();
+  ThreadStatusManager::Event ev(thread_status_manager);
 
   Queue q;
 
@@ -33,6 +34,7 @@ int JobQueue::handle_exception(ACE_HANDLE /*fd*/)
   }
 
   for (Queue::const_iterator pos = q.begin(), limit = q.end(); pos != limit; ++pos) {
+    ThreadStatusManager::Event ev(thread_status_manager);
     (*pos)->execute();
   }
 

--- a/dds/DCPS/JobQueue.cpp
+++ b/dds/DCPS/JobQueue.cpp
@@ -34,7 +34,7 @@ int JobQueue::handle_exception(ACE_HANDLE /*fd*/)
   }
 
   for (Queue::const_iterator pos = q.begin(), limit = q.end(); pos != limit; ++pos) {
-    ThreadStatusManager::Event ev(thread_status_manager);
+    ThreadStatusManager::Event event(thread_status_manager);
     (*pos)->execute();
   }
 

--- a/dds/DCPS/ThreadStatusManager.cpp
+++ b/dds/DCPS/ThreadStatusManager.cpp
@@ -108,7 +108,7 @@ void ThreadStatusManager::add_thread(const String& name)
   map_.insert(std::make_pair(thread_id, Thread(bit_key)));
 }
 
-void ThreadStatusManager::active(bool nested)
+void ThreadStatusManager::update_current_thread(Thread::ThreadStatus status, bool nested)
 {
   if (!update_thread_status()) {
     return;
@@ -122,31 +122,12 @@ void ThreadStatusManager::active(bool nested)
 
   const Map::iterator pos = map_.find(thread_id);
   if (pos != map_.end()) {
-    pos->second.update(m_now, s_now, Thread::ThreadStatus_Active, bucket_limit_, nested);
+    pos->second.update(m_now, s_now, status, bucket_limit_, nested);
   }
 
   cleanup(m_now);
 }
 
-void ThreadStatusManager::idle(bool nested)
-{
-  if (!update_thread_status()) {
-    return;
-  }
-
-  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
-
-  const MonotonicTimePoint m_now = MonotonicTimePoint::now();
-  const SystemTimePoint s_now = SystemTimePoint::now();
-  const ThreadId thread_id = get_thread_id();
-
-  const Map::iterator pos = map_.find(thread_id);
-  if (pos != map_.end()) {
-    pos->second.update(m_now, s_now, Thread::ThreadStatus_Idle, bucket_limit_, nested);
-  }
-
-  cleanup(m_now);
-}
 
 void ThreadStatusManager::finished()
 {

--- a/dds/DCPS/ThreadStatusManager.h
+++ b/dds/DCPS/ThreadStatusManager.h
@@ -185,8 +185,11 @@ public:
 private:
   static ThreadId get_thread_id();
   void add_thread(const String& name);
-  void active(bool nested = false);
-  void idle(bool nested = false);
+
+  void update_current_thread(Thread::ThreadStatus status, bool nested = false);
+  void active(bool nested = false) { update_current_thread(Thread::ThreadStatus_Active, nested); }
+  void idle(bool nested = false) { update_current_thread(Thread::ThreadStatus_Idle, nested); }
+
   void finished();
 
   void cleanup(const MonotonicTimePoint& now);

--- a/dds/DCPS/ThreadStatusManager.h
+++ b/dds/DCPS/ThreadStatusManager.h
@@ -41,10 +41,11 @@ public:
     Thread(const String& bit_key)
       : bit_key_(bit_key)
       , timestamp_(SystemTimePoint::now())
-      , status_(ThreadStatus_Active)
       , last_update_(MonotonicTimePoint::now())
-      , current_bucket_(0)
+      , last_status_change_(MonotonicTimePoint::now())
+      , status_(ThreadStatus_Active)
       , nesting_depth_(0)
+      , current_bucket_(0)
     {}
 
     const String& bit_key() const { return bit_key_; }
@@ -63,18 +64,18 @@ public:
   private:
     const String bit_key_;
     SystemTimePoint timestamp_;
+    MonotonicTimePoint last_update_, last_status_change_;
     ThreadStatus status_;
+    size_t nesting_depth_;
 
     struct OpenDDS_Dcps_Export Bucket {
       TimeDuration active_time;
       TimeDuration idle_time;
       TimeDuration total_time() const { return active_time + idle_time; }
     };
-    MonotonicTimePoint last_update_;
     Bucket total_;
     Bucket buckets_[bucket_count];
     size_t current_bucket_;
-    size_t nesting_depth_;
   };
   typedef OPENDDS_MAP(ThreadId, Thread) Map;
   typedef OPENDDS_LIST(Thread) List;
@@ -175,29 +176,28 @@ public:
                List& running,
                List& finished) const;
 
-#ifdef ACE_HAS_GETTID
-  static inline pid_t gettid()
-  {
-    return syscall(SYS_gettid);
-  }
-#endif
-
 private:
   static ThreadId get_thread_id();
   void add_thread(const String& name);
 
-  void update_current_thread(Thread::ThreadStatus status, bool nested = false);
+  void update_current_thread(Thread::ThreadStatus status, bool nested = false)
+  {
+    update_i(status, false, nested);
+  }
+
+  void finished() { update_i(Thread::ThreadStatus_Idle, true, false); }
+
+  void update_i(Thread::ThreadStatus status, bool finished = false, bool nested = false);
+
   void active(bool nested = false) { update_current_thread(Thread::ThreadStatus_Active, nested); }
   void idle(bool nested = false) { update_current_thread(Thread::ThreadStatus_Idle, nested); }
-
-  void finished();
 
   void cleanup(const MonotonicTimePoint& now);
 
   TimeDuration thread_status_interval_;
   TimeDuration bucket_limit_;
   Map map_;
-  List list_;
+  List finished_;
 
   mutable ACE_Thread_Mutex lock_;
 };

--- a/docs/news.d/thread-status-manager.rst
+++ b/docs/news.d/thread-status-manager.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4830
+
+.. news-start-section: Fixes
+- Updated ThreadStatusManager for iterative event handling
+.. news-end-section

--- a/tools/dds/rtpsrelaylib/Relay.idl
+++ b/tools/dds/rtpsrelaylib/Relay.idl
@@ -64,7 +64,6 @@ module RtpsRelay {
   };
 
   const string RELAY_PARTICIPANT_STATUS_TOPIC_NAME = "Relay Participant Status";
-
   @topic
   @mutable
   @autoid(HASH)
@@ -112,7 +111,6 @@ module RtpsRelay {
   };
 
   const string PARTICIPANT_STATISTICS_TOPIC_NAME = "Participant Statistics";
-
   @topic
   @mutable
   @autoid(HASH)
@@ -125,7 +123,6 @@ module RtpsRelay {
   };
 
   const string HANDLER_STATISTICS_TOPIC_NAME = "Handler Statistics";
-
   @topic
   @mutable
   @autoid(HASH)
@@ -142,7 +139,6 @@ module RtpsRelay {
   };
 
   const string RELAY_STATISTICS_TOPIC_NAME = "Relay Statistics";
-
   @topic
   @mutable
   @autoid(HASH)

--- a/tools/rtpsrelay/GuidPartitionTable.cpp
+++ b/tools/rtpsrelay/GuidPartitionTable.cpp
@@ -76,7 +76,7 @@ GuidPartitionTable::Result GuidPartitionTable::insert(const OpenDDS::DCPS::GUID_
       spdp_replay.address(address_);
       spdp_replay.guid(rtps_guid_to_relay_guid(OpenDDS::DCPS::make_id(guid, OpenDDS::DCPS::ENTITYID_PARTICIPANT)));
       if (spdp_replay_writer_->write(spdp_replay, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
-        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: GuidPartitionTable::insert failed to write Relay Partitions\n"));
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: GuidPartitionTable::insert failed to write SPDP Replay\n"));
       }
     }
   }

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -415,13 +415,13 @@ int run(int argc, ACE_TCHAR* argv[])
   }
   CORBA::String_var relay_status_type_name = relay_status_ts->get_type_name();
 
-  DDS::Topic_var relay_statuss_topic =
+  DDS::Topic_var relay_status_topic =
     relay_participant->create_topic(RELAY_STATUS_TOPIC_NAME.c_str(),
                                     relay_status_type_name,
                                     TOPIC_QOS_DEFAULT, nullptr,
                                     OpenDDS::DCPS::DEFAULT_STATUS_MASK);
 
-  if (!relay_statuss_topic) {
+  if (!relay_status_topic) {
     ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: failed to create Relay Instances topic\n"));
     return EXIT_FAILURE;
   }
@@ -943,7 +943,7 @@ int run(int argc, ACE_TCHAR* argv[])
 
   DDS::DataWriterListener_var relay_status_writer_listener =
     new StatisticsWriterListener(relay_statistics_reporter, &RelayStatisticsReporter::relay_status_sub_count);
-  DDS::DataWriter_var relay_status_writer_var = relay_publisher->create_datawriter(relay_statuss_topic, relay_status_writer_qos, relay_status_writer_listener, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+  DDS::DataWriter_var relay_status_writer_var = relay_publisher->create_datawriter(relay_status_topic, relay_status_writer_qos, relay_status_writer_listener, OpenDDS::DCPS::DEFAULT_STATUS_MASK);
   if (!relay_status_writer_var) {
     ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: failed to create Relay Status data writer\n"));
     return EXIT_FAILURE;


### PR DESCRIPTION
Some event loops process entire batches of events at once. Before this change, the batch of data would be considered an "Event" for the ThreadStatusManager.  With this change, each element within the batch counts as its own event for the ThreadStatusManager. That way the thread appears to be active and not stuck.