### PR TITLE
LivelinessTimer is a ReactorInterceptor

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -76,7 +76,6 @@ DataReaderImpl::DataReaderImpl()
   , domain_id_(0)
   , n_chunks_(TheServiceParticipant->n_chunks())
   , reactor_(0)
-  , liveliness_timer_(make_rch<LivelinessTimer>(TheServiceParticipant->reactor(), TheServiceParticipant->reactor_owner(), this))
   , last_deadline_missed_total_count_(0)
   , deadline_queue_enabled_(false)
   , deadline_task_(make_rch<DRISporadicTask>(TheServiceParticipant->time_source(), TheServiceParticipant->interceptor(), rchandle_from(this), &DataReaderImpl::deadline_task))
@@ -271,7 +270,7 @@ DataReaderImpl::add_association(const WriterAssociation& writer,
     ACE_WRITE_GUARD(ACE_RW_Thread_Mutex, write_guard, writers_lock_);
 
     const GUID_t& writer_id = writer.writerId;
-    WriterInfo_rch info = make_rch<WriterInfo>(rchandle_from<WriterInfoListener>(this), writer_id, writer.writerQos);
+    WriterInfo_rch info = make_rch<WriterInfo>(rchandle_from<WriterInfoListener>(this), writer_id, writer.writerQos, qos_.liveliness.lease_duration);
     std::pair<WriterMapType::iterator, bool> bpair = writers_.insert(
         // This insertion is idempotent.
         WriterMapType::value_type(
@@ -364,18 +363,6 @@ DataReaderImpl::transport_assoc_done(int flags, const GUID_t& remote_id)
     return;
   }
 
-  // LIVELINESS policy timers are managed here.
-  if (!liveliness_lease_duration_.is_zero()) {
-    if (DCPS_debug_level >= 5) {
-      ACE_DEBUG((LM_DEBUG,
-          ACE_TEXT("(%P|%t) DataReaderImpl::transport_assoc_done: ")
-          ACE_TEXT("starting/resetting liveliness timer for reader %C\n"),
-          LogGuid(get_guid()).c_str()));
-    }
-    // this call will start the timer if it is not already set
-    liveliness_timer_->check_liveliness();
-  }
-
   const RcHandle<DomainParticipantImpl> participant = participant_servant_.lock();
 
   if (!participant)
@@ -436,10 +423,12 @@ DataReaderImpl::transport_assoc_done(int flags, const GUID_t& remote_id)
       ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, sample_lock_);
       ACE_WRITE_GUARD(ACE_RW_Thread_Mutex, write_guard, writers_lock_);
 
-      if (!writers_.count(remote_id)) {
+      WriterMapType::iterator pos = writers_.find(remote_id);
+      if (pos == writers_.end()) {
         return;
       }
-      writers_[remote_id]->handle(handle);
+      pos->second->handle(handle);
+      pos->second->start_liveliness_timer();
     }
   }
 
@@ -1185,13 +1174,6 @@ DataReaderImpl::enable()
         " Cached_Allocator_With_Overflow %x with %d chunks\n",
         rd_allocator_.get(), n_chunks_));
 
-  if ((qos_.liveliness.lease_duration.sec !=
-      DDS::DURATION_INFINITE_SEC) &&
-      (qos_.liveliness.lease_duration.nanosec !=
-          DDS::DURATION_INFINITE_NSEC)) {
-    liveliness_lease_duration_ = TimeDuration(qos_.liveliness.lease_duration);
-  }
-
   // Setup the requested deadline watchdog if the configured deadline
   // period is not the default (infinite).
   DDS::Duration_t const deadline_period = this->qos_.deadline.period;
@@ -1795,131 +1777,6 @@ CORBA::Long DataReaderImpl::total_samples() const
 }
 
 void
-DataReaderImpl::LivelinessTimer::check_liveliness()
-{
-  execute_or_enqueue(make_rch<CheckLivelinessCommand>(this));
-}
-
-int
-DataReaderImpl::LivelinessTimer::handle_timeout(const ACE_Time_Value& tv,
-                                                const void * /*arg*/)
-{
-  ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
-
-  check_liveliness_i(false, MonotonicTimePoint(tv));
-  return 0;
-}
-
-void
-DataReaderImpl::LivelinessTimer::check_liveliness_i(bool cancel,
-                                                    const MonotonicTimePoint& now)
-{
-  // Working copy of the active timer Id.
-
-  RcHandle<DataReaderImpl> data_reader = data_reader_.lock();
-  if (! data_reader) {
-    this->reactor()->purge_pending_notifications(this);
-    return;
-  }
-
-  long local_timer_id = liveliness_timer_id_;
-  bool timer_was_reset = false;
-
-  if (local_timer_id != -1 && cancel) {
-    if (DCPS_debug_level >= 5) {
-      ACE_DEBUG((LM_DEBUG,
-                 ACE_TEXT("(%P|%t) DataReaderImpl::LivelinessTimer::check_liveliness_i: ")
-                 ACE_TEXT(" canceling timer for reader %C.\n"),
-                 LogGuid(data_reader->get_guid()).c_str()));
-    }
-
-    // called from add_associations and there is already a timer
-    // so cancel the existing timer.
-    if (this->reactor()->cancel_timer(local_timer_id) == -1) {
-      // this could fail because the reactor's call and
-      // the add_associations' call to this could overlap
-      // so it is not a failure.
-      ACE_DEBUG((LM_DEBUG,
-                 ACE_TEXT("(%P|%t) ERROR: DataReaderImpl::LivelinessTimer::check_liveliness_i: ")
-                 ACE_TEXT(" %p.\n"), ACE_TEXT("cancel_timer")));
-    }
-
-    timer_was_reset = true;
-  }
-
-  // Used after the lock scope ends.
-  MonotonicTimePoint smallest(MonotonicTimePoint::max_value);
-  int alive_writers = 0;
-
-  // This is a bit convoluted.  The reasoning goes as follows:
-  // 1) We grab the current timer Id value when we enter the method.
-  // 2) We *might* cancel the timer if it is active.
-  // 3) The timer *might* be rescheduled while we do not hold the sample lock.
-  // 4) If we (or another thread) canceled the timer that we can tell, then
-  // 5) we should clear the Id value,
-  // 6) unless it has been rescheduled.
-  // We are using a changed timer Id value as a proxy for having been
-  // rescheduled.
-  if( timer_was_reset && (liveliness_timer_id_ == local_timer_id)) {
-    liveliness_timer_id_ = -1;
-  }
-
-  // Iterate over each writer to this reader
-  {
-    ACE_READ_GUARD(ACE_RW_Thread_Mutex,
-        read_guard,
-        data_reader->writers_lock_);
-    WriterMapType writers = data_reader->writers_;
-    read_guard.release();
-
-    for (WriterMapType::iterator iter = writers.begin();
-        iter != writers.end();
-        ++iter) {
-      // deal with possibly not being alive or
-      // tell when it will not be alive next (if no activity)
-      const MonotonicTimePoint next_absolute(iter->second->check_activity(now));
-      if (!next_absolute.is_max()) {
-        alive_writers++;
-        smallest = std::min(smallest, next_absolute);
-      }
-    }
-  }
-
-  if (!alive_writers) {
-    // no live writers so no need to schedule a timer
-    // but be sure we don't try to cancel the timer later.
-    liveliness_timer_id_ = -1;
-  }
-
-  if (DCPS_debug_level >= 5) {
-    ACE_DEBUG((LM_DEBUG,
-        ACE_TEXT("(%P|%t) DataReaderImpl::LivelinessTimer::check_liveliness_i: ")
-        ACE_TEXT("reader %C has %d live writers; from_reactor=%d\n"),
-        LogGuid(data_reader->get_guid()).c_str(),
-        alive_writers,
-        !cancel));
-  }
-
-  // Call into the reactor after releasing the sample lock.
-  if (alive_writers) {
-    // compare the time now with the earliest(smallest) deadline we found
-    TimeDuration relative;
-    if (now < smallest) {
-      relative = smallest - now;
-    } else {
-      relative = TimeDuration(0, 1); // ASAP
-    }
-    liveliness_timer_id_ = this->reactor()->schedule_timer(this, 0, relative.value());
-
-    if (liveliness_timer_id_ == -1) {
-      ACE_ERROR((LM_ERROR,
-          ACE_TEXT("(%P|%t) ERROR: DataReaderImpl::LivelinessTimer::check_liveliness_i: ")
-          ACE_TEXT(" %p.\n"), ACE_TEXT("schedule_timer")));
-    }
-  }
-}
-
-void
 DataReaderImpl::release_instance(DDS::InstanceHandle_t handle)
 {
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
@@ -2050,15 +1907,15 @@ DataReaderImpl::writer_removed(WriterInfo& info)
 
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, sample_lock_);
 
-    const WriterInfo::WriterState info_state = info.state();
+    const WriterState info_state = info.state();
 
-    if (info_state == WriterInfo::ALIVE) {
+    if (info_state == ALIVE) {
       --liveliness_changed_status_.alive_count;
       --liveliness_changed_status_.alive_count_change;
       liveliness_changed = true;
     }
 
-    if (info_state == WriterInfo::DEAD) {
+    if (info_state == DEAD) {
       --liveliness_changed_status_.not_alive_count;
       --liveliness_changed_status_.not_alive_count_change;
       liveliness_changed = true;
@@ -2075,7 +1932,9 @@ DataReaderImpl::writer_removed(WriterInfo& info)
 }
 
 void
-DataReaderImpl::writer_became_alive(WriterInfo& info, const MonotonicTimePoint& /* when */)
+DataReaderImpl::writer_became_alive(WriterInfo& info,
+                                    const MonotonicTimePoint& /* when */,
+                                    WriterState previous_state)
 {
   const GUID_t info_writer_id = info.writer_id();
 
@@ -2084,25 +1943,23 @@ DataReaderImpl::writer_became_alive(WriterInfo& info, const MonotonicTimePoint& 
                ACE_TEXT("reader %C from writer %C previous state %C.\n"),
                LogGuid(get_guid()).c_str(),
                LogGuid(info_writer_id).c_str(),
-               info.get_state_str()));
+               get_state_str(previous_state)));
   }
 
   // NOTE: each instance will change to ALIVE_STATE when they receive a sample
-
-  const WriterInfo::WriterState info_state = info.state();
 
   {
     bool liveliness_changed = false;
 
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, sample_lock_);
 
-    if (info_state != WriterInfo::ALIVE) {
+    if (previous_state != ALIVE) {
       liveliness_changed_status_.alive_count++;
       liveliness_changed_status_.alive_count_change++;
       liveliness_changed = true;
     }
 
-    if (info_state == WriterInfo::DEAD) {
+    if (previous_state == DEAD) {
       liveliness_changed_status_.not_alive_count--;
       liveliness_changed_status_.not_alive_count_change--;
     }
@@ -2125,10 +1982,6 @@ DataReaderImpl::writer_became_alive(WriterInfo& info, const MonotonicTimePoint& 
 
     liveliness_changed_status_.last_publication_handle = info.handle();
 
-    // Change the state to ALIVE since handle_timeout may call writer_became_dead
-    // which need the current state info.
-    info.state(WriterInfo::ALIVE);
-
     if (this->monitor_) {
       this->monitor_->report();
     }
@@ -2139,13 +1992,11 @@ DataReaderImpl::writer_became_alive(WriterInfo& info, const MonotonicTimePoint& 
       this->notify_liveliness_change();
     }
   }
-
-  // this call will start the liveliness timer if it is not already set
-  liveliness_timer_->check_liveliness();
 }
 
 void
-DataReaderImpl::writer_became_dead(WriterInfo& info)
+DataReaderImpl::writer_became_dead(WriterInfo& info,
+                                   WriterState previous_state)
 {
   const GUID_t info_writer_id = info.writer_id();
 
@@ -2154,7 +2005,7 @@ DataReaderImpl::writer_became_dead(WriterInfo& info)
                ACE_TEXT("reader %C from writer %C previous state %C.\n"),
                LogGuid(get_guid()).c_str(),
                LogGuid(info_writer_id).c_str(),
-               info.get_state_str()));
+               get_state_str(previous_state)));
   }
 
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
@@ -2166,8 +2017,6 @@ DataReaderImpl::writer_became_dead(WriterInfo& info)
 #endif
 
   bool liveliness_changed = false;
-
-  const WriterInfo::WriterState info_state = info.state();
 
   DDS::InstanceHandle_t publication_handle = DDS::HANDLE_NIL;
   {
@@ -2181,13 +2030,13 @@ DataReaderImpl::writer_became_dead(WriterInfo& info)
   {
     ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, sample_lock_);
 
-    if (info_state != WriterInfo::DEAD) {
+    if (previous_state != DEAD) {
       ++liveliness_changed_status_.not_alive_count;
       ++liveliness_changed_status_.not_alive_count_change;
       liveliness_changed = true;
     }
 
-    if (info_state == WriterInfo::ALIVE) {
+    if (previous_state == ALIVE) {
       --liveliness_changed_status_.alive_count;
       --liveliness_changed_status_.alive_count_change;
     }
@@ -2209,8 +2058,6 @@ DataReaderImpl::writer_became_dead(WriterInfo& info)
     }
 
     liveliness_changed_status_.last_publication_handle = info.handle();
-
-    info.state(WriterInfo::DEAD);
 
     if (this->monitor_) {
       this->monitor_->report();
@@ -2773,7 +2620,7 @@ void DataReaderImpl::notify_liveliness_change()
       output_str += "\n\tNOTIFY: writer[ ";
       output_str += LogGuid(id).conv_;
       output_str += "] == ";
-      output_str += current->second->get_state_str();
+      output_str += get_state_str(current->second->state());
     }
 
     ACE_DEBUG((LM_DEBUG,

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -187,12 +187,14 @@ public:
   /// The writer state is inout parameter, it has to be set ALIVE before
   /// handle_timeout is called since some subroutine use the state.
   void writer_became_alive(WriterInfo& info,
-                           const MonotonicTimePoint& when);
+                           const MonotonicTimePoint& when,
+                           WriterState previous_state);
 
   /// tell instances when a DataWriter transitions to DEAD
   /// The writer state is inout parameter, the state is set to DEAD
   /// when it returns.
-  void writer_became_dead(WriterInfo& info);
+  void writer_became_dead(WriterInfo& info,
+                          WriterState previous_state);
 
   /// tell instance when a DataWriter is removed.
   /// The liveliness status need update.
@@ -385,7 +387,7 @@ public:
   typedef OPENDDS_VECTOR(DDS::InstanceHandle_t) InstanceHandleVec;
   void get_instance_handles(InstanceHandleVec& instance_handles);
 
-  typedef std::pair<GUID_t, WriterInfo::WriterState> WriterStatePair;
+  typedef std::pair<GUID_t, WriterState> WriterStatePair;
   typedef OPENDDS_VECTOR(WriterStatePair) WriterStatePairVec;
   void get_writer_states(WriterStatePairVec& writer_states);
 
@@ -831,73 +833,6 @@ private:
   /// The orb's reactor to be used to register the liveliness
   /// timer.
   ACE_Reactor_Timer_Interface* reactor_;
-
-  class LivelinessTimer : public ReactorInterceptor {
-  public:
-    LivelinessTimer(ACE_Reactor* reactor,
-                    ACE_thread_t owner,
-                    DataReaderImpl* data_reader)
-      : ReactorInterceptor(reactor, owner)
-      , data_reader_(*data_reader)
-      , liveliness_timer_id_(-1)
-    { }
-
-    void check_liveliness();
-
-    void cancel_timer()
-    {
-      execute_or_enqueue(make_rch<CancelCommand>(this));
-    }
-
-    virtual bool reactor_is_shut_down() const
-    {
-      return TheServiceParticipant->is_shut_down();
-    }
-
-  private:
-    WeakRcHandle<DataReaderImpl> data_reader_;
-
-    /// liveliness timer id; -1 if no timer is set
-    long liveliness_timer_id_;
-    void check_liveliness_i(bool cancel, const MonotonicTimePoint& now);
-
-    int handle_timeout(const ACE_Time_Value& current_time, const void* arg);
-
-    class CommandBase : public Command {
-    public:
-      CommandBase(LivelinessTimer* timer)
-        : timer_(timer)
-      { }
-
-    protected:
-      LivelinessTimer* timer_;
-    };
-
-    class CheckLivelinessCommand : public CommandBase {
-    public:
-      CheckLivelinessCommand(LivelinessTimer* timer)
-        : CommandBase(timer)
-      { }
-      virtual void execute()
-      {
-        timer_->check_liveliness_i(true, MonotonicTimePoint::now());
-      }
-    };
-
-    class CancelCommand : public CommandBase {
-    public:
-      CancelCommand(LivelinessTimer* timer)
-        : CommandBase(timer)
-      { }
-      virtual void execute()
-      {
-        if (timer_->liveliness_timer_id_ != -1) {
-          timer_->reactor()->cancel_timer(timer_);
-        }
-      }
-    };
-  };
-  RcHandle<LivelinessTimer> liveliness_timer_;
 
   CORBA::Long last_deadline_missed_total_count_;
   /// Watchdog responsible for reporting missed offered

--- a/dds/DCPS/RecorderImpl.cpp
+++ b/dds/DCPS/RecorderImpl.cpp
@@ -292,7 +292,7 @@ RecorderImpl::add_association(const WriterAssociation& writer,
       ACE_WRITE_GUARD(ACE_RW_Thread_Mutex, write_guard, writers_lock_);
 
       const GUID_t& writer_id = writer.writerId;
-      RcHandle<WriterInfo> info ( make_rch<WriterInfo>(rchandle_from<WriterInfoListener>(this), writer_id, writer.writerQos));
+      RcHandle<WriterInfo> info (make_rch<WriterInfo>(rchandle_from<WriterInfoListener>(this), writer_id, writer.writerQos, qos_.liveliness.lease_duration));
       /*std::pair<WriterMapType::iterator, bool> bpair =*/
       writers_.insert(
         // This insertion is idempotent.

--- a/dds/DCPS/WriterInfo.cpp
+++ b/dds/DCPS/WriterInfo.cpp
@@ -34,7 +34,8 @@ WriterInfoListener::~WriterInfoListener()
 /// handle_timeout is called since some subroutine use the state.
 void
 WriterInfoListener::writer_became_alive(WriterInfo&,
-                                        const MonotonicTimePoint&)
+                                        const MonotonicTimePoint&,
+                                        WriterState)
 {
 }
 
@@ -42,7 +43,8 @@ WriterInfoListener::writer_became_alive(WriterInfo&,
 /// The writer state is inout parameter, the state is set to DEAD
 /// when it returns.
 void
-WriterInfoListener::writer_became_dead(WriterInfo&)
+WriterInfoListener::writer_became_dead(WriterInfo&,
+                                       WriterState)
 {
 }
 
@@ -60,9 +62,10 @@ WriterInfoListener::resume_sample_processing(WriterInfo&)
 
 WriterInfo::WriterInfo(const WriterInfoListener_rch& reader,
                        const GUID_t& writer_id,
-                       const ::DDS::DataWriterQos& writer_qos)
-  : last_liveliness_activity_time_(MonotonicTimePoint::now())
-  , historic_samples_sweeper_task_(make_rch<WriterInfoSporadicTask>(TheServiceParticipant->time_source(), TheServiceParticipant->interceptor(), rchandle_from(this), &WriterInfo::sweep_historic_samples))
+                       const ::DDS::DataWriterQos& writer_qos,
+                       const DDS::Duration_t& reader_liveliness_lease_duration)
+  : historic_samples_sweeper_task_(make_rch<WriterInfoSporadicTask>(TheServiceParticipant->time_source(), TheServiceParticipant->interceptor(), rchandle_from(this), &WriterInfo::sweep_historic_samples))
+  , liveliness_check_task_(make_rch<WriterInfoSporadicTask>(TheServiceParticipant->time_source(), TheServiceParticipant->interceptor(), rchandle_from(this), &WriterInfo::check_liveliness))
   , last_historic_seq_(SequenceNumber::SEQUENCENUMBER_UNKNOWN())
   , waiting_for_end_historic_samples_(false)
   , delivering_historic_samples_(false)
@@ -71,6 +74,8 @@ WriterInfo::WriterInfo(const WriterInfoListener_rch& reader,
   , reader_(reader)
   , writer_id_(writer_id)
   , writer_qos_(writer_qos)
+  , reader_liveliness_lease_duration_(reader_liveliness_lease_duration)
+  , reader_liveliness_lease_duration_is_finite_(!is_infinite(reader_liveliness_lease_duration))
   , handle_(DDS::HANDLE_NIL)
 {
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
@@ -89,12 +94,12 @@ WriterInfo::WriterInfo(const WriterInfoListener_rch& reader,
 WriterInfo::~WriterInfo()
 {
   historic_samples_sweeper_task_->cancel();
+  liveliness_check_task_->cancel();
 }
 
-const char* WriterInfo::get_state_str() const
+const char* get_state_str(WriterState state)
 {
-  ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
-  switch (state_) {
+  switch (state) {
   case NOT_SET:
     return "NOT_SET";
   case ALIVE:
@@ -102,9 +107,9 @@ const char* WriterInfo::get_state_str() const
   case DEAD:
     return "DEAD";
   default:
-    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: WriterInfo::get_state_str: ")
+    ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR:get_state_str(WriterState): ")
       ACE_TEXT("%d is either invalid or not recognized.\n"),
-      state_));
+      state));
     return "Invalid state";
   }
 }
@@ -239,28 +244,40 @@ WriterInfo::remove_instance(DDS::InstanceHandle_t instance)
   owner_evaluated_.erase(instance);
 }
 
-MonotonicTimePoint
-WriterInfo::check_activity(const MonotonicTimePoint& now)
+void
+WriterInfo::start_liveliness_timer()
 {
-  MonotonicTimePoint expires_at(MonotonicTimePoint::max_value);
-
   ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+  last_liveliness_activity_time_ = MonotonicTimePoint::now();
+  if (reader_liveliness_lease_duration_is_finite_) {
+    liveliness_check_task_->schedule(reader_liveliness_lease_duration_);
+  }
+}
 
-  WriterInfoListener_rch reader = reader_.lock();
+void
+WriterInfo::check_liveliness(const MonotonicTimePoint& now)
+{
+  bool became_dead = false;
+  WriterState previous_state;
 
-  // We only need check the liveliness with the non-zero liveliness_lease_duration_.
-  if (state_ == ALIVE && reader && !reader->liveliness_lease_duration_.is_zero()) {
-    expires_at = last_liveliness_activity_time_ + reader->liveliness_lease_duration_;
-
-    if (expires_at <= now) {
-      // let all instances know this write is not alive.
-      guard.release();
-      reader->writer_became_dead(*this);
-      expires_at = MonotonicTimePoint::max_value;
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    previous_state = state_;
+    if (state_ == ALIVE) {
+      const TimeDuration elapsed = now - last_liveliness_activity_time_;
+      became_dead = elapsed > reader_liveliness_lease_duration_;
+      if (became_dead) {
+        state_ = DEAD;
+      } else {
+        liveliness_check_task_->schedule(reader_liveliness_lease_duration_ - elapsed);
+      }
     }
   }
 
-  return expires_at;
+  WriterInfoListener_rch reader = reader_.lock();
+  if (reader && became_dead) {
+    reader->writer_became_dead(*this, previous_state);
+  }
 }
 
 void
@@ -272,6 +289,8 @@ WriterInfo::removed()
   if (reader) {
     reader->writer_removed(*this);
   }
+  historic_samples_sweeper_task_->cancel();
+  liveliness_check_task_->cancel();
 }
 
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE


### PR DESCRIPTION
Problem
-------

Custom implementations of ReactorInterceptor duplicate code which makes maintenance difficult.

Solution
--------

To make the code easier to maintain, replace custom implementations of ReactorInterceptor with helper classes.