### PR TITLE
Service Participant thread doesn't update thread status

### DIFF
--- a/docs/news.d/rtpsrelay-service-participant.rst
+++ b/docs/news.d/rtpsrelay-service-participant.rst
@@ -1,0 +1,10 @@
+# This is a news fragment example. Copy this file in this directory and change
+# it to have content added to the release notes for the next release.
+# See https://opendds.readthedocs.io/en/master/internal/docs.html#news for details
+
+# This will have to be replaced with the PR number after the PR is created:
+.. news-prs: 4900
+
+.. news-start-section: Fixes
+- Signal the thread monitor in RtpsRelay listeners to avoid thread monitor timeouts.
+.. news-end-section

--- a/tools/rtpsrelay/ParticipantListener.cpp
+++ b/tools/rtpsrelay/ParticipantListener.cpp
@@ -35,20 +35,21 @@ void ParticipantListener::on_data_available(DDS::DataReader_ptr reader)
   }
 
   for (CORBA::ULong idx = 0; idx != infos.length(); ++idx) {
+    OpenDDS::DCPS::ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
     const auto& data = datas[idx];
     const auto& info = infos[idx];
 
     switch (info.instance_state) {
     case DDS::ALIVE_INSTANCE_STATE:
       if (info.valid_data) {
-        participant_status_reporter_.add_participant(participant_->get_repoid(info.instance_handle), data);
+        participant_status_reporter_.add_participant(participant_->get_repoid(info.instance_handle), data, idx, infos.length());
       }
       break;
     case DDS::NOT_ALIVE_DISPOSED_INSTANCE_STATE:
     case DDS::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE:
       {
         GuidAddrSet::Proxy proxy(guid_addr_set_);
-        participant_status_reporter_.remove_participant(proxy, participant_->get_repoid(info.instance_handle));
+        participant_status_reporter_.remove_participant(proxy, participant_->get_repoid(info.instance_handle), idx, infos.length());
       }
       break;
     }

--- a/tools/rtpsrelay/PublicationListener.cpp
+++ b/tools/rtpsrelay/PublicationListener.cpp
@@ -49,6 +49,7 @@ void PublicationListener::on_data_available(DDS::DataReader_ptr reader)
   using OpenDDS::DCPS::make_part_guid;
 
   for (CORBA::ULong idx = 0; idx != infos.length(); ++idx) {
+    OpenDDS::DCPS::ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
     switch (infos[idx].instance_state) {
     case DDS::ALIVE_INSTANCE_STATE:
       {
@@ -62,14 +63,16 @@ void PublicationListener::on_data_available(DDS::DataReader_ptr reader)
             if (config_.log_discovery()) {
               GuidAddrSet::Proxy proxy(guid_addr_set_);
               ACE_DEBUG((LM_INFO, "(%P|%t) INFO: PublicationListener::on_data_available "
-                         "add local writer %C %C %C into session\n",
+                         "add local writer %C %C %C into session [%u/%u]\n",
                          guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
-                         proxy.get_session_time(make_part_guid(repoid), now).sec_str().c_str()));
+                         proxy.get_session_time(make_part_guid(repoid), now).sec_str().c_str(),
+                         idx, infos.length()));
             }
             stats_reporter_.local_writers(++count_, OpenDDS::DCPS::MonotonicTimePoint::now());
           } else if (r == GuidPartitionTable::UPDATED) {
             if (config_.log_discovery()) {
-              ACE_DEBUG((LM_INFO, "(%P|%t) INFO: PublicationListener::on_data_available update local writer %C %C\n", guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str()));
+              ACE_DEBUG((LM_INFO, "(%P|%t) INFO: PublicationListener::on_data_available update local writer %C %C [%u/%u]\n", guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
+                         idx, infos.length()));
             }
           }
         }
@@ -85,9 +88,10 @@ void PublicationListener::on_data_available(DDS::DataReader_ptr reader)
         if (config_.log_discovery()) {
           GuidAddrSet::Proxy proxy(guid_addr_set_);
           ACE_DEBUG((LM_INFO, "(%P|%t) INFO: PublicationListener::on_data_available "
-                     "remove local writer %C %C into session\n",
+                     "remove local writer %C %C into session [%u/%u]\n",
                      guid_to_string(repoid).c_str(),
-                     proxy.get_session_time(make_part_guid(repoid), now).sec_str().c_str()));
+                     proxy.get_session_time(make_part_guid(repoid), now).sec_str().c_str(),
+                     idx, infos.length()));
         }
         guid_partition_table_.remove(repoid);
         stats_reporter_.local_writers(--count_, OpenDDS::DCPS::MonotonicTimePoint::now());

--- a/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
+++ b/tools/rtpsrelay/RelayParticipantStatusReporter.cpp
@@ -3,7 +3,9 @@
 namespace RtpsRelay {
 
 void RelayParticipantStatusReporter::add_participant(const OpenDDS::DCPS::GUID_t& repoid,
-                                                     const DDS::ParticipantBuiltinTopicData& data)
+                                                     const DDS::ParticipantBuiltinTopicData& data,
+                                                     CORBA::ULong idx,
+                                                     CORBA::ULong total)
 {
   const auto monotonic_now = OpenDDS::DCPS::MonotonicTimePoint::now();
   const auto system_now = OpenDDS::DCPS::SystemTimePoint::now();
@@ -31,8 +33,9 @@ void RelayParticipantStatusReporter::add_participant(const OpenDDS::DCPS::GUID_t
     if (p.second) {
       if (config_.log_discovery()) {
         ACE_DEBUG((LM_INFO, "(%P|%t) INFO: RelayParticipantStatusReporter::add_participant "
-                   "add local participant %C %C\n",
-                   guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str()));
+                   "add local participant %C %C [%u/%u]\n",
+                   guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
+                   idx, total));
       }
     } else {
       p.first->second = std::move(status);
@@ -43,7 +46,9 @@ void RelayParticipantStatusReporter::add_participant(const OpenDDS::DCPS::GUID_t
 }
 
 void RelayParticipantStatusReporter::remove_participant(GuidAddrSet::Proxy& proxy,
-                                                        const OpenDDS::DCPS::GUID_t& repoid)
+                                                        const OpenDDS::DCPS::GUID_t& repoid,
+                                                        CORBA::ULong idx,
+                                                        CORBA::ULong total)
 {
   const auto monotonic_now = OpenDDS::DCPS::MonotonicTimePoint::now();
 
@@ -64,9 +69,10 @@ void RelayParticipantStatusReporter::remove_participant(GuidAddrSet::Proxy& prox
 
   if (config_.log_discovery()) {
     ACE_DEBUG((LM_INFO, "(%P|%t) INFO: RelayParticipantStatusReporter::remove_participant "
-               "remove local participant %C %C into session\n",
+               "remove local participant %C %C into session [%u/%u]\n",
                guid_to_string(repoid).c_str(),
-               proxy.get_session_time(repoid, monotonic_now).sec_str().c_str()));
+               proxy.get_session_time(repoid, monotonic_now).sec_str().c_str(),
+               idx, total));
   }
 
   proxy.remove(repoid, monotonic_now, nullptr);

--- a/tools/rtpsrelay/RelayParticipantStatusReporter.h
+++ b/tools/rtpsrelay/RelayParticipantStatusReporter.h
@@ -21,10 +21,14 @@ public:
   {}
 
   void add_participant(const OpenDDS::DCPS::GUID_t& repoid,
-                       const DDS::ParticipantBuiltinTopicData& data);
+                       const DDS::ParticipantBuiltinTopicData& data,
+                       CORBA::ULong idx,
+                       CORBA::ULong total);
 
   void remove_participant(GuidAddrSet::Proxy& proxy,
-                          const OpenDDS::DCPS::GUID_t& repoid);
+                          const OpenDDS::DCPS::GUID_t& repoid,
+                          CORBA::ULong idx,
+                          CORBA::ULong total);
 
   void set_alive(const OpenDDS::DCPS::GUID_t& repoid,
                  bool alive);

--- a/tools/rtpsrelay/SubscriptionListener.cpp
+++ b/tools/rtpsrelay/SubscriptionListener.cpp
@@ -47,6 +47,7 @@ void SubscriptionListener::on_data_available(DDS::DataReader_ptr reader)
   }
 
   for (CORBA::ULong idx = 0; idx != infos.length(); ++idx) {
+    OpenDDS::DCPS::ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
     const auto& data = datas[idx];
     const auto& info = infos[idx];
 
@@ -63,14 +64,16 @@ void SubscriptionListener::on_data_available(DDS::DataReader_ptr reader)
             GuidAddrSet::Proxy proxy(guid_addr_set_);
             ACE_DEBUG((LM_INFO,
                        "(%P|%t) INFO: SubscriptionListener::on_data_available "
-                       "add local reader %C %C %C into session\n",
+                       "add local reader %C %C %C into session [%u/%u]\n",
                        guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
-                       proxy.get_session_time(make_part_guid(repoid), now).sec_str().c_str()));
+                       proxy.get_session_time(make_part_guid(repoid), now).sec_str().c_str(),
+                       idx, infos.length()));
           }
           stats_reporter_.local_readers(++count_, OpenDDS::DCPS::MonotonicTimePoint::now());
         } else if (r == GuidPartitionTable::UPDATED) {
           if (config_.log_discovery()) {
-            ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SubscriptionListener::on_data_available update local reader %C %C\n", guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str()));
+            ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SubscriptionListener::on_data_available update local reader %C %C [%u/%u]\n", guid_to_string(repoid).c_str(), OpenDDS::DCPS::to_json(data).c_str(),
+                       idx, infos.length()));
           }
         }
       }
@@ -83,9 +86,10 @@ void SubscriptionListener::on_data_available(DDS::DataReader_ptr reader)
         if (config_.log_discovery()) {
           GuidAddrSet::Proxy proxy(guid_addr_set_);
           ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SubscriptionListener::on_data_available "
-                     "remove local reader %C %C into session\n",
+                     "remove local reader %C %C into session [%u/%u]\n",
                      guid_to_string(repoid).c_str(),
-                     proxy.get_session_time(make_part_guid(repoid), now).sec_str().c_str()));
+                     proxy.get_session_time(make_part_guid(repoid), now).sec_str().c_str(),
+                     idx, infos.length()));
         }
 
         guid_partition_table_.remove(repoid);


### PR DESCRIPTION
Problem
-------

The Service Participant thread invokes the BIT listeners in the RtpsRelay.  Given large enough batches, the listeners can occupy the processor long enough for the thread monitoring logic to trip.

Solution
--------

Add events for each sample to update the thread status.

Add logging to show the size of the batches.