### PR TITLE
Update FlexibleTypeSupport to handle an additional order of events

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -7068,6 +7068,19 @@ void Sedp::match(const GUID_t& writer, const GUID_t& reader)
   if (lpi != local_publications_.end()) {
     writer_local = true;
     writer_type_info = lpi->second.typeInfoFor(reader);
+    if ((lpi->second.type_info_.flags_ & DCPS::TypeInformation::Flags_FlexibleTypeSupport)
+        && writer_type_info->minimal.typeid_with_size.type_id.kind() == XTypes::TK_NONE) {
+      if (DCPS_debug_level >= 4) {
+        ACE_DEBUG((LM_DEBUG, "(%P|%t) Sedp::match: Local writer with Flexible TS and no type\n"));
+      }
+      const DCPS::DataWriterCallbacks_rch callbacks = lpi->second.publication_.lock();
+      if (callbacks) {
+        const DCPS::String typeKey = spdp_.find_flexible_types_key_i(reader);
+        if (typeKey != "") {
+          writer_type_info = lpi->second.getFlexibleTypes(callbacks, reader, typeKey.c_str());
+        }
+      }
+    }
   } else if ((dpi = discovered_publications_.find(writer))
              != discovered_publications_.end()) {
     writer_type_info = &dpi->second.type_info_;
@@ -7086,6 +7099,19 @@ void Sedp::match(const GUID_t& writer, const GUID_t& reader)
   if (lsi != local_subscriptions_.end()) {
     reader_local = true;
     reader_type_info = lsi->second.typeInfoFor(writer);
+    if ((lsi->second.type_info_.flags_ & DCPS::TypeInformation::Flags_FlexibleTypeSupport)
+        && reader_type_info->minimal.typeid_with_size.type_id.kind() == XTypes::TK_NONE) {
+      if (DCPS_debug_level >= 4) {
+        ACE_DEBUG((LM_DEBUG, "(%P|%t) Sedp::match: Local reader with Flexible TS and no type\n"));
+      }
+      const DCPS::DataReaderCallbacks_rch callbacks = lsi->second.subscription_.lock();
+      if (callbacks) {
+        const DCPS::String typeKey = spdp_.find_flexible_types_key_i(writer);
+        if (typeKey != "") {
+          reader_type_info = lsi->second.getFlexibleTypes(callbacks, writer, typeKey.c_str());
+        }
+      }
+    }
   } else if ((dsi = discovered_subscriptions_.find(reader))
              != discovered_subscriptions_.end()) {
     reader_type_info = &dsi->second.type_info_;

--- a/tests/DCPS/FlexibleTS/Controller/Controller.cpp
+++ b/tests/DCPS/FlexibleTS/Controller/Controller.cpp
@@ -44,6 +44,8 @@ std::string setup_typesupport(HelloWorld::MessageTypeSupport& base, const DDS::D
                                                getCompleteTypeIdentifier<HelloWorld_State_xtag>(),
                                                valuesToRemove, *lookup, cmpTm);
   flex->add(OLD_TYPE, minOldTi, minTm, cmpOldTi, cmpTm);
+  lookup->add(minTm.begin(), minTm.end());
+  lookup->add(cmpTm.begin(), cmpTm.end());
   return NEW_TYPE;
 }
 
@@ -124,6 +126,9 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 
   HelloWorld::MessageDataReader_var message_data_reader = HelloWorld::MessageDataReader::_narrow(data_reader);
 
+  DDS::ReadCondition_var read_condition =
+    data_reader->create_readcondition(DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
+
   DDS::Topic_var topic2 = participant->create_topic(HelloWorld::COMMAND_TOPIC_NAME, type_name.c_str(),
                                                     TOPIC_QOS_DEFAULT, 0, 0);
 
@@ -132,9 +137,6 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   DDS::DataWriter_var data_writer = publisher->create_datawriter(topic2, DATAWRITER_QOS_DEFAULT, 0, 0);
 
   HelloWorld::MessageDataWriter_var message_data_writer = HelloWorld::MessageDataWriter::_narrow(data_writer);
-
-  DDS::ReadCondition_var read_condition =
-    data_reader->create_readcondition(DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
   DDS::WaitSet_var wait_set = new DDS::WaitSet;
   wait_set->attach_condition(read_condition);
@@ -171,6 +173,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   HelloWorld::Message message;
   message.deviceId = HelloWorld::OLDDEV;
   message.st = HelloWorld::Intermediate;
+  message.added = true;
   message_data_writer->write(message, DDS::HANDLE_NIL);
 
   message.deviceId = HelloWorld::NEWDEV;

--- a/tests/DCPS/FlexibleTS/NewDevice/NewDevice.cpp
+++ b/tests/DCPS/FlexibleTS/NewDevice/NewDevice.cpp
@@ -59,6 +59,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   HelloWorld::Message message;
   message.deviceId = HelloWorld::NEWDEV;
   message.st = HelloWorld::Initial;
+  message.added = true;
   message_data_writer->write(message, DDS::HANDLE_NIL);
 
   DDS::ReadCondition_var read_condition =

--- a/tests/DCPS/FlexibleTS/NewDevice/NewDevice.idl
+++ b/tests/DCPS/FlexibleTS/NewDevice/NewDevice.idl
@@ -6,5 +6,6 @@ module HelloWorld {
   struct Message {
     @key string deviceId;
     State st;
+    boolean added;
   };
 };


### PR DESCRIPTION
Also test the case where types have a compatible change (adding a member to a struct)