### PR TITLE
DataLink Interceptor is a ReactorInterceptor

### DIFF
--- a/dds/DCPS/Timers.cpp
+++ b/dds/DCPS/Timers.cpp
@@ -88,6 +88,7 @@ TimerId schedule(ACE_Reactor* reactor,
     if (log_level >= LogLevel::Notice) {
       ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: Timers::schedule: register_handler %m\n"));
     }
+    close(fd);
     return InvalidTimerId;
   }
   static const timespec one_ns = {0, 1};
@@ -100,6 +101,7 @@ TimerId schedule(ACE_Reactor* reactor,
     if (log_level >= LogLevel::Notice) {
       ACE_ERROR((LM_NOTICE, "(%P|%t) NOTICE: Timers::schedule: timerfd_settime %m\n"));
     }
+    close(fd);
     return InvalidTimerId;
   }
   return fd;

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -264,12 +264,6 @@ public:
   bool invoke_on_start_callbacks(const GUID_t& local, const GUID_t& remote, bool success);
   void remove_startup_callbacks(const GUID_t& local, const GUID_t& remote);
 
-  class Interceptor : public ReactorInterceptor {
-  public:
-    Interceptor(ACE_Reactor* reactor, ACE_thread_t owner) : ReactorInterceptor(reactor, owner) {}
-    bool reactor_is_shut_down() const;
-  };
-
   class ImmediateStart : public virtual ReactorInterceptor::Command {
   public:
     ImmediateStart(RcHandle<DataLink> link, WeakRcHandle<TransportClient> client, const GUID_t& remote) : link_(link), client_(client), remote_(remote) {}
@@ -466,8 +460,6 @@ protected:
 
   /// Listener for TransportSendControlElements created in send_control
   SendResponseListener send_response_listener_;
-
-  Interceptor interceptor_;
 };
 
 } // namespace DCPS


### PR DESCRIPTION
Problem
-------

Custom implementations of ReactorInterceptor duplicate code which makes maintenance difficult.

Solution
--------

To make the code easier to maintain, replace custom implementations of ReactorInterceptor with helper classes.