### PR TITLE
Fix CMake iShapes and Comply with CMP0165

### DIFF
--- a/cmake/ace_group.cmake
+++ b/cmake/ace_group.cmake
@@ -67,7 +67,6 @@ if(MSVC AND OPENDDS_STATIC)
   _opendds_vs_force_static()
 endif()
 
-enable_language(C)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 

--- a/cmake/opendds_version.cmake
+++ b/cmake/opendds_version.cmake
@@ -33,4 +33,5 @@ if(NOT DEFINED OPENDDS_VERSION)
     "${_OPENDDS_CMAKE_DIR}/../../dds"
     "${_OPENDDS_CMAKE_DIR}/.."
   )
+  set(OpenDDS_VERSION "${OPENDDS_VERSION}")
 endif()

--- a/examples/DCPS/ishapes/CMakeLists.txt
+++ b/examples/DCPS/ishapes/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.3...3.27)
-find_package(OpenDDS REQUIRED)
+include("${CMAKE_CURRENT_LIST_DIR}/../../../cmake/opendds_version.cmake")
 project(ishapes VERSION ${OpenDDS_VERSION} LANGUAGES CXX)
+find_package(OpenDDS REQUIRED)
 
 # Make sure the MPC-generated headers are gone so the CMake build will use the
 # right ones. This is not needed in a real project.


### PR DESCRIPTION
Fixes https://github.com/OpenDDS/OpenDDS/issues/4849

Changes from https://github.com/OpenDDS/OpenDDS/pull/4487 require C++ language to be enabled in CMake, which it basically is all the time through `project(... LANGUAGES CXX)` expect in ishapes. There `find_project(OpenDDS)` was used to get the OpenDDS version before `project` enabled C++ which results in `try_compile` failing fatally. These changes both make sure C and C++ are enabled early in CMake initialization and switch the `project` and `find_package` to comply with https://cmake.org/cmake/help/latest/policy/CMP0165.html#policy:CMP0165

Also changed the C++ standard checks to include the min C++ standard (currently C++98/03), so it would never mistake a broken compiler setup with a compiler that only supports the min standard.