### PR TITLE
Thread monitors may be starved for data

### DIFF
--- a/dds/DCPS/Qos_Helper.h
+++ b/dds/DCPS/Qos_Helper.h
@@ -250,6 +250,11 @@ public:
 
   static bool copy_from_topic_qos(DDS::DataWriterQos& a_datareader_qos,
                                   const DDS::TopicQos& a_topic_qos);
+
+  static void append(DDS::PropertySeq& props,
+                     const char* name,
+                     const std::string& value,
+                     bool propagate = false);
 };
 
 #ifndef OPENDDS_SAFETY_PROFILE

--- a/dds/DCPS/Qos_Helper.inl
+++ b/dds/DCPS/Qos_Helper.inl
@@ -1290,6 +1290,18 @@ bool Qos_Helper::copy_from_topic_qos(DDS::DataWriterQos& a_datawriter_qos,
   return true;
 }
 
+ACE_INLINE
+void Qos_Helper::append(DDS::PropertySeq& props,
+                        const char* name,
+                        const std::string& value,
+                        bool propagate)
+{
+  const DDS::Property_t prop = {name, value.c_str(), propagate};
+  const size_t len = props.length();
+  props.length(len + 1);
+  props[len] = prop;
+}
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -43,7 +43,7 @@ const char RTPS_DISCOVERY_ENDPOINT_ANNOUNCEMENTS[] = "OpenDDS.RtpsDiscovery.Endp
 const char RTPS_DISCOVERY_TYPE_LOOKUP_SERVICE[] = "OpenDDS.RtpsDiscovery.TypeLookupService";
 const char RTPS_RELAY_APPLICATION_PARTICIPANT[] = "OpenDDS.Rtps.RelayApplicationParticipant";
 const char RTPS_REFLECT_HEARTBEAT_COUNT[] = "OpenDDS.Rtps.ReflectHeartbeatCount";
-
+const char RTPS_HARVEST_THREAD_STATUS[] = "OpenDDS.Rtps.HarvestThreadStatus";
 
 /**
  * @class RtpsDiscovery

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -159,6 +159,8 @@ void Spdp::init(DDS::DomainId_t /*domain*/,
       const CORBA::ULong old_flags = config_->participant_flags();
       const CORBA::ULong new_flags = prop_to_bool(prop) ? (old_flags | PFLAGS_REFLECT_HEARTBEAT_COUNT) : (old_flags & ~PFLAGS_REFLECT_HEARTBEAT_COUNT);
       config_->participant_flags(new_flags);
+    } else if (std::strcmp(RTPS_HARVEST_THREAD_STATUS, prop.name.in()) == 0) {
+      harvest_thread_status_ = prop_to_bool(prop);
     }
   }
 
@@ -249,6 +251,7 @@ Spdp::Spdp(DDS::DomainId_t domain,
   , guid_(guid)
   , participant_discovered_at_(MonotonicTimePoint::now().to_idl_struct())
   , is_application_participant_(false)
+  , harvest_thread_status_(false)
   , ipv4_participant_port_id_(0)
 #ifdef ACE_HAS_IPV6
   , ipv6_participant_port_id_(0)
@@ -312,6 +315,7 @@ Spdp::Spdp(DDS::DomainId_t domain,
   , guid_(guid)
   , participant_discovered_at_(MonotonicTimePoint::now().to_idl_struct())
   , is_application_participant_(false)
+  , harvest_thread_status_(false)
   , ipv4_participant_port_id_(0)
 #ifdef ACE_HAS_IPV6
   , ipv6_participant_port_id_(0)
@@ -2493,7 +2497,7 @@ Spdp::SpdpTransport::open(const DCPS::ReactorTask_rch& reactor_task,
 
 #ifndef DDS_HAS_MINIMUM_BIT
   // internal thread bit reporting
-  if (TheServiceParticipant->get_thread_status_manager().update_thread_status()) {
+  if (TheServiceParticipant->get_thread_status_manager().update_thread_status() && outer->harvest_thread_status_) {
     thread_status_task_ = DCPS::make_rch<SpdpPeriodic>(reactor_task, ref(*this), &SpdpTransport::thread_status_task);
   }
 #endif /* DDS_HAS_MINIMUM_BIT */
@@ -2581,8 +2585,8 @@ Spdp::SpdpTransport::enable_periodic_tasks()
     local_send_task_->enable(TimeDuration::zero_value);
   }
 
-#if OPENDDS_CONFIG_SECURITY
   DCPS::RcHandle<Spdp> outer = outer_.lock();
+#if OPENDDS_CONFIG_SECURITY
   if (!outer) return;
 
   outer->sedp_->core().reset_relay_spdp_task_falloff();
@@ -2594,7 +2598,7 @@ Spdp::SpdpTransport::enable_periodic_tasks()
 
 #ifndef DDS_HAS_MINIMUM_BIT
   const DCPS::ThreadStatusManager& thread_status_manager = TheServiceParticipant->get_thread_status_manager();
-  if (thread_status_manager.update_thread_status()) {
+  if (thread_status_manager.update_thread_status() && outer->harvest_thread_status_) {
     thread_status_task_->enable(false, thread_status_manager.thread_status_interval());
   }
 #endif /* DDS_HAS_MINIMUM_BIT */

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -411,6 +411,7 @@ private:
   DCPS::GUID_t guid_;
   const DCPS::MonotonicTime_t participant_discovered_at_;
   bool is_application_participant_;
+  bool harvest_thread_status_;
   DDS::UInt16 ipv4_participant_port_id_;
 #ifdef ACE_HAS_IPV6
   DDS::UInt16 ipv6_participant_port_id_;

--- a/docs/devguide/built_in_topics.rst
+++ b/docs/devguide/built_in_topics.rst
@@ -288,9 +288,26 @@ OpenDDSInternalThread Topic
 ..
     Sect<6.8.3>
 
-The built-in topic ``OpenDDSInternalThread`` is published when OpenDDS is configured with :cfg:prop:`DCPSThreadStatusInterval`.
+The built-in topic ``OpenDDSInternalThread`` is published when OpenDDS is configured with :cfg:prop:`DCPSThreadStatusInterval` and status harvesting is enabled for a participant.
 When enabled, the DataReader for this built-in topic will report the status of threads created and managed by OpenDDS within the current process.
 The timestamp associated with samples can be used to determine the health (responsiveness) of the thread.
+Status harvesting should only be enabled for one participant.
+The following snippet shows how to enable status harvesting for a participant:
+
+.. code-block:: cpp
+
+        #include <dds/DCPS/RTPS/RtpsDiscovery.h>
+        #include <dds/DCPS/Qos_Helper.h>
+
+        DDS::DomainParticipantFactory_var factory = ...;
+        ...
+        DDS::DomainParticipantQos participant_qos;
+        factory->get_default_participant_qos(participant_qos);
+        DDS::PropertySeq& properties = participant_qos.property.value;
+        OpenDDS::DCPS::Qos_Helper::append(properties, OpenDDS::RTPS::RTPS_HARVEST_THREAD_STATUS, "true");
+        ...
+        DDS::DomainParticipant_var participant =
+          factory->create_participant(..., participant_qos, ..., ...);
 
 The topic type InternalThreadBuiltinTopicData is defined in :ghfile:`dds/OpenddsDcpsExt.idl` in the ``OpenDDS::DCPS`` module:
 

--- a/docs/news.d/harvest_control.rst
+++ b/docs/news.d/harvest_control.rst
@@ -1,0 +1,14 @@
+# This is a news fragment example. Copy this file in this directory and change
+# it to have content added to the release notes for the next release.
+# See https://opendds.readthedocs.io/en/master/internal/docs.html#news for details
+
+# This will have to be replaced with the PR number after the PR is created:
+.. news-prs: 4887
+
+.. news-start-section: Fixes
+- Added ``RTPS_HARVEST_THREAD_STATUS`` property to select the participant that harvests thread status.
+
+  - This addresses erroneous results from multiple participants harvesting thread status.
+
+  - See :ref:`_built_in_topics--openddsinternalthread-topic` for usage.
+.. news-end-section

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -624,6 +624,7 @@ int run(int argc, ACE_TCHAR* argv[])
   append(application_properties, OpenDDS::RTPS::RTPS_DISCOVERY_TYPE_LOOKUP_SERVICE, "false");
   append(application_properties, OpenDDS::RTPS::RTPS_REFLECT_HEARTBEAT_COUNT, "true");
   append(application_properties, OpenDDS::RTPS::RTPS_RELAY_APPLICATION_PARTICIPANT, "true");
+  append(application_properties, OpenDDS::RTPS::RTPS_HARVEST_THREAD_STATUS, "true");
 
   if (secure) {
     append(application_properties, DDS::Security::Properties::AuthIdentityCA, identity_ca_file);


### PR DESCRIPTION
Problem
-------

When thread status monitoring is enabled, all participants that use RTPS discovery will harvest the thread status from the monitor and publish it on the OpenDDSInternalThread BIT.  If there are multiple participants, they will each harvest.  Typically, an application will only look at one of the BIT readers with the result being that any monitoring logic may be operating on an incomplete set of data.

Solution
--------

Add a property `RTPS_HARVEST_THREAD_STATUS` that enables harvesting for particular participants.