### PR TITLE
TypeLookupService doesn't support SCCs

### DIFF
--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -7843,16 +7843,16 @@ void Sedp::get_remote_type_objects(const XTypes::TypeIdentifierWithDependencies&
   XTypes::TypeIdentifierSeq type_ids;
   if (tid_with_deps.dependent_typeid_count == -1 ||
       tid_with_deps.dependent_typeids.length() < (CORBA::ULong)tid_with_deps.dependent_typeid_count) {
-    type_ids.append(tid_with_deps.typeid_with_size.type_id);
+    type_ids.append(make_scc_id_or_default(tid_with_deps.typeid_with_size.type_id));
 
     // Get dependencies of the topic type. TypeObjects of both topic type and
     // its dependencies are obtained in subsequent type lookup requests.
     send_type_lookup_request(type_ids, remote_id, is_discovery_protected, false, orig_req_data.seq_number);
   } else {
     type_ids.length(tid_with_deps.dependent_typeid_count + 1);
-    type_ids[0] = tid_with_deps.typeid_with_size.type_id;
+    type_ids[0] = make_scc_id_or_default(tid_with_deps.typeid_with_size.type_id);
     for (unsigned i = 1; i <= (unsigned)tid_with_deps.dependent_typeid_count; ++i) {
-      type_ids[i] = tid_with_deps.dependent_typeids[i - 1].type_id;
+      type_ids[i] = make_scc_id_or_default(tid_with_deps.dependent_typeids[i - 1].type_id);
     }
 
     // Get TypeObjects of topic type and all of its dependencies.

--- a/dds/DCPS/XTypes/TypeLookupService.cpp
+++ b/dds/DCPS/XTypes/TypeLookupService.cpp
@@ -57,11 +57,31 @@ TypeLookupService::~TypeLookupService()
 void TypeLookupService::get_type_objects(const TypeIdentifierSeq& type_ids,
                                          TypeIdentifierTypeObjectPairSeq& types) const
 {
-  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+  TypeIdentifierSet tids;
+
   for (unsigned i = 0; i < type_ids.length(); ++i) {
-    TypeMap::const_iterator pos = type_map_.find(type_ids[i]);
-    if (pos != type_map_.end()) {
-      types.append(TypeIdentifierTypeObjectPair(pos->first, pos->second));
+    const TypeIdentifier& tid = type_ids[i];
+    if (tid.kind() != TI_STRONGLY_CONNECTED_COMPONENT) {
+      tids.insert(tid);
+    } else {
+      TypeIdentifier scc_id(tid);
+      for (ACE_CDR::Long j = 1; j <= scc_id.sc_component_id().scc_length; ++j) {
+        scc_id.sc_component_id().scc_index = j;
+        tids.insert(scc_id);
+      }
+    }
+  }
+
+  ACE_GUARD(ACE_Thread_Mutex, g, mutex_);
+  for (TypeIdentifierSet::const_iterator pos = tids.begin(), limit = tids.end(); pos != limit; ++pos) {
+    const TypeIdentifier& tid = *pos;
+    TypeMap::const_iterator pos2 = type_map_.find(tid);
+    if (pos2 != type_map_.end()) {
+      types.append(TypeIdentifierTypeObjectPair(tid, pos2->second));
+    } else if (DCPS::log_level >= DCPS::LogLevel::Warning) {
+      ACE_ERROR((LM_WARNING,
+                 "(%P|%t) WARNING: TypeLookupService::set_type_objects: "
+                 "unknown type\n"));
     }
   }
 }
@@ -103,25 +123,15 @@ void TypeLookupService::get_type_dependencies(const TypeIdentifierSeq& type_ids,
 void TypeLookupService::get_type_dependencies_i(const TypeIdentifierSeq& type_ids,
   TypeIdentifierWithSizeSeq& dependencies) const
 {
-  OPENDDS_SET(TypeIdentifier) tmp;
   for (unsigned i = 0; i < type_ids.length(); ++i) {
-    const TypeIdentifierWithSizeSeqMap::const_iterator it = type_dependencies_map_.find(type_ids[i]);
+    const TypeIdentifier tid = make_scc_id_or_default(type_ids[i]);
+    const TypeIdentifierWithSizeSeqMap::const_iterator it = type_dependencies_map_.find(tid);
     if (it != type_dependencies_map_.end()) {
       for (unsigned j = 0; j < it->second.length(); ++j) {
-        tmp.insert(it->second[j].type_id);
+        const ACE_CDR::ULong idx = dependencies.length();
+        dependencies.length(idx + 1);
+        dependencies[idx] = it->second[j];
       }
-    }
-  }
-
-  // All dependent TypeIdentifiers are expected to have an entry in the TypeObject cache.
-  dependencies.length(static_cast<unsigned>(tmp.size()));
-  OPENDDS_SET(TypeIdentifier)::const_iterator iter = tmp.begin();
-  for (unsigned i = 0; iter != tmp.end(); ++i, ++iter) {
-    const TypeMap::const_iterator tobj_it = type_map_.find(*iter);
-    if (tobj_it != type_map_.end()) {
-      dependencies[i].type_id = *iter;
-      const size_t sz = DCPS::serialized_size(get_typeobject_encoding(), tobj_it->second);
-      dependencies[i].typeobject_serialized_size = static_cast<unsigned>(sz);
     }
   }
 }

--- a/dds/DCPS/XTypes/TypeObject.cpp
+++ b/dds/DCPS/XTypes/TypeObject.cpp
@@ -466,49 +466,64 @@ bool has_type_object(const TypeIdentifier& ti)
     ti.kind() != TK_NONE;
 }
 
+TypeIdentifier make_scc_id_or_default(const TypeIdentifier& tid)
+{
+  if (tid.kind() != TI_STRONGLY_CONNECTED_COMPONENT) {
+    return tid;
+  }
+
+  TypeIdentifier scc_id(tid);
+  scc_id.sc_component_id().scc_index = 0;
+  return scc_id;
+}
+
 const TypeMap TypeMapBuilder::EmptyMap;
 
 namespace {
   void compute_dependencies_i(const TypeMap& type_map,
                               const TypeIdentifier& type_identifier,
-                              OPENDDS_SET(TypeIdentifier)& dependencies);
+                              TypeIdentifierSet& dependencies);
+
+  void compute_dependencies_j(const TypeMap& type_map,
+                              const TypeIdentifier& type_identifier,
+                              TypeIdentifierSet& dependencies);
 
   template <typename T>
   void compute_dependencies_i(const TypeMap& type_map,
                               const Sequence<T>& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies);
+                              TypeIdentifierSet& dependencies);
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CommonAliasBody& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.related_type, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalAliasBody& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.common, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalAliasType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.body, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const AppliedAnnotation& ann,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, ann.annotation_typeid, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const OPENDDS_OPTIONAL_NS::optional<AppliedAnnotationSeq>& ann_seq,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     if (ann_seq) {
       compute_dependencies_i(type_map, ann_seq.value(), dependencies);
@@ -517,21 +532,21 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteTypeDetail& type_detail,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type_detail.ann_custom, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteAliasHeader& header,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, header.detail, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteAliasBody& body,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, body.common, dependencies);
     compute_dependencies_i(type_map, body.ann_custom, dependencies);
@@ -539,7 +554,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteAliasType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, type.body, dependencies);
@@ -547,63 +562,63 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CommonAnnotationParameter& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.member_type_id, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalAnnotationParameter& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.common, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalAnnotationType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.member_seq, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteAnnotationParameter& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.common, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteAnnotationType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.member_seq, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalStructHeader& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.base_type, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CommonStructMember& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.member_type_id, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalStructMember& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.common, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalStructType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, type.member_seq, dependencies);
@@ -611,7 +626,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteStructHeader& header,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, header.base_type, dependencies);
     compute_dependencies_i(type_map, header.detail, dependencies);
@@ -619,14 +634,14 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteMemberDetail& detail,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, detail.ann_custom, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteStructMember& member,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, member.common, dependencies);
     compute_dependencies_i(type_map, member.detail, dependencies);
@@ -634,7 +649,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteStructType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, type.member_seq, dependencies);
@@ -642,35 +657,35 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CommonDiscriminatorMember& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.type_id, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalDiscriminatorMember& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.common, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CommonUnionMember& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.type_id, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalUnionMember& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.common, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalUnionType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.discriminator, dependencies);
     compute_dependencies_i(type_map, type.member_seq, dependencies);
@@ -678,14 +693,14 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteUnionHeader& header,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, header.detail, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteDiscriminatorMember& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.common, dependencies);
     compute_dependencies_i(type_map, type.ann_custom, dependencies);
@@ -693,7 +708,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteUnionMember& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.common, dependencies);
     compute_dependencies_i(type_map, type.detail, dependencies);
@@ -701,7 +716,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteUnionType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, type.discriminator, dependencies);
@@ -710,28 +725,28 @@ namespace {
 
   void compute_dependencies_i(const TypeMap&,
                               const MinimalBitsetType&,
-                              OPENDDS_SET(TypeIdentifier)&)
+                              TypeIdentifierSet&)
   {
     // Doesn't have any dependencies.
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteBitsetHeader& header,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, header.detail, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteBitfield& field,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, field.detail, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteBitsetType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, type.field_seq, dependencies);
@@ -739,28 +754,28 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CommonCollectionElement& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.type, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalCollectionElement& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.common, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalSequenceType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.element, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteCollectionHeader& header,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     if (header.detail) {
       compute_dependencies_i(type_map, header.detail.value(), dependencies);
@@ -769,14 +784,14 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteElementDetail& detail,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, detail.ann_custom, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteCollectionElement& element,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, element.common, dependencies);
     compute_dependencies_i(type_map, element.detail, dependencies);
@@ -784,7 +799,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteSequenceType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, type.element, dependencies);
@@ -792,21 +807,21 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalArrayType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.element, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteArrayHeader& header,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, header.detail, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteArrayType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, type.element, dependencies);
@@ -814,7 +829,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const MinimalMapType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.key, dependencies);
     compute_dependencies_i(type_map, type.element, dependencies);
@@ -822,7 +837,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteMapType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, type.key, dependencies);
@@ -831,28 +846,28 @@ namespace {
 
   void compute_dependencies_i(const TypeMap&,
                               const MinimalEnumeratedType&,
-                              OPENDDS_SET(TypeIdentifier)&)
+                              TypeIdentifierSet&)
   {
     // Doesn't have any dependencies.
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteEnumeratedHeader& header,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, header.detail, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteEnumeratedLiteral& literal,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, literal.detail, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteEnumeratedType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, type.literal_seq, dependencies);
@@ -860,21 +875,21 @@ namespace {
 
   void compute_dependencies_i(const TypeMap&,
                               const MinimalBitmaskType&,
-                              OPENDDS_SET(TypeIdentifier)&)
+                              TypeIdentifierSet&)
   {
     // Doesn't have any dependencies.
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteBitflag& bitflag,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, bitflag.detail, dependencies);
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const CompleteBitmaskType& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, type.flag_seq, dependencies);
@@ -883,7 +898,7 @@ namespace {
   template <typename T>
   void compute_dependencies_i(const TypeMap& type_map,
                               const T& type_object, // MinimalTypeObject, CompleteTypeObject
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     switch (type_object.kind) {
     case TK_ALIAS:
@@ -921,7 +936,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const TypeObject& type_object,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     switch (type_object.kind) {
     case EK_COMPLETE:
@@ -935,28 +950,28 @@ namespace {
 
   void compute_dependencies_i(const TypeMap&,
                               const StringSTypeDefn&,
-                              OPENDDS_SET(TypeIdentifier)&)
+                              TypeIdentifierSet&)
   {
     // Do nothing.
   }
 
   void compute_dependencies_i(const TypeMap&,
                               const StringLTypeDefn&,
-                              OPENDDS_SET(TypeIdentifier)&)
+                              TypeIdentifierSet&)
   {
     // Do nothing.
   }
 
   void compute_dependencies_i(const TypeMap&,
                               const PlainCollectionHeader&,
-                              OPENDDS_SET(TypeIdentifier)&)
+                              TypeIdentifierSet&)
   {
     // Do nothing.
   }
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const PlainSequenceSElemDefn& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, *type.element_identifier, dependencies);
@@ -964,7 +979,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const PlainSequenceLElemDefn& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, *type.element_identifier, dependencies);
@@ -972,7 +987,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const PlainArraySElemDefn& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, *type.element_identifier, dependencies);
@@ -980,7 +995,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const PlainArrayLElemDefn& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, *type.element_identifier, dependencies);
@@ -988,7 +1003,7 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const PlainMapSTypeDefn& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, *type.element_identifier, dependencies);
@@ -997,24 +1012,32 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const PlainMapLTypeDefn& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     compute_dependencies_i(type_map, type.header, dependencies);
     compute_dependencies_i(type_map, *type.element_identifier, dependencies);
     compute_dependencies_i(type_map, *type.key_identifier, dependencies);
   }
 
-  void compute_dependencies_i(const TypeMap&,
-                              const StronglyConnectedComponentId&,
-                              OPENDDS_SET(TypeIdentifier)&)
+  void compute_dependencies_i(const TypeMap& type_map,
+                              const StronglyConnectedComponentId& type,
+                              TypeIdentifierSet& dependencies)
   {
-    // Do nothing.
+    // An SCCId (identifies the entire component.)
+    TypeIdentifier scc_id(TI_STRONGLY_CONNECTED_COMPONENT, type);
+    for (ACE_CDR::Long i = 1; i <= scc_id.sc_component_id().scc_length; ++i) {
+      scc_id.sc_component_id().scc_index = i;
+      TypeMap::const_iterator pos = type_map.find(scc_id);
+      if (pos != type_map.end()) {
+        compute_dependencies_i(type_map, pos->second, dependencies);
+      }
+    }
   }
 
   template <typename T>
   void compute_dependencies_i(const TypeMap& type_map,
                               const Sequence<T>& type,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
     for (typename Sequence<T>::const_iterator pos = type.begin(), limit = type.end(); pos != limit; ++pos) {
       compute_dependencies_i(type_map, *pos, dependencies);
@@ -1023,62 +1046,73 @@ namespace {
 
   void compute_dependencies_i(const TypeMap& type_map,
                               const TypeIdentifier& type_identifier,
-                              OPENDDS_SET(TypeIdentifier)& dependencies)
+                              TypeIdentifierSet& dependencies)
   {
-    if (dependencies.count(type_identifier) != 0) {
+    const TypeIdentifier scc_id = make_scc_id_or_default(type_identifier);
+
+    if (dependencies.count(scc_id) != 0) {
       return;
     }
 
-    dependencies.insert(type_identifier);
+    if (scc_id.kind() != TK_NONE) {
+      dependencies.insert(scc_id);
+    }
 
-    compute_dependencies(type_map, type_identifier, dependencies);
+    compute_dependencies_j(type_map, scc_id, dependencies);
+  }
+
+  void compute_dependencies_j(const TypeMap& type_map,
+                              const TypeIdentifier& type_identifier,
+                              TypeIdentifierSet& dependencies)
+  {
+    switch (type_identifier.kind()) {
+    case TI_STRING8_SMALL:
+    case TI_STRING16_SMALL:
+      compute_dependencies_i(type_map, type_identifier.string_sdefn(), dependencies);
+      break;
+    case TI_STRING8_LARGE:
+    case TI_STRING16_LARGE:
+      compute_dependencies_i(type_map, type_identifier.string_ldefn(), dependencies);
+      break;
+    case TI_PLAIN_SEQUENCE_SMALL:
+      compute_dependencies_i(type_map, type_identifier.seq_sdefn(), dependencies);
+      break;
+    case TI_PLAIN_SEQUENCE_LARGE:
+      compute_dependencies_i(type_map, type_identifier.seq_ldefn(), dependencies);
+      break;
+    case TI_PLAIN_ARRAY_SMALL:
+      compute_dependencies_i(type_map, type_identifier.array_sdefn(), dependencies);
+      break;
+    case TI_PLAIN_ARRAY_LARGE:
+      compute_dependencies_i(type_map, type_identifier.array_ldefn(), dependencies);
+      break;
+    case TI_PLAIN_MAP_SMALL:
+      compute_dependencies_i(type_map, type_identifier.map_sdefn(), dependencies);
+      break;
+    case TI_PLAIN_MAP_LARGE:
+      compute_dependencies_i(type_map, type_identifier.map_ldefn(), dependencies);
+      break;
+    case TI_STRONGLY_CONNECTED_COMPONENT:
+      compute_dependencies_i(type_map, type_identifier.sc_component_id(), dependencies);
+      break;
+    case EK_COMPLETE:
+    case EK_MINIMAL:
+      {
+        TypeMap::const_iterator pos = type_map.find(type_identifier);
+        if (pos != type_map.end()) {
+          compute_dependencies_i(type_map, pos->second, dependencies);
+        }
+        break;
+      }
+    }
   }
 }
 
 void compute_dependencies(const TypeMap& type_map,
                           const TypeIdentifier& type_identifier,
-                          OPENDDS_SET(TypeIdentifier)& dependencies)
+                          TypeIdentifierSet& dependencies)
 {
-  switch (type_identifier.kind()) {
-  case TI_STRING8_SMALL:
-  case TI_STRING16_SMALL:
-    compute_dependencies_i(type_map, type_identifier.string_sdefn(), dependencies);
-    break;
-  case TI_STRING8_LARGE:
-  case TI_STRING16_LARGE:
-    compute_dependencies_i(type_map, type_identifier.string_ldefn(), dependencies);
-    break;
-  case TI_PLAIN_SEQUENCE_SMALL:
-    compute_dependencies_i(type_map, type_identifier.seq_sdefn(), dependencies);
-    break;
-  case TI_PLAIN_SEQUENCE_LARGE:
-    compute_dependencies_i(type_map, type_identifier.seq_ldefn(), dependencies);
-    break;
-  case TI_PLAIN_ARRAY_SMALL:
-    compute_dependencies_i(type_map, type_identifier.array_sdefn(), dependencies);
-    break;
-  case TI_PLAIN_ARRAY_LARGE:
-    compute_dependencies_i(type_map, type_identifier.array_ldefn(), dependencies);
-    break;
-  case TI_PLAIN_MAP_SMALL:
-    compute_dependencies_i(type_map, type_identifier.map_sdefn(), dependencies);
-    break;
-  case TI_PLAIN_MAP_LARGE:
-    compute_dependencies_i(type_map, type_identifier.map_ldefn(), dependencies);
-    break;
-  case TI_STRONGLY_CONNECTED_COMPONENT:
-    compute_dependencies_i(type_map, type_identifier.sc_component_id(), dependencies);
-    break;
-  case EK_COMPLETE:
-  case EK_MINIMAL:
-    {
-      TypeMap::const_iterator pos = type_map.find(type_identifier);
-      if (pos != type_map.end()) {
-        compute_dependencies_i(type_map, pos->second, dependencies);
-      }
-      break;
-    }
-  }
+  compute_dependencies_j(type_map, type_identifier, dependencies);
 }
 
 bool write_empty_xcdr2_nonfinal(DCPS::Serializer& strm)

--- a/dds/DCPS/XTypes/TypeObject.h
+++ b/dds/DCPS/XTypes/TypeObject.h
@@ -260,7 +260,9 @@ namespace XTypes {
 
     TypeObjectHashId()
       : kind(EK_NONE)
-    {}
+    {
+      std::memset(hash, 0, sizeof(hash));
+    }
 
     TypeObjectHashId(const EquivalenceKind& a_kind,
                      const EquivalenceHashWrapper& a_hash)
@@ -3366,9 +3368,15 @@ namespace XTypes {
     static const TypeMap EmptyMap;
   };
 
+  typedef OPENDDS_SET(TypeIdentifier) TypeIdentifierSet;
+
+  OpenDDS_Dcps_Export
+  TypeIdentifier make_scc_id_or_default(const TypeIdentifier& tid);
+
+  OpenDDS_Dcps_Export
   void compute_dependencies(const TypeMap& type_map,
                             const TypeIdentifier& type_identifier,
-                            OPENDDS_SET(TypeIdentifier)& dependencies);
+                            TypeIdentifierSet& dependencies);
 
   OpenDDS_Dcps_Export
   const char* typekind_to_string(TypeKind tk);

--- a/tests/unit-tests/dds/DCPS/XTypes/TypeObject.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/TypeObject.cpp
@@ -5,6 +5,8 @@
  * See: http://www.opendds.org/license.html
  */
 
+#include <CompleteToMinimalTypeObjectTypeSupportImpl.h>
+
 #include "dds/DCPS/XTypes/TypeObject.h"
 
 #include "gtest/gtest.h"
@@ -100,15 +102,23 @@ TypeObject getTypeObject()
 std::ostream& operator<<(std::ostream& os, const TypeIdentifier& ti)
 {
   std::ostream os_hex(os.rdbuf());
-  os_hex << std::hex << std::showbase;
-  os_hex << "Kind: " << int(ti.kind()) << ' ';
+  os << std::hex << std::showbase;
+  os << "Kind: " << int(ti.kind()) << ' ';
   if (ti.kind() == EK_COMPLETE || ti.kind() == EK_MINIMAL) {
     os_hex << "Equiv Hash: ";
     for (size_t i = 0; i < sizeof ti.equivalence_hash(); ++i) {
       os_hex << int(ti.equivalence_hash()[i]) << ' ';
     }
+  } else if (ti.kind() == TI_STRONGLY_CONNECTED_COMPONENT) {
+    os_hex << "SC Hash Kind: " << int(ti.sc_component_id().sc_component_id.kind);
+    os << " SC Hash: ";
+    for (size_t i = 0; i < sizeof ti.sc_component_id().sc_component_id.hash; ++i) {
+      os_hex << int(ti.sc_component_id().sc_component_id.hash[i]) << ' ';
+    }
+    os << " length: " << ti.sc_component_id().scc_length;
+    os << " index: " << ti.sc_component_id().scc_index;
   }
-  return os << '\n';
+  return os;
 }
 
 TEST(dds_DCPS_XTypes_TypeObject, maintest)
@@ -1922,4 +1932,36 @@ TEST(dds_DCPS_XTypes_TypeIdentifierWithSize, TypeIdentifierWithSize_equal)
 
   EXPECT_EQ(uut1, uut2);
   EXPECT_NE(uut2, uut3);
+}
+
+TEST(dds_DCPS_XTypes, make_scc_id_or_default)
+{
+  TypeIdentifier none;
+  EXPECT_EQ(none, make_scc_id_or_default(none));
+
+  TypeIdentifier scc_x(TI_STRONGLY_CONNECTED_COMPONENT, StronglyConnectedComponentId());
+  scc_x.sc_component_id().scc_index = 1;
+  scc_x.sc_component_id().scc_length = 5;
+  TypeIdentifier scc_y(scc_x);
+  scc_y.sc_component_id().scc_index = 0;
+  EXPECT_EQ(scc_y, make_scc_id_or_default(scc_x));
+}
+
+TEST(dds_DCPS_XTypes, compute_dependencies)
+{
+  MyModCompleteToMinimal::CircularStructTypeSupportImpl type_support;
+
+  const TypeIdentifier ti = type_support.getMinimalTypeIdentifier();
+  ASSERT_EQ(ti.kind(), TI_STRONGLY_CONNECTED_COMPONENT);
+  ASSERT_EQ(ti.sc_component_id().scc_index, 1);
+  ASSERT_EQ(ti.sc_component_id().scc_length, 5);
+
+  const TypeMap& tm = type_support.getMinimalTypeMap();
+
+  TypeIdentifierSet dependencies;
+  compute_dependencies(tm, ti, dependencies);
+
+  ASSERT_EQ(dependencies.size(), 1U);
+  const TypeIdentifier& x = *dependencies.begin();
+  ASSERT_EQ(x, make_scc_id_or_default(ti));
 }


### PR DESCRIPTION
Problem
-------

The TypeLookupService doesn't support strongly connected components (SCCs) correctly.

Solution
--------

* Add the SCCId to dependencies when necessary (fixes `getTypeDependencies`).
* Update `getTypes` to consolidate type identifiers and send all components of an SCC.