### PR TITLE
iShapes demo doesn't have complete type objects

### DIFF
--- a/examples/DCPS/ishapes/CMakeLists.txt
+++ b/examples/DCPS/ishapes/CMakeLists.txt
@@ -45,7 +45,7 @@ add_executable(ishapes
   WriterQosDialog.hpp
 )
 target_include_directories(ishapes PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-opendds_target_sources(ishapes ShapeType.idl)
+opendds_target_sources(ishapes ShapeType.idl OPENDDS_IDL_OPTIONS -Gxtypes-complete)
 target_link_libraries(ishapes
   Qt5::Widgets
   OpenDDS::Dcps

--- a/examples/DCPS/ishapes/ishapes.mpc
+++ b/examples/DCPS/ishapes/ishapes.mpc
@@ -3,6 +3,8 @@ project: dcpsexe, dcps_tcp, dcps_udp, dcps_multicast, dcps_rtps_udp, qt5_widgets
   exename = *
   includes += .
 
+  dcps_ts_flags += -Gxtypes-complete
+
   TypeSupport_Files {
     ShapeType.idl
   }


### PR DESCRIPTION
Problem
-------

The iShapes demo doesn't have complete type objects which is something other vendors expect.

Solution
--------

Add complete type objects.