### PR TITLE
RtpsRelay output queue may be ill-behaved

### DIFF
--- a/docs/devguide/internet_enabled_rtps.rst
+++ b/docs/devguide/internet_enabled_rtps.rst
@@ -339,6 +339,10 @@ The command-line options for the RtpsRelay:
 
   Use a thread pool with this many threads (default 1) to handle input/output/timer events.
 
+.. option:: -SynchronousOutput 0|1
+
+  Send messages immediately, defaults to 0 (disabled).
+
 .. _internet_enabled_rtps--deployment-considerations:
 
 Deployment Considerations

--- a/docs/news.d/rtpsrelay-synchronous-output.rst
+++ b/docs/news.d/rtpsrelay-synchronous-output.rst
@@ -1,0 +1,5 @@
+.. news-prs: 4928
+
+.. news-start-section: Additions
+- Added :option:`RtpsRelay -SynchronousOutput` option to RtpsRelay.
+.. news-end-section

--- a/tests/DCPS/RtpsRelay/Smoke/run_test.pl
+++ b/tests/DCPS/RtpsRelay/Smoke/run_test.pl
@@ -75,7 +75,8 @@ sub get_relay_args {
     "-VerticalAddress ${port_digit}444",
     "-HorizontalAddress 127.0.0.1:11${port_digit}44",
     "-MetaDiscoveryAddress 127.0.0.1:808${n}",
-    "-ORBVerboseLogging 1"
+    "-ORBVerboseLogging 1",
+    "-SynchronousOutput 1"
   );
 }
 

--- a/tools/rtpsrelay/Config.h
+++ b/tools/rtpsrelay/Config.h
@@ -38,6 +38,7 @@ public:
     , admission_max_participants_high_water_(0)
     , admission_max_participants_low_water_(0)
     , handler_threads_(1)
+    , synchronous_output_(false)
   {}
 
   void relay_id(const std::string& value)
@@ -360,6 +361,16 @@ public:
     return handler_threads_;
   }
 
+  void synchronous_output(bool flag)
+  {
+    synchronous_output_ = flag;
+  }
+
+  bool synchronous_output() const
+  {
+    return synchronous_output_;
+  }
+
 private:
   std::string relay_id_;
   OpenDDS::DCPS::GUID_t application_participant_guid_;
@@ -393,6 +404,7 @@ private:
   size_t admission_max_participants_high_water_;
   size_t admission_max_participants_low_water_;
   size_t handler_threads_;
+  bool synchronous_output_;
 };
 
 }

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -75,6 +75,8 @@ private:
       , type(type)
     {}
   };
+  ssize_t send_i(const Element& out,
+                 size_t& total_bytes);
   using OutgoingType = std::queue<Element>;
   OutgoingType outgoing_;
   mutable ACE_Thread_Mutex outgoing_mutex_;
@@ -199,11 +201,11 @@ public:
 
   void vertical_handler(VerticalHandler* vertical_handler) { vertical_handler_ = vertical_handler; }
 
-  void enqueue_message(const ACE_INET_Addr& addr,
-                       const StringSet& to_partitions,
-                       const GuidSet& to_guids,
-                       const OpenDDS::DCPS::Lockable_Message_Block_Ptr& msg,
-                       const OpenDDS::DCPS::MonotonicTimePoint& now);
+  void enqueue_or_send_message(const ACE_INET_Addr& addr,
+                               const StringSet& to_partitions,
+                               const GuidSet& to_guids,
+                               const OpenDDS::DCPS::Lockable_Message_Block_Ptr& msg,
+                               const OpenDDS::DCPS::MonotonicTimePoint& now);
 
 private:
   const GuidPartitionTable& guid_partition_table_;

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -235,6 +235,9 @@ int run(int argc, ACE_TCHAR* argv[])
     } else if ((arg = args.get_the_parameter("-HandlerThreads"))) {
       config.handler_threads(std::atoi(arg));
       args.consume_arg();
+    } else if ((arg = args.get_the_parameter("-SynchronousOutput"))) {
+      config.synchronous_output(ACE_OS::atoi(arg));
+      args.consume_arg();
     } else if ((arg = args.get_the_parameter("-MaxIpsPerClient"))) {
       config.max_ips_per_client(ACE_OS::atoi(arg));
       args.consume_arg();


### PR DESCRIPTION
Problem
-------

The RtpsRelay uses an output queue.  When a message needs to be sent, the message is placed on a queue and a handler is registered with the reactor if necessary.  When the handler is invoked, a message is removed from the queue and sent. This avoid errors from the send buffer being full since the socket is non-blocking.

This design has shown to have undesirable behavior which stems from a lack of fairness between input and output processing.  That is, given that both tasks are ready, there is no guarantee that one will not be systematically preferred over another.  Given a high enough input rate, the output task will fall behind and the queue will grow.

Solution
--------

Introduce a `-SynchronousOutput` option that sends messages as soon as possible instead of queueing them and waiting on the reactor.  In this configuration, it is possible that the output socket will not be ready and return an error indicating that a write would block.