### PR TITLE
PendingAssocTimer is a ReactorInterceptor

### DIFF
--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -34,8 +34,7 @@ namespace OpenDDS {
 namespace DCPS {
 
 TransportClient::TransportClient()
-  : pending_assoc_timer_(make_rch<PendingAssocTimer> (TheServiceParticipant->reactor(), TheServiceParticipant->reactor_owner()))
-  , expected_transaction_id_(1)
+  : expected_transaction_id_(1)
   , max_transaction_id_seen_(0)
   , max_transaction_tail_(0)
   , swap_bytes_(false)
@@ -326,7 +325,7 @@ TransportClient::associate(const AssociationData& data, bool active)
             if (res.link_.is_nil()) {
               // In this case, it may be waiting for the TCP connection to be
               // established.  Just wait without trying other transports.
-              pending_assoc_timer_->schedule_timer(rchandle_from(this), iter->second);
+              iter->second->schedule(passive_connect_duration_);
             } else {
               use_datalink_i(data.remote_id_, res.link_, guard);
               return true;
@@ -336,7 +335,7 @@ TransportClient::associate(const AssociationData& data, bool active)
       }
     }
 
-    pending_assoc_timer_->schedule_timer(rchandle_from(this), iter->second);
+    iter->second->schedule(passive_connect_duration_);
   }
 
   return true;
@@ -357,39 +356,8 @@ TransportClient::PendingAssoc::safe_to_remove()
 }
 
 void
-TransportClient::PendingAssocTimer::ScheduleCommand::execute()
+TransportClient::PendingAssoc::timeout(const MonotonicTimePoint&)
 {
-  if (timer_->reactor()) {
-    const TransportClient_rch client = transport_client_.lock();
-    if (client) {
-      ACE_Guard<ACE_Thread_Mutex> guard(assoc_->mutex_);
-      assoc_->scheduled_ = true;
-      const Timers::TimerId id = Timers::schedule(timer_->reactor(), *assoc_, client.in(),
-                                                  client->passive_connect_duration_);
-      if (id != Timers::InvalidTimerId) {
-        timer_->set_id(id);
-      }
-    }
-  }
-}
-
-void
-TransportClient::PendingAssocTimer::CancelCommand::execute()
-{
-  if (timer_->reactor() && timer_->get_id() != Timers::InvalidTimerId) {
-    ACE_Guard<ACE_Thread_Mutex> guard(assoc_->mutex_);
-    Timers::cancel(timer_->reactor(), timer_->get_id());
-    timer_->set_id(Timers::InvalidTimerId);
-    assoc_->scheduled_ = false;
-  }
-}
-
-int
-TransportClient::PendingAssoc::handle_timeout(const ACE_Time_Value&,
-                                              const void* arg)
-{
-  ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
-
   RcHandle<TransportClient> client;
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
@@ -397,10 +365,9 @@ TransportClient::PendingAssoc::handle_timeout(const ACE_Time_Value&,
     scheduled_ = false;
   }
 
-  if (client && client.get() == static_cast<TransportClient*>(const_cast<void*>(arg))) {
+  if (client) {
     client->use_datalink(data_.remote_id_, DataLink_rch());
   }
-  return 0;
 }
 
 bool
@@ -622,7 +589,7 @@ TransportClient::use_datalink_i(const GUID_t& remote_id_ref,
 
   pend_guard.release();
   pend->reset_client();
-  pending_assoc_timer_->cancel_timer(pend);
+  pend->cancel();
   prev_pending_.insert(std::make_pair(iter->first, iter->second));
   pending_.erase(iter);
 
@@ -664,7 +631,7 @@ TransportClient::stop_associating()
       }
     }
     it->second->reset_client();
-    pending_assoc_timer_->cancel_timer(it->second);
+    it->second->cancel();
     prev_pending_.insert(std::make_pair(it->first, it->second));
   }
   pending_.clear();
@@ -692,7 +659,7 @@ TransportClient::stop_associating(const GUID_t* repos, CORBA::ULong length)
           }
         }
         iter->second->reset_client();
-        pending_assoc_timer_->cancel_timer(iter->second);
+        iter->second->cancel();
         prev_pending_.insert(std::make_pair(iter->first, iter->second));
         pending_.erase(iter);
       }
@@ -733,7 +700,7 @@ TransportClient::disassociate(const GUID_t& peerId)
       }
     }
     iter->second->reset_client();
-    pending_assoc_timer_->cancel_timer(iter->second);
+    iter->second->cancel();
     prev_pending_.insert(std::make_pair(iter->first, iter->second));
     pending_.erase(iter);
     return;

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -14,7 +14,6 @@
 
 #include <dds/DCPS/dcps_export.h>
 #include <dds/DCPS/AssociationData.h>
-#include <dds/DCPS/ReactorInterceptor.h>
 #include <dds/DCPS/Service_Participant.h>
 #include <dds/DCPS/PoolAllocator.h>
 #include <dds/DCPS/PoolAllocationBase.h>
@@ -207,9 +206,10 @@ private:
   typedef OPENDDS_VECTOR(WeakRcHandle<TransportImpl>) ImplsType;
 
   typedef ACE_Reverse_Lock<ACE_Thread_Mutex> Reverse_Lock_t;
-  struct PendingAssoc : RcEventHandler {
+  struct PendingAssoc : RcObject {
     ACE_Thread_Mutex mutex_;
-    bool active_, scheduled_;
+    bool active_;
+    bool scheduled_;
     ImplsType impls_;
     CORBA::ULong blob_index_;
     AssociationData data_;
@@ -221,12 +221,36 @@ private:
       , scheduled_(false)
       , blob_index_(0)
       , client_(tc_rch)
+      , timeout_task_(make_rch<PendingAssocSporadicTask>(TheServiceParticipant->time_source(), TheServiceParticipant->interceptor(), rchandle_from(this), &PendingAssoc::timeout))
     {}
+
+    ~PendingAssoc()
+    {
+      timeout_task_->cancel();
+    }
 
     void reset_client();
     bool safe_to_remove();
     bool initiate_connect(TransportClient* tc, Guard& guard);
-    int handle_timeout(const ACE_Time_Value& time, const void* arg);
+
+    void schedule(const TimeDuration& delay)
+    {
+      ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+      timeout_task_->schedule(delay);
+      scheduled_ = true;
+    }
+
+    void cancel()
+    {
+      ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+      timeout_task_->cancel();
+      scheduled_ = false;
+    }
+
+  private:
+    typedef PmfSporadicTask<PendingAssoc> PendingAssocSporadicTask;
+    RcHandle<PendingAssocSporadicTask> timeout_task_;
+    void timeout(const MonotonicTimePoint& now);
   };
 
   typedef RcHandle<PendingAssoc> PendingAssoc_rch;
@@ -235,65 +259,6 @@ private:
   typedef OPENDDS_MULTIMAP_CMP(GUID_t, PendingAssoc_rch, GUID_tKeyLessThan) PrevPendingMap;
 
   void clean_prev_pending();
-
-  class PendingAssocTimer : public ReactorInterceptor {
-  public:
-    PendingAssocTimer(ACE_Reactor* reactor,
-                      ACE_thread_t owner)
-      : ReactorInterceptor(reactor, owner)
-      , timer_id_(-1)
-    { }
-
-    void schedule_timer(TransportClient_rch transport_client, const PendingAssoc_rch& pend)
-    {
-      execute_or_enqueue(make_rch<ScheduleCommand>(this, transport_client, pend));
-    }
-
-    ReactorInterceptor::CommandPtr cancel_timer(const PendingAssoc_rch& pend)
-    {
-      return execute_or_enqueue(make_rch<CancelCommand>(this, pend));
-    }
-
-    void set_id(long id) { timer_id_ = id; }
-    long get_id() const { return timer_id_; }
-
-    virtual bool reactor_is_shut_down() const
-    {
-      return TheServiceParticipant->is_shut_down();
-    }
-
-  private:
-    class CommandBase : public Command {
-    public:
-      CommandBase(PendingAssocTimer* timer,
-                  const PendingAssoc_rch& assoc)
-        : timer_(timer)
-        , assoc_(assoc)
-      { }
-    protected:
-      PendingAssocTimer* timer_;
-      PendingAssoc_rch assoc_;
-    };
-    struct ScheduleCommand : public CommandBase {
-      ScheduleCommand(PendingAssocTimer* timer,
-                      TransportClient_rch transport_client,
-                      const PendingAssoc_rch& assoc)
-        : CommandBase(timer, assoc)
-        , transport_client_(transport_client)
-      { }
-      virtual void execute();
-      const WeakRcHandle<TransportClient> transport_client_;
-    };
-    struct CancelCommand : public CommandBase {
-      CancelCommand(PendingAssocTimer* timer,
-                    const PendingAssoc_rch& assoc)
-        : CommandBase(timer, assoc)
-      { }
-      virtual void execute();
-    };
-    long timer_id_;
-  };
-  RcHandle<PendingAssocTimer> pending_assoc_timer_;
 
   // Associated Impls and DataLinks:
 


### PR DESCRIPTION
Problem
-------

Custom implementations of ReactorInterceptor duplicate code which makes maintenance difficult.

Solution
--------

To make the code easier to maintain, replace custom implementations of ReactorInterceptor with helper classes.