### PR TITLE
Updated links in documentation

### DIFF
--- a/docs/devguide/building/dependencies.rst
+++ b/docs/devguide/building/dependencies.rst
@@ -124,7 +124,7 @@ TAO is a C++ CORBA Implementation built on ACE.
 
   - This is the only library which depends on ``TAO_PortableServer``.
 
-The TAO Developer's Guide book can be requested for free from https://objectcomputing.com/platforms/tao/tao-developers-guide.
+The TAO Developer's Guide book can be requested for free from https://objectcomputing.com/how-we-serve/accelerators/tao/tao-developers-guide.
 The CORBA Programmers Guide can be downloaded for free from https://www.remedy.nl/opensource/corbapg.html.
 
 .. _deps-optional:

--- a/docs/devguide/internet_enabled_rtps.rst
+++ b/docs/devguide/internet_enabled_rtps.rst
@@ -453,7 +453,7 @@ Understand the Weaknesses of (Secure) RTPS Discovery
 ..
     Sect<15.4.2>
 
-Secure RTPS Discovery has a behavior that can be exploited to launch a denial of service attack (see https://www.cisa.gov/news-events/ics-advisories/icsa-21-315-02).
+Secure RTPS Discovery has a behavior that can be exploited to launch a denial of service attack (see CISA advisory icsa-21-315-02).
 Basically, an attacker can send a fake SPDP message to a secure participant which will cause it to begin authentication with a non-existent participant.
 The authentication messages are repeated resulting in amplification.
 An attacker could manipulate a group of secure participants to launch a denial of service attack against a specific host or group of hosts.


### PR DESCRIPTION
Use a more specific link for the TAO Developer's Guide
CISA website is constantly failing the link check in GitHub Actions