### PR TITLE
Update Sphinx Markdown Builder

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ Sphinx>=7.2
 doc2dash
 furo
 sphinx-copybutton
-sphinx-markdown-builder==0.6.6
+sphinx-markdown-builder>=0.6.8
 sphinx-inline-tabs
 PyMuPDF
 sphinxcontrib-svgbob


### PR DESCRIPTION
Fixes https://github.com/OpenDDS/OpenDDS/issues/4822 by updating to a version with a fix for https://github.com/liran-funaro/sphinx-markdown-builder/issues/25.