### PR TITLE
EndHistoricSamplesMissedSweeper is a ReactorInterceptor

### DIFF
--- a/bin/PerlDDS/Run_Test.pm
+++ b/bin/PerlDDS/Run_Test.pm
@@ -13,6 +13,7 @@ use PerlDDS::ProcessFactory;
 use Cwd;
 use POSIX qw(strftime);
 use File::Spec::Functions qw(catfile catdir);
+use File::Path qw(rmtree);
 
 sub is_executable {
   my $path = shift;
@@ -454,7 +455,36 @@ sub new {
     ++$index;
   }
 
+  PerlDDS::rmtree('./DCS');
+
   return $self;
+}
+
+sub log_wait_for {
+  my $waiting_actor = shift;
+  my $posting_actor = shift;
+  my $condition = shift;
+  my $message = shift // "";
+  return "TestFramework " . $waiting_actor . " wait_for " . $posting_actor . " " . $condition . " " . $message;
+}
+
+sub wait_for {
+  my $self = shift;
+  my $waiting_actor = shift;
+  my $posting_actor = shift;
+  my $condition = shift;
+  my $maxwait = shift;
+
+  $self->_info(log_wait_for($waiting_actor, $posting_actor, $condition));
+  my $path = '.DCS/' . $posting_actor . "/" . $condition;
+  for (my $i = 0; $i < $maxwait && ! -e $path; $i = $i + 1) {
+    sleep(1);
+  }
+  if (-e $path) {
+    $self->_info(log_wait_for($waiting_actor, $posting_actor, $condition, "done"));
+  } else {
+    $self->_info(log_wait_for($waiting_actor, $posting_actor, $condition, "timeout"));
+  }
 }
 
 sub wait_kill {

--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -74,7 +74,6 @@ DataReaderImpl::DataReaderImpl()
   , topic_desc_(0)
   , listener_mask_(DEFAULT_STATUS_MASK)
   , domain_id_(0)
-  , end_historic_sweeper_(make_rch<EndHistoricSamplesMissedSweeper>(TheServiceParticipant->reactor(), TheServiceParticipant->reactor_owner(), this))
   , n_chunks_(TheServiceParticipant->n_chunks())
   , reactor_(0)
   , liveliness_timer_(make_rch<LivelinessTimer>(TheServiceParticipant->reactor(), TheServiceParticipant->reactor_owner(), this))
@@ -544,7 +543,7 @@ DataReaderImpl::remove_associations_i(const WriterIdSeq& writers,
 
       if (it != this->writers_.end()) {
         removed_writers.insert(*it);
-        end_historic_sweeper_->cancel_timer(it->second);
+        it->second->cancel_historic_samples_timer();
       }
 
       if (this->writers_.erase(writer_id) == 0) {
@@ -3180,12 +3179,18 @@ DataReaderImpl::resume_sample_processing(const GUID_t& pub_id)
   }
 
   if (info) {
-    OPENDDS_MAP(SequenceNumber, ReceivedDataSample) to_deliver;
-    // Stop filtering these
-    if (info->check_end_historic_samples(end_historic_sweeper_.in(), to_deliver)) {
-      deliver_historic(to_deliver);
-      info->finished_delivering_historic();
-    }
+    resume_sample_processing(*info);
+  }
+}
+
+void
+DataReaderImpl::resume_sample_processing(WriterInfo& info)
+{
+  OPENDDS_MAP(SequenceNumber, ReceivedDataSample) to_deliver;
+  // Stop filtering these
+  if (info.check_end_historic_samples(to_deliver)) {
+    deliver_historic(to_deliver);
+    info.finished_delivering_historic();
   }
 }
 
@@ -3230,7 +3235,7 @@ DataReaderImpl::add_link(const DataLink_rch& link, const GUID_t& peer)
     if (it != writers_.end()) {
       // Schedule timer if necessary
       //   - only need to check reader qos - we know the writer must be >= reader
-      end_historic_sweeper_->schedule_timer(it->second);
+      it->second->schedule_historic_samples_timer();
     }
   }
   TransportClient::add_link(link, peer);
@@ -3397,75 +3402,6 @@ DDS::Security::ParticipantCryptoHandle DataReaderImpl::get_crypto_handle() const
   return participant ? participant->crypto_handle() : DDS::HANDLE_NIL;
 }
 #endif
-
-EndHistoricSamplesMissedSweeper::EndHistoricSamplesMissedSweeper(ACE_Reactor* reactor,
-                                                                 ACE_thread_t owner,
-                                                                 DataReaderImpl* reader)
-  : ReactorInterceptor (reactor, owner)
-  , reader_(*reader)
-{ }
-
-void EndHistoricSamplesMissedSweeper::schedule_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info)
-{
-  info->waiting_for_end_historic_samples(true);
-  execute_or_enqueue(make_rch<ScheduleCommand>(this, ref(info)));
-}
-
-void EndHistoricSamplesMissedSweeper::cancel_timer(OpenDDS::DCPS::RcHandle<OpenDDS::DCPS::WriterInfo>& info)
-{
-  info->waiting_for_end_historic_samples(false);
-  execute_or_enqueue(make_rch<CancelCommand>(this, ref(info)));
-}
-
-int EndHistoricSamplesMissedSweeper::handle_timeout(
-    const ACE_Time_Value& ,
-    const void* arg)
-{
-  ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
-
-  WriterInfo* const info =
-    const_cast<WriterInfo*>(reinterpret_cast<const WriterInfo*>(arg));
-  const GUID_t pub_id = info->writer_id();
-
-  {
-    ACE_Guard<ACE_Thread_Mutex> guard(this->mutex_);
-    info_set_.erase(rchandle_from(info));
-  }
-
-  RcHandle<DataReaderImpl> reader = reader_.lock();
-  if (!reader)
-    return 0;
-
-  if (DCPS_debug_level >= 1) {
-    ACE_DEBUG((LM_INFO, "(%P|%t) EndHistoricSamplesMissedSweeper::handle_timeout reader: %C waiting on writer: %C\n",
-               LogGuid(reader->get_guid()).c_str(),
-               LogGuid(pub_id).c_str()));
-  }
-
-  reader->resume_sample_processing(pub_id);
-  return 0;
-}
-
-void EndHistoricSamplesMissedSweeper::ScheduleCommand::execute()
-{
-  static const ACE_Time_Value ten_seconds(10);
-  info_->schedule_historic_samples_timer(sweeper_, ten_seconds);
-  const bool insert_result = sweeper_->info_set_.insert(info_).second;
-
-  if (insert_result && DCPS_debug_level) {
-    ACE_DEBUG((LM_INFO, "(%P|%t) EndHistoricSamplesMissedSweeper::ScheduleCommand::execute() - sweeper %@ is now scheduled\n", info_.in()));
-  }
-}
-
-void EndHistoricSamplesMissedSweeper::CancelCommand::execute()
-{
-  info_->cancel_historic_samples_timer(sweeper_);
-  const bool erase_result = sweeper_->info_set_.erase(info_) > 0;
-
-  if (erase_result && DCPS_debug_level) {
-    ACE_DEBUG((LM_INFO, "(%P|%t) EndHistoricSamplesMissedSweeper::CancelCommand::execute() - sweeper %@ is no longer scheduled\n", info_.in()));
-  }
-}
 
 void DataReaderImpl::transport_discovery_change()
 {

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -123,60 +123,6 @@ public:
 
 #endif
 
-// Class to cleanup in case EndHistoricSamples is missed
-class EndHistoricSamplesMissedSweeper : public ReactorInterceptor {
-public:
-  EndHistoricSamplesMissedSweeper(ACE_Reactor* reactor,
-                                  ACE_thread_t owner,
-                                  DataReaderImpl* reader);
-
-  void schedule_timer(WriterInfo_rch& info);
-  void cancel_timer(WriterInfo_rch& info);
-
-  // Arg will be PublicationId
-  int handle_timeout(const ACE_Time_Value& current_time, const void* arg);
-
-  virtual bool reactor_is_shut_down() const
-  {
-    return TheServiceParticipant->is_shut_down();
-  }
-
-private:
-  WeakRcHandle<DataReaderImpl> reader_;
-  OPENDDS_SET(WriterInfo_rch) info_set_;
-
-  class CommandBase : public Command {
-  public:
-    CommandBase(EndHistoricSamplesMissedSweeper* sweeper,
-                WriterInfo_rch& info)
-      : sweeper_(sweeper)
-      , info_(info)
-    { }
-
-  protected:
-    EndHistoricSamplesMissedSweeper* sweeper_;
-    WriterInfo_rch info_;
-  };
-
-  class ScheduleCommand : public CommandBase {
-  public:
-    ScheduleCommand(EndHistoricSamplesMissedSweeper* sweeper,
-                    WriterInfo_rch& info)
-      : CommandBase(sweeper, info)
-    { }
-    virtual void execute();
-  };
-
-  class CancelCommand : public CommandBase {
-  public:
-    CancelCommand(EndHistoricSamplesMissedSweeper* sweeper,
-                  WriterInfo_rch& info)
-      : CommandBase(sweeper, info)
-    { }
-    virtual void execute();
-  };
-};
-
 /**
 * @class DataReaderImpl
 *
@@ -828,6 +774,7 @@ private:
 
   /// when done handling historic samples, resume
   void resume_sample_processing(const GUID_t& pub_id);
+  void resume_sample_processing(WriterInfo& info);
 
   /// collect samples received before END_HISTORIC_SAMPLES
   /// returns false if normal processing of this sample should be skipped
@@ -837,7 +784,6 @@ private:
   void deliver_historic(OPENDDS_MAP(SequenceNumber, ReceivedDataSample)& samples);
 
   friend class InstanceState;
-  friend class EndHistoricSamplesMissedSweeper;
 
   friend class ::DDS_TEST; //allows tests to get at private data
 
@@ -851,7 +797,6 @@ private:
   // transport reactor thread and that thread doesn't have the owenership of the
   // the subscriber_servant_ object.
   WeakRcHandle<SubscriberImpl>              subscriber_servant_;
-  RcHandle<EndHistoricSamplesMissedSweeper> end_historic_sweeper_;
 
   CORBA::Long                  depth_;
   size_t                       n_chunks_;

--- a/tests/DCPS/TransientLocalMultiInstanceTest/.gitignore
+++ b/tests/DCPS/TransientLocalMultiInstanceTest/.gitignore
@@ -1,3 +1,4 @@
+/DCS
 /publisher
 /subscriber
 /test_run.data

--- a/tests/DCPS/TransientLocalMultiInstanceTest/DataReaderListener.cpp
+++ b/tests/DCPS/TransientLocalMultiInstanceTest/DataReaderListener.cpp
@@ -10,8 +10,14 @@
 using namespace Messenger;
 using namespace std;
 
-DataReaderListenerImpl::DataReaderListenerImpl()
-  : ok_(true), read_intances_message_count_()
+DataReaderListenerImpl::DataReaderListenerImpl(DistributedConditionSet_rch dcs,
+                                               const OpenDDS::DCPS::String& actor,
+                                               long expected)
+  : dcs_(dcs)
+  , actor_(actor)
+  , expected_(expected)
+  , ok_(true)
+  , read_instances_message_count_()
 {
   ACE_DEBUG((LM_INFO, "(%P|%t) DataReaderListnerImpl[%@]\n", this));
 }
@@ -31,32 +37,31 @@ void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 
     Messenger::Message message;
     DDS::SampleInfo si;
-    DDS::ReturnCode_t status = message_dr->take_next_sample(message, si);
+    for (DDS::ReturnCode_t status = message_dr->take_next_sample(message, si);
+         status == DDS::RETCODE_OK;
+         status = message_dr->take_next_sample(message, si)) {
 
-    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+      ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
 
-    if (si.valid_data) {
-      if (status == DDS::RETCODE_OK) {
-
-        if (read_intances_message_count_.count(message.subject_id)) {
-          read_intances_message_count_[message.subject_id] += 1;
+      if (si.valid_data) {
+        if (read_instances_message_count_.count(message.subject_id)) {
+          read_instances_message_count_[message.subject_id] += 1;
         }
         else {
-          read_intances_message_count_.insert(std::make_pair(message.subject_id, 1));
+          read_instances_message_count_.insert(std::make_pair(message.subject_id, 1));
         }
+
         ACE_DEBUG((LM_INFO, "(%P|%t) DataReaderListenerImpl[%@]::on_data_available - instance: %d count = %d\n", this,
-              message.subject_id, message.count));
+                   message.subject_id, message.count));
         if (message.count != message.subject_id) {
           ACE_DEBUG((LM_INFO, "(%P|%t) ERROR: durable reader received wrong data (instance: %d msg count = %d and num_reads = %d)\n",
-            message.subject_id, message.count, num_reads()));
+                     message.subject_id, message.count, num_reads()));
           ok_ = false;
         }
-      } else if (status == DDS::RETCODE_NO_DATA) {
-        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: reader received DDS::RETCODE_NO_DATA!\n")));
-        ok_ = false;
-      } else {
-        ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: read Message: Error: %d\n"), status));
-        ok_ = false;
+
+        if (num_reads() == expected_ && received_all_expected_messages()) {
+          dcs_->post(actor_, "read done");
+        }
       }
     }
   } catch (CORBA::Exception& e) {
@@ -69,21 +74,21 @@ void DataReaderListenerImpl::on_requested_deadline_missed (
     DDS::DataReader_ptr,
     const DDS::RequestedDeadlineMissedStatus &)
 {
-  ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_requested_deadline_missed\n")));
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_requested_deadline_missed\n")));
 }
 
 void DataReaderListenerImpl::on_requested_incompatible_qos (
     DDS::DataReader_ptr,
     const DDS::RequestedIncompatibleQosStatus &)
 {
-  ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_requested_incompatible_qos\n")));
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_requested_incompatible_qos\n")));
 }
 
 void DataReaderListenerImpl::on_liveliness_changed (
     DDS::DataReader_ptr,
     const DDS::LivelinessChangedStatus &)
 {
-  ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_liveliness_changed\n")));
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_liveliness_changed\n")));
 }
 
 void DataReaderListenerImpl::on_subscription_matched (
@@ -97,23 +102,21 @@ void DataReaderListenerImpl::on_sample_rejected(
     DDS::DataReader_ptr,
     const DDS::SampleRejectedStatus&)
 {
-  ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_sample_rejected\n")));
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_sample_rejected\n")));
 }
 
 void DataReaderListenerImpl::on_sample_lost(
   DDS::DataReader_ptr,
   const DDS::SampleLostStatus&)
 {
-  ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_sample_lost\n")));
+  ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DataReaderListenerImpl::on_sample_lost\n")));
 }
 
 long DataReaderListenerImpl::num_reads() const
 {
-  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
-
   long num_reads = 0;
-  std::map<int, int>::const_iterator map_iter = read_intances_message_count_.begin();
-  for (; map_iter != read_intances_message_count_.end(); ++map_iter) {
+  std::map<int, int>::const_iterator map_iter = read_instances_message_count_.begin();
+  for (; map_iter != read_instances_message_count_.end(); ++map_iter) {
     num_reads += map_iter->second;
   }
   return num_reads;
@@ -121,17 +124,15 @@ long DataReaderListenerImpl::num_reads() const
 
 bool DataReaderListenerImpl::received_all_expected_messages() const
 {
-  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
-
   for (int i = 0; i < 4; ++i) {
     int message_instance = i + 1;
-    if (!read_intances_message_count_.count(message_instance))
+    if (!read_instances_message_count_.count(message_instance))
     {
       return false;
     }
     else {
-      std::map<int, int>::const_iterator search = read_intances_message_count_.find(message_instance);
-      if (search == read_intances_message_count_.end() || 1 != search->second) {
+      std::map<int, int>::const_iterator search = read_instances_message_count_.find(message_instance);
+      if (search == read_instances_message_count_.end() || 1 != search->second) {
         return false;
       }
     }

--- a/tests/DCPS/TransientLocalMultiInstanceTest/DataReaderListener.h
+++ b/tests/DCPS/TransientLocalMultiInstanceTest/DataReaderListener.h
@@ -3,6 +3,8 @@
 #ifndef DATAREADER_LISTENER_IMPL
 #define DATAREADER_LISTENER_IMPL
 
+#include <tests/Utils/DistributedConditionSet.h>
+
 #include <dds/DdsDcpsSubscriptionExtC.h>
 #include <dds/DCPS/LocalObject.h>
 #include <map>
@@ -15,7 +17,9 @@ class DataReaderListenerImpl
   : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener>
 {
 public:
-  DataReaderListenerImpl();
+  DataReaderListenerImpl(DistributedConditionSet_rch dcs,
+                         const OpenDDS::DCPS::String& actor,
+                         long expected);
   virtual ~DataReaderListenerImpl();
 
   virtual void on_requested_deadline_missed (
@@ -45,10 +49,6 @@ public:
     DDS::DataReader_ptr reader,
     const DDS::SampleLostStatus& status);
 
-  long num_reads() const;
-
-  bool received_all_expected_messages() const;
-
   bool ok() const
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -56,9 +56,15 @@ public:
   }
 
 private:
+  long num_reads() const;
+  bool received_all_expected_messages() const;
+
+  DistributedConditionSet_rch dcs_;
+  const OpenDDS::DCPS::String actor_;
+  const long expected_;
   mutable ACE_Thread_Mutex mutex_;
   bool ok_;
-  std::map<int, int> read_intances_message_count_;
+  std::map<int, int> read_instances_message_count_;
 };
 
 #endif /* DATAREADER_LISTENER_IMPL  */

--- a/tests/DCPS/TransientLocalMultiInstanceTest/run_test.pl
+++ b/tests/DCPS/TransientLocalMultiInstanceTest/run_test.pl
@@ -37,22 +37,21 @@ my $sub_opts = $pub_opts;
 
 my $test = new PerlDDS::TestFramework();
 $test->{'wait_after_first_proc'} = 50;
-$test->enable_console_logging();
+#$test->enable_console_logging();
 
 $test->setup_discovery();
 
-$test->process('pub', 'publisher', $pub_opts);
-$test->process('sub1', 'subscriber', $sub_opts);
-$test->process('sub2', 'subscriber', $sub_opts);
+$test->process('pub', 'publisher', "-OpenDDSAppName pub " . $pub_opts);
+$test->process('sub1', 'subscriber', "-OpenDDSAppName sub1 " . $sub_opts);
+$test->process('sub2', 'subscriber', "-OpenDDSAppName sub2 " . $sub_opts);
 
 $test->start_process('sub1');
 
-sleep(2);
+$test->wait_for('driver', 'sub1', 'ready', 5);
 
 $test->start_process('pub');
 
-# Sleep for 2 seconds for publisher to write durable data.
-sleep(2);
+$test->wait_for('driver', 'pub', 'write done', 5);
 
 $test->start_process('sub2');
 


### PR DESCRIPTION
Problem
-------

Custom implementations of ReactorInterceptor duplicate code which makes maintenance difficult.

Solution
--------

To make the code easier to maintain, replace custom implementations of ReactorInterceptor with helper classes.