### PR TITLE
CLOCK_BOOTTIME timers ignore zero delay with interval

### DIFF
--- a/dds/DCPS/Timers.cpp
+++ b/dds/DCPS/Timers.cpp
@@ -93,16 +93,9 @@ TimerId schedule(ACE_Reactor* reactor,
   static const timespec one_ns = {0, 1};
   itimerspec ts;
   ts.it_interval = interval.value();
-  if (delay < TimeDuration::zero_value) {
-    // expiration in the past, execute as soon as possible (see note about zeros below)
-    ts.it_value = one_ns;
-  } else if (delay == TimeDuration::zero_value) {
-    // avoid zeros since that would disarm the timer
-    // if the interval is positive, use that as the initial expiration
-    ts.it_value = (interval == TimeDuration::zero_value) ? one_ns : interval.value();
-  } else {
-    ts.it_value = delay.value();
-  }
+  // expiration in the past, execute as soon as possible
+  // avoid zeros since that would disarm the timer
+  ts.it_value = (delay <= TimeDuration::zero_value) ? one_ns : delay.value();
   if (timerfd_settime(fd, 0, &ts, 0) == -1) {
     if (log_level >= LogLevel::Notice) {
       ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: Timers::schedule: timerfd_settime %m\n"));

--- a/docs/news.d/boottime-timers.rst
+++ b/docs/news.d/boottime-timers.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4835
+
+.. news-start-section: Fixes
+- Fix periodic timers with ``--boottime`` so that the initial delay is honored.
+.. news-end-section

--- a/tests/unit-tests/dds/DCPS/Timers.cpp
+++ b/tests/unit-tests/dds/DCPS/Timers.cpp
@@ -46,7 +46,7 @@ TEST(dds_DCPS_Timers, test_repeat)
   ACE_Time_Value one_sec(1);
   reactor.run_reactor_event_loop(one_sec);
 
-  ASSERT_GT(handler->calls_, 10);
+  ASSERT_GT(handler->calls_, 11);
   Timers::cancel(&reactor, id);
 }
 


### PR DESCRIPTION
Problem
-------

Scheduling a timer with an interval but no delay causes the first firing of the timer to occur after the interval instead of as soon as possible.  Without CLOCK_BOOTTIME, the timer fires immediately and then starts to fire on the requested interval.

Solution
--------

Address the delay independent of the interval.