### PR TITLE
Use Release Year in Sphinx Copyright

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,8 +68,8 @@ pygments_style = 'manni'
 nitpicky = True
 
 project = 'OpenDDS'
-copyright = '2024 OpenDDS Foundation'
 author = 'OpenDDS Foundation'
+copyright = author
 github_links_repo = 'OpenDDS/OpenDDS'
 github_main_branch = 'master'
 github_repo = 'https://github.com/' + github_links_repo
@@ -83,6 +83,8 @@ if is_release:
     github_links_release_tag = opendds_version_info.tag
 ace6tao2_version = opendds_version_info.ace6tao2_version
 ace7tao3_version = opendds_version_info.ace7tao3_version
+if opendds_version_info.release_year:
+    copyright = f'{opendds_version_info.release_year} {copyright}'
 
 # Generate news for all releases
 with (docs_path / 'news.rst').open('w') as f:

--- a/docs/news.d/harvest_control.rst
+++ b/docs/news.d/harvest_control.rst
@@ -10,5 +10,5 @@
 
   - This addresses erroneous results from multiple participants harvesting thread status.
 
-  - See :ref:`_built_in_topics--openddsinternalthread-topic` for usage.
+  - See :ref:`built_in_topics--openddsinternalthread-topic` for usage.
 .. news-end-section


### PR DESCRIPTION
Fixes https://github.com/OpenDDS/OpenDDS/issues/4891

It will use the year from VERSION.txt if it's a release, else doesn't include a year.

Also fixed a link issue with https://github.com/OpenDDS/OpenDDS/pull/4887