### PR TITLE
TypeLookup fails with missing dependencies

### DIFF
--- a/dds/DCPS/FlexibleTypeSupport.cpp
+++ b/dds/DCPS/FlexibleTypeSupport.cpp
@@ -68,6 +68,47 @@ void FlexibleTypeSupport::get_flexible_types(const char* key, XTypes::TypeInform
   }
 }
 
+void FlexibleTypeSupport::add_types(const RcHandle<XTypes::TypeLookupService>& tls) const
+{
+  for (MapType::const_iterator pos = map_.begin(), limit = map_.end(); pos != limit; ++pos) {
+    {
+      XTypes::TypeMap type_map = getMinimalTypeMap();
+      type_map.insert(pos->second.minimalMap_.begin(), pos->second.minimalMap_.end());
+      populate_dependencies_i(tls, pos->second.minimalId_, type_map);
+    }
+    {
+      XTypes::TypeMap type_map = getCompleteTypeMap();
+      type_map.insert(pos->second.completeMap_.begin(), pos->second.completeMap_.end());
+      populate_dependencies_i(tls, pos->second.completeId_, type_map);
+    }
+  }
+  base_->add_types(tls);
+}
+
+void FlexibleTypeSupport::populate_dependencies_i(const XTypes::TypeLookupService_rch& tls,
+                                                  const XTypes::TypeIdentifier& type_id,
+                                                  const XTypes::TypeMap& type_map) const
+{
+  OPENDDS_SET(XTypes::TypeIdentifier) dependencies;
+  XTypes::compute_dependencies(type_map, type_id, dependencies);
+
+  XTypes::TypeIdentifierWithSizeSeq deps_with_size;
+  OPENDDS_SET(XTypes::TypeIdentifier)::const_iterator it = dependencies.begin();
+  for (; it != dependencies.end(); ++it) {
+    XTypes::TypeMap::const_iterator iter = type_map.find(*it);
+    if (iter != type_map.end()) {
+      const size_t tobj_size = serialized_size(XTypes::get_typeobject_encoding(), iter->second);
+      XTypes::TypeIdentifierWithSize ti_with_size(*it, static_cast<ACE_CDR::ULong>(tobj_size));
+      deps_with_size.append(ti_with_size);
+    } else if (XTypes::has_type_object(*it)) {
+      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: FlexibleTypeSupport::populate_dependencies_io, ")
+                 ACE_TEXT("local TypeIdentifier (%C) not found in local type map.\n"),
+                 XTypes::equivalence_hash_to_string(it->equivalence_hash()).c_str()));
+    }
+  }
+  tls->add_type_dependencies(type_id, deps_with_size);
+}
+
 FlexibleTypeSupport::Alternative::Alternative(const XTypes::TypeIdentifier& minimalTypeIdentifier,
                                               const XTypes::TypeMap& minimalTypeMap,
                                               const XTypes::TypeIdentifier& completeTypeIdentifier,

--- a/dds/DCPS/FlexibleTypeSupport.cpp
+++ b/dds/DCPS/FlexibleTypeSupport.cpp
@@ -101,9 +101,11 @@ void FlexibleTypeSupport::populate_dependencies_i(const XTypes::TypeLookupServic
       XTypes::TypeIdentifierWithSize ti_with_size(*it, static_cast<ACE_CDR::ULong>(tobj_size));
       deps_with_size.append(ti_with_size);
     } else if (XTypes::has_type_object(*it)) {
-      ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR: FlexibleTypeSupport::populate_dependencies_io, ")
-                 ACE_TEXT("local TypeIdentifier (%C) not found in local type map.\n"),
-                 XTypes::equivalence_hash_to_string(it->equivalence_hash()).c_str()));
+      if (log_level >= LogLevel::Error) {
+        ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: FlexibleTypeSupport::populate_dependencies_i: "
+                   "local TypeIdentifier (%C) not found in local type map.\n",
+                   XTypes::equivalence_hash_to_string(it->equivalence_hash()).c_str()));
+      }
     }
   }
   tls->add_type_dependencies(type_id, deps_with_size);

--- a/dds/DCPS/FlexibleTypeSupport.h
+++ b/dds/DCPS/FlexibleTypeSupport.h
@@ -36,7 +36,6 @@ public:
                         const XTypes::TypeMap& minimalTypeMap,
                         const XTypes::TypeIdentifier& completeTypeIdentifier,
                         const XTypes::TypeMap& completeTypeMap);
-  void populate_dependencies(const RcHandle<XTypes::TypeLookupService>& tls) const;
 
   void to_type_info(TypeInformation& type_info) const;
   const XTypes::TypeIdentifier& getMinimalTypeIdentifier() const;

--- a/dds/DCPS/FlexibleTypeSupport.h
+++ b/dds/DCPS/FlexibleTypeSupport.h
@@ -36,6 +36,7 @@ public:
                         const XTypes::TypeMap& minimalTypeMap,
                         const XTypes::TypeIdentifier& completeTypeIdentifier,
                         const XTypes::TypeMap& completeTypeMap);
+  void populate_dependencies(const RcHandle<XTypes::TypeLookupService>& tls) const;
 
   void to_type_info(TypeInformation& type_info) const;
   const XTypes::TypeIdentifier& getMinimalTypeIdentifier() const;
@@ -60,8 +61,13 @@ public:
   Extensibility base_extensibility() const { return base_->base_extensibility(); }
   Extensibility max_extensibility() const { return base_->max_extensibility(); }
 
-private:
   void get_flexible_types(const char* key, XTypes::TypeInformation& type_info);
+  void add_types(const XTypes::TypeLookupService_rch& tls) const;
+
+private:
+  void populate_dependencies_i(const XTypes::TypeLookupService_rch& tls,
+                               const XTypes::TypeIdentifier& tid,
+                               const XTypes::TypeMap& tm) const;
 
   RcHandle<TypeSupportImpl> base_;
   String name_;
@@ -75,7 +81,8 @@ private:
     XTypes::TypeIdentifier minimalId_, completeId_;
     XTypes::TypeMap minimalMap_, completeMap_;
   };
-  OPENDDS_MAP(String, Alternative) map_;
+  typedef OPENDDS_MAP(String, Alternative) MapType;
+  MapType map_;
 
   OPENDDS_DELETED_COPY_MOVE_CTOR_ASSIGN(FlexibleTypeSupport)
 };

--- a/dds/DCPS/TypeSupportImpl.h
+++ b/dds/DCPS/TypeSupportImpl.h
@@ -137,7 +137,7 @@ public:
   virtual void get_flexible_types(const char* /*key*/,
                                   XTypes::TypeInformation& /*type_info*/) {}
 
-  void add_types(const XTypes::TypeLookupService_rch& tls) const;
+  virtual void add_types(const XTypes::TypeLookupService_rch& tls) const;
 
   RepresentationFormat* make_format(DDS::DataRepresentationId_t representation);
 

--- a/dds/DCPS/XTypes/TypeObject.cpp
+++ b/dds/DCPS/XTypes/TypeObject.cpp
@@ -880,46 +880,9 @@ namespace {
     compute_dependencies_i(type_map, type.flag_seq, dependencies);
   }
 
+  template <typename T>
   void compute_dependencies_i(const TypeMap& type_map,
-                              const MinimalTypeObject& type_object,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
-  {
-    switch (type_object.kind) {
-    case TK_ALIAS:
-      compute_dependencies_i(type_map, type_object.alias_type, dependencies);
-      break;
-    case TK_ANNOTATION:
-      compute_dependencies_i(type_map, type_object.annotation_type, dependencies);
-      break;
-    case TK_STRUCTURE:
-      compute_dependencies_i(type_map, type_object.struct_type, dependencies);
-      break;
-    case TK_UNION:
-      compute_dependencies_i(type_map, type_object.union_type, dependencies);
-      break;
-    case TK_BITSET:
-      compute_dependencies_i(type_map, type_object.bitset_type, dependencies);
-      break;
-    case TK_SEQUENCE:
-      compute_dependencies_i(type_map, type_object.sequence_type, dependencies);
-      break;
-    case TK_ARRAY:
-      compute_dependencies_i(type_map, type_object.array_type, dependencies);
-      break;
-    case TK_MAP:
-      compute_dependencies_i(type_map, type_object.map_type, dependencies);
-      break;
-    case TK_ENUM:
-      compute_dependencies_i(type_map, type_object.enumerated_type, dependencies);
-      break;
-    case TK_BITMASK:
-      compute_dependencies_i(type_map, type_object.bitmask_type, dependencies);
-      break;
-    }
-  }
-
-  void compute_dependencies_i(const TypeMap& type_map,
-                              const CompleteTypeObject& type_object,
+                              const T& type_object, // MinimalTypeObject, CompleteTypeObject
                               OPENDDS_SET(TypeIdentifier)& dependencies)
   {
     switch (type_object.kind) {

--- a/dds/DCPS/XTypes/TypeObject.cpp
+++ b/dds/DCPS/XTypes/TypeObject.cpp
@@ -469,639 +469,649 @@ bool has_type_object(const TypeIdentifier& ti)
 const TypeMap TypeMapBuilder::EmptyMap;
 
 namespace {
-template <typename T>
-void compute_dependencies(const TypeMap& type_map,
-                          const Sequence<T>& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies);
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const TypeIdentifier& type_identifier,
+                              OPENDDS_SET(TypeIdentifier)& dependencies);
 
-void compute_dependencies(const TypeMap& type_map,
-                          const CommonAliasBody& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.related_type, dependencies);
-}
+  template <typename T>
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const Sequence<T>& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies);
 
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalAliasBody& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.common, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalAliasType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.body, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const AppliedAnnotation& ann,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, ann.annotation_typeid, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const OPENDDS_OPTIONAL_NS::optional<AppliedAnnotationSeq>& ann_seq,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  if (ann_seq) {
-    compute_dependencies(type_map, ann_seq.value(), dependencies);
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CommonAliasBody& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.related_type, dependencies);
   }
-}
 
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteTypeDetail& type_detail,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type_detail.ann_custom, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteAliasHeader& header,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, header.detail, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteAliasBody& body,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, body.common, dependencies);
-  compute_dependencies(type_map, body.ann_custom, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteAliasType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, type.body, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CommonAnnotationParameter& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.member_type_id, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalAnnotationParameter& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.common, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalAnnotationType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.member_seq, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteAnnotationParameter& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.common, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteAnnotationType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.member_seq, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalStructHeader& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.base_type, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CommonStructMember& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.member_type_id, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalStructMember& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.common, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalStructType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, type.member_seq, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteStructHeader& header,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, header.base_type, dependencies);
-  compute_dependencies(type_map, header.detail, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteMemberDetail& detail,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, detail.ann_custom, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteStructMember& member,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, member.common, dependencies);
-  compute_dependencies(type_map, member.detail, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteStructType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, type.member_seq, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CommonDiscriminatorMember& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.type_id, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalDiscriminatorMember& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.common, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CommonUnionMember& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.type_id, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalUnionMember& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.common, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalUnionType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.discriminator, dependencies);
-  compute_dependencies(type_map, type.member_seq, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteUnionHeader& header,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, header.detail, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteDiscriminatorMember& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.common, dependencies);
-  compute_dependencies(type_map, type.ann_custom, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteUnionMember& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.common, dependencies);
-  compute_dependencies(type_map, type.detail, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteUnionType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, type.discriminator, dependencies);
-  compute_dependencies(type_map, type.member_seq, dependencies);
-}
-
-void compute_dependencies(const TypeMap&,
-                          const MinimalBitsetType&,
-                          OPENDDS_SET(TypeIdentifier)&)
-{
-  // Doesn't have any dependencies.
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteBitsetHeader& header,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, header.detail, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteBitfield& field,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, field.detail, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteBitsetType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, type.field_seq, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CommonCollectionElement& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.type, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalCollectionElement& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.common, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalSequenceType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.element, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteCollectionHeader& header,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  if (header.detail) {
-    compute_dependencies(type_map, header.detail.value(), dependencies);
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalAliasBody& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.common, dependencies);
   }
-}
 
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteElementDetail& detail,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, detail.ann_custom, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteCollectionElement& element,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, element.common, dependencies);
-  compute_dependencies(type_map, element.detail, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteSequenceType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, type.element, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalArrayType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.element, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteArrayHeader& header,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, header.detail, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteArrayType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, type.element, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalMapType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.key, dependencies);
-  compute_dependencies(type_map, type.element, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteMapType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, type.key, dependencies);
-  compute_dependencies(type_map, type.element, dependencies);
-}
-
-void compute_dependencies(const TypeMap&,
-                          const MinimalEnumeratedType&,
-                          OPENDDS_SET(TypeIdentifier)&)
-{
-  // Doesn't have any dependencies.
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteEnumeratedHeader& header,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, header.detail, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteEnumeratedLiteral& literal,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, literal.detail, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteEnumeratedType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, type.literal_seq, dependencies);
-}
-
-void compute_dependencies(const TypeMap&,
-                          const MinimalBitmaskType&,
-                          OPENDDS_SET(TypeIdentifier)&)
-{
-  // Doesn't have any dependencies.
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteBitflag& bitflag,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, bitflag.detail, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteBitmaskType& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, type.flag_seq, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const MinimalTypeObject& type_object,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  switch (type_object.kind) {
-  case TK_ALIAS:
-    compute_dependencies(type_map, type_object.alias_type, dependencies);
-    break;
-  case TK_ANNOTATION:
-    compute_dependencies(type_map, type_object.annotation_type, dependencies);
-    break;
-  case TK_STRUCTURE:
-    compute_dependencies(type_map, type_object.struct_type, dependencies);
-    break;
-  case TK_UNION:
-    compute_dependencies(type_map, type_object.union_type, dependencies);
-    break;
-  case TK_BITSET:
-    compute_dependencies(type_map, type_object.bitset_type, dependencies);
-    break;
-  case TK_SEQUENCE:
-    compute_dependencies(type_map, type_object.sequence_type, dependencies);
-    break;
-  case TK_ARRAY:
-    compute_dependencies(type_map, type_object.array_type, dependencies);
-    break;
-  case TK_MAP:
-    compute_dependencies(type_map, type_object.map_type, dependencies);
-    break;
-  case TK_ENUM:
-    compute_dependencies(type_map, type_object.enumerated_type, dependencies);
-    break;
-  case TK_BITMASK:
-    compute_dependencies(type_map, type_object.bitmask_type, dependencies);
-    break;
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalAliasType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.body, dependencies);
   }
-}
 
-void compute_dependencies(const TypeMap& type_map,
-                          const CompleteTypeObject& type_object,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  switch (type_object.kind) {
-  case TK_ALIAS:
-    compute_dependencies(type_map, type_object.alias_type, dependencies);
-    break;
-  case TK_ANNOTATION:
-    compute_dependencies(type_map, type_object.annotation_type, dependencies);
-    break;
-  case TK_STRUCTURE:
-    compute_dependencies(type_map, type_object.struct_type, dependencies);
-    break;
-  case TK_UNION:
-    compute_dependencies(type_map, type_object.union_type, dependencies);
-    break;
-  case TK_BITSET:
-    compute_dependencies(type_map, type_object.bitset_type, dependencies);
-    break;
-  case TK_SEQUENCE:
-    compute_dependencies(type_map, type_object.sequence_type, dependencies);
-    break;
-  case TK_ARRAY:
-    compute_dependencies(type_map, type_object.array_type, dependencies);
-    break;
-  case TK_MAP:
-    compute_dependencies(type_map, type_object.map_type, dependencies);
-    break;
-  case TK_ENUM:
-    compute_dependencies(type_map, type_object.enumerated_type, dependencies);
-    break;
-  case TK_BITMASK:
-    compute_dependencies(type_map, type_object.bitmask_type, dependencies);
-    break;
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const AppliedAnnotation& ann,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, ann.annotation_typeid, dependencies);
   }
-}
 
-void compute_dependencies(const TypeMap& type_map,
-                          const TypeObject& type_object,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  switch (type_object.kind) {
-  case EK_COMPLETE:
-    compute_dependencies(type_map, type_object.complete, dependencies);
-    break;
-  case EK_MINIMAL:
-    compute_dependencies(type_map, type_object.minimal, dependencies);
-    break;
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const OPENDDS_OPTIONAL_NS::optional<AppliedAnnotationSeq>& ann_seq,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    if (ann_seq) {
+      compute_dependencies_i(type_map, ann_seq.value(), dependencies);
+    }
   }
-}
 
-void compute_dependencies(const TypeMap&,
-                          const StringSTypeDefn&,
-                          OPENDDS_SET(TypeIdentifier)&)
-{
-  // Do nothing.
-}
-
-void compute_dependencies(const TypeMap&,
-                          const StringLTypeDefn&,
-                          OPENDDS_SET(TypeIdentifier)&)
-{
-  // Do nothing.
-}
-
-void compute_dependencies(const TypeMap&,
-                          const PlainCollectionHeader&,
-                          OPENDDS_SET(TypeIdentifier)&)
-{
-  // Do nothing.
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const PlainSequenceSElemDefn& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, *type.element_identifier, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const PlainSequenceLElemDefn& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, *type.element_identifier, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const PlainArraySElemDefn& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, *type.element_identifier, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const PlainArrayLElemDefn& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, *type.element_identifier, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const PlainMapSTypeDefn& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, *type.element_identifier, dependencies);
-  compute_dependencies(type_map, *type.key_identifier, dependencies);
-}
-
-void compute_dependencies(const TypeMap& type_map,
-                          const PlainMapLTypeDefn& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  compute_dependencies(type_map, type.header, dependencies);
-  compute_dependencies(type_map, *type.element_identifier, dependencies);
-  compute_dependencies(type_map, *type.key_identifier, dependencies);
-}
-
-void compute_dependencies(const TypeMap&,
-                          const StronglyConnectedComponentId&,
-                          OPENDDS_SET(TypeIdentifier)&)
-{
-  // Do nothing.
-}
-
-template <typename T>
-void compute_dependencies(const TypeMap& type_map,
-                          const Sequence<T>& type,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
-{
-  for (typename Sequence<T>::const_iterator pos = type.begin(), limit = type.end(); pos != limit; ++pos) {
-    compute_dependencies(type_map, *pos, dependencies);
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteTypeDetail& type_detail,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type_detail.ann_custom, dependencies);
   }
-}
 
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteAliasHeader& header,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, header.detail, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteAliasBody& body,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, body.common, dependencies);
+    compute_dependencies_i(type_map, body.ann_custom, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteAliasType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, type.body, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CommonAnnotationParameter& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.member_type_id, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalAnnotationParameter& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.common, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalAnnotationType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.member_seq, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteAnnotationParameter& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.common, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteAnnotationType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.member_seq, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalStructHeader& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.base_type, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CommonStructMember& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.member_type_id, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalStructMember& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.common, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalStructType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, type.member_seq, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteStructHeader& header,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, header.base_type, dependencies);
+    compute_dependencies_i(type_map, header.detail, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteMemberDetail& detail,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, detail.ann_custom, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteStructMember& member,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, member.common, dependencies);
+    compute_dependencies_i(type_map, member.detail, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteStructType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, type.member_seq, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CommonDiscriminatorMember& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.type_id, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalDiscriminatorMember& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.common, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CommonUnionMember& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.type_id, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalUnionMember& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.common, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalUnionType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.discriminator, dependencies);
+    compute_dependencies_i(type_map, type.member_seq, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteUnionHeader& header,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, header.detail, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteDiscriminatorMember& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.common, dependencies);
+    compute_dependencies_i(type_map, type.ann_custom, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteUnionMember& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.common, dependencies);
+    compute_dependencies_i(type_map, type.detail, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteUnionType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, type.discriminator, dependencies);
+    compute_dependencies_i(type_map, type.member_seq, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap&,
+                              const MinimalBitsetType&,
+                              OPENDDS_SET(TypeIdentifier)&)
+  {
+    // Doesn't have any dependencies.
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteBitsetHeader& header,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, header.detail, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteBitfield& field,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, field.detail, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteBitsetType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, type.field_seq, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CommonCollectionElement& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.type, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalCollectionElement& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.common, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalSequenceType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.element, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteCollectionHeader& header,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    if (header.detail) {
+      compute_dependencies_i(type_map, header.detail.value(), dependencies);
+    }
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteElementDetail& detail,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, detail.ann_custom, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteCollectionElement& element,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, element.common, dependencies);
+    compute_dependencies_i(type_map, element.detail, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteSequenceType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, type.element, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalArrayType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.element, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteArrayHeader& header,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, header.detail, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteArrayType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, type.element, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalMapType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.key, dependencies);
+    compute_dependencies_i(type_map, type.element, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteMapType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, type.key, dependencies);
+    compute_dependencies_i(type_map, type.element, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap&,
+                              const MinimalEnumeratedType&,
+                              OPENDDS_SET(TypeIdentifier)&)
+  {
+    // Doesn't have any dependencies.
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteEnumeratedHeader& header,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, header.detail, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteEnumeratedLiteral& literal,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, literal.detail, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteEnumeratedType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, type.literal_seq, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap&,
+                              const MinimalBitmaskType&,
+                              OPENDDS_SET(TypeIdentifier)&)
+  {
+    // Doesn't have any dependencies.
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteBitflag& bitflag,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, bitflag.detail, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteBitmaskType& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, type.flag_seq, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const MinimalTypeObject& type_object,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    switch (type_object.kind) {
+    case TK_ALIAS:
+      compute_dependencies_i(type_map, type_object.alias_type, dependencies);
+      break;
+    case TK_ANNOTATION:
+      compute_dependencies_i(type_map, type_object.annotation_type, dependencies);
+      break;
+    case TK_STRUCTURE:
+      compute_dependencies_i(type_map, type_object.struct_type, dependencies);
+      break;
+    case TK_UNION:
+      compute_dependencies_i(type_map, type_object.union_type, dependencies);
+      break;
+    case TK_BITSET:
+      compute_dependencies_i(type_map, type_object.bitset_type, dependencies);
+      break;
+    case TK_SEQUENCE:
+      compute_dependencies_i(type_map, type_object.sequence_type, dependencies);
+      break;
+    case TK_ARRAY:
+      compute_dependencies_i(type_map, type_object.array_type, dependencies);
+      break;
+    case TK_MAP:
+      compute_dependencies_i(type_map, type_object.map_type, dependencies);
+      break;
+    case TK_ENUM:
+      compute_dependencies_i(type_map, type_object.enumerated_type, dependencies);
+      break;
+    case TK_BITMASK:
+      compute_dependencies_i(type_map, type_object.bitmask_type, dependencies);
+      break;
+    }
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const CompleteTypeObject& type_object,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    switch (type_object.kind) {
+    case TK_ALIAS:
+      compute_dependencies_i(type_map, type_object.alias_type, dependencies);
+      break;
+    case TK_ANNOTATION:
+      compute_dependencies_i(type_map, type_object.annotation_type, dependencies);
+      break;
+    case TK_STRUCTURE:
+      compute_dependencies_i(type_map, type_object.struct_type, dependencies);
+      break;
+    case TK_UNION:
+      compute_dependencies_i(type_map, type_object.union_type, dependencies);
+      break;
+    case TK_BITSET:
+      compute_dependencies_i(type_map, type_object.bitset_type, dependencies);
+      break;
+    case TK_SEQUENCE:
+      compute_dependencies_i(type_map, type_object.sequence_type, dependencies);
+      break;
+    case TK_ARRAY:
+      compute_dependencies_i(type_map, type_object.array_type, dependencies);
+      break;
+    case TK_MAP:
+      compute_dependencies_i(type_map, type_object.map_type, dependencies);
+      break;
+    case TK_ENUM:
+      compute_dependencies_i(type_map, type_object.enumerated_type, dependencies);
+      break;
+    case TK_BITMASK:
+      compute_dependencies_i(type_map, type_object.bitmask_type, dependencies);
+      break;
+    }
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const TypeObject& type_object,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    switch (type_object.kind) {
+    case EK_COMPLETE:
+      compute_dependencies_i(type_map, type_object.complete, dependencies);
+      break;
+    case EK_MINIMAL:
+      compute_dependencies_i(type_map, type_object.minimal, dependencies);
+      break;
+    }
+  }
+
+  void compute_dependencies_i(const TypeMap&,
+                              const StringSTypeDefn&,
+                              OPENDDS_SET(TypeIdentifier)&)
+  {
+    // Do nothing.
+  }
+
+  void compute_dependencies_i(const TypeMap&,
+                              const StringLTypeDefn&,
+                              OPENDDS_SET(TypeIdentifier)&)
+  {
+    // Do nothing.
+  }
+
+  void compute_dependencies_i(const TypeMap&,
+                              const PlainCollectionHeader&,
+                              OPENDDS_SET(TypeIdentifier)&)
+  {
+    // Do nothing.
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const PlainSequenceSElemDefn& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, *type.element_identifier, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const PlainSequenceLElemDefn& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, *type.element_identifier, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const PlainArraySElemDefn& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, *type.element_identifier, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const PlainArrayLElemDefn& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, *type.element_identifier, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const PlainMapSTypeDefn& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, *type.element_identifier, dependencies);
+    compute_dependencies_i(type_map, *type.key_identifier, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const PlainMapLTypeDefn& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    compute_dependencies_i(type_map, type.header, dependencies);
+    compute_dependencies_i(type_map, *type.element_identifier, dependencies);
+    compute_dependencies_i(type_map, *type.key_identifier, dependencies);
+  }
+
+  void compute_dependencies_i(const TypeMap&,
+                              const StronglyConnectedComponentId&,
+                              OPENDDS_SET(TypeIdentifier)&)
+  {
+    // Do nothing.
+  }
+
+  template <typename T>
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const Sequence<T>& type,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    for (typename Sequence<T>::const_iterator pos = type.begin(), limit = type.end(); pos != limit; ++pos) {
+      compute_dependencies_i(type_map, *pos, dependencies);
+    }
+  }
+
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const TypeIdentifier& type_identifier,
+                              OPENDDS_SET(TypeIdentifier)& dependencies)
+  {
+    if (dependencies.count(type_identifier) != 0) {
+      return;
+    }
+
+    dependencies.insert(type_identifier);
+
+    compute_dependencies(type_map, type_identifier, dependencies);
+  }
 }
 
 void compute_dependencies(const TypeMap& type_map,
                           const TypeIdentifier& type_identifier,
                           OPENDDS_SET(TypeIdentifier)& dependencies)
 {
-  if (dependencies.count(type_identifier) != 0) {
-    return;
-  }
-
-  dependencies.insert(type_identifier);
-
   switch (type_identifier.kind()) {
   case TI_STRING8_SMALL:
   case TI_STRING16_SMALL:
-    compute_dependencies(type_map, type_identifier.string_sdefn(), dependencies);
+    compute_dependencies_i(type_map, type_identifier.string_sdefn(), dependencies);
     break;
   case TI_STRING8_LARGE:
   case TI_STRING16_LARGE:
-    compute_dependencies(type_map, type_identifier.string_ldefn(), dependencies);
+    compute_dependencies_i(type_map, type_identifier.string_ldefn(), dependencies);
     break;
   case TI_PLAIN_SEQUENCE_SMALL:
-    compute_dependencies(type_map, type_identifier.seq_sdefn(), dependencies);
+    compute_dependencies_i(type_map, type_identifier.seq_sdefn(), dependencies);
     break;
   case TI_PLAIN_SEQUENCE_LARGE:
-    compute_dependencies(type_map, type_identifier.seq_ldefn(), dependencies);
+    compute_dependencies_i(type_map, type_identifier.seq_ldefn(), dependencies);
     break;
   case TI_PLAIN_ARRAY_SMALL:
-    compute_dependencies(type_map, type_identifier.array_sdefn(), dependencies);
+    compute_dependencies_i(type_map, type_identifier.array_sdefn(), dependencies);
     break;
   case TI_PLAIN_ARRAY_LARGE:
-    compute_dependencies(type_map, type_identifier.array_ldefn(), dependencies);
+    compute_dependencies_i(type_map, type_identifier.array_ldefn(), dependencies);
     break;
   case TI_PLAIN_MAP_SMALL:
-    compute_dependencies(type_map, type_identifier.map_sdefn(), dependencies);
+    compute_dependencies_i(type_map, type_identifier.map_sdefn(), dependencies);
     break;
   case TI_PLAIN_MAP_LARGE:
-    compute_dependencies(type_map, type_identifier.map_ldefn(), dependencies);
+    compute_dependencies_i(type_map, type_identifier.map_ldefn(), dependencies);
     break;
   case TI_STRONGLY_CONNECTED_COMPONENT:
-    compute_dependencies(type_map, type_identifier.sc_component_id(), dependencies);
+    compute_dependencies_i(type_map, type_identifier.sc_component_id(), dependencies);
     break;
   case EK_COMPLETE:
   case EK_MINIMAL:
     {
       TypeMap::const_iterator pos = type_map.find(type_identifier);
       if (pos != type_map.end()) {
-        compute_dependencies(type_map, pos->second, dependencies);
+        compute_dependencies_i(type_map, pos->second, dependencies);
       }
       break;
     }


### PR DESCRIPTION
Problem
-------

Dependencies generated via FlexibleTypes were not calculated.

The algorithm for computing dependencies erroneously inserted the top-level type.

Solution
--------

* Add dependency support for FlexibleTypes.
* Correct the dependency algorithm.