### PR TITLE
Add Class Dependencies For Strongly Connected Components

### DIFF
--- a/dds/DCPS/XTypes/TypeObject.cpp
+++ b/dds/DCPS/XTypes/TypeObject.cpp
@@ -1068,6 +1068,11 @@ void compute_dependencies(const TypeMap& type_map,
     break;
   case TI_STRONGLY_CONNECTED_COMPONENT:
     compute_dependencies_i(type_map, type_identifier.sc_component_id(), dependencies);
+    for (ACE_CDR::Long i = 1; i <= type_identifier.sc_component_id().scc_length; ++i) {
+      TypeIdentifier tmp(type_identifier);
+      tmp.sc_component_id().scc_index = i;
+      dependencies.insert(tmp);
+    }
     break;
   case EK_COMPLETE:
   case EK_MINIMAL:


### PR DESCRIPTION
Problem:
 - Not all StronglyConnectedComponent types in the same class are being added to list of type dependencies, preventing the TypeLookupService from sending enough type information for complex types.
 - This can be seen, for example, when looking at the opendds-monitor complex topic type instances (which currently cause the monitor to crash)

Solution:
 - Add all the StronglyConnectedComponent class typeids when one is encountered during dependency calculation