### PR TITLE
FlexibleTypes delay association

### DIFF
--- a/dds/DCPS/RTPS/AssociationRecord.h
+++ b/dds/DCPS/RTPS/AssociationRecord.h
@@ -90,10 +90,12 @@ class WriterAssociationRecord : public DCPS::RcObject {
 public:
   WriterAssociationRecord(DCPS::DataWriterCallbacks_wrch callbacks,
                           const DCPS::GUID_t& writer_id,
-                          const DCPS::ReaderAssociation& reader_association)
+                          const DCPS::ReaderAssociation& reader_association,
+                          const DCPS::SequenceNumber& publication_sn = DCPS::SequenceNumber::SEQUENCENUMBER_UNKNOWN())
     : callbacks_(callbacks)
     , writer_id_(writer_id)
     , reader_association_(reader_association)
+    , publication_sn_(publication_sn)
   {}
 
   const DCPS::GUID_t& writer_id() const { return writer_id_; }
@@ -102,6 +104,7 @@ public:
   const DCPS::DataWriterCallbacks_wrch callbacks_;
   const DCPS::GUID_t writer_id_;
   const DCPS::ReaderAssociation reader_association_;
+  DCPS::SequenceNumber publication_sn_;
 };
 typedef DCPS::RcHandle<WriterAssociationRecord> WriterAssociationRecord_rch;
 
@@ -109,10 +112,12 @@ class ReaderAssociationRecord : public DCPS::RcObject {
 public:
   ReaderAssociationRecord(DCPS::DataReaderCallbacks_wrch callbacks,
                           const DCPS::GUID_t& reader_id,
-                          const DCPS::WriterAssociation& writer_association)
+                          const DCPS::WriterAssociation& writer_association,
+                          const DCPS::SequenceNumber& subscription_sn = DCPS::SequenceNumber::SEQUENCENUMBER_UNKNOWN())
     : callbacks_(callbacks)
     , reader_id_(reader_id)
     , writer_association_(writer_association)
+    , subscription_sn_(subscription_sn)
   {}
 
   const DCPS::GUID_t& reader_id() const { return reader_id_; }
@@ -121,6 +126,7 @@ public:
   const DCPS::DataReaderCallbacks_wrch callbacks_;
   const DCPS::GUID_t reader_id_;
   const DCPS::WriterAssociation writer_association_;
+  DCPS::SequenceNumber subscription_sn_;
 };
 typedef DCPS::RcHandle<ReaderAssociationRecord> ReaderAssociationRecord_rch;
 

--- a/dds/DCPS/transport/framework/DataLink.h
+++ b/dds/DCPS/transport/framework/DataLink.h
@@ -280,6 +280,9 @@ public:
 
   virtual WeakRcHandle<ICE::Endpoint> get_ice_endpoint() const { return WeakRcHandle<ICE::Endpoint>(); }
 
+  virtual SequenceNumber cur_cumulative_ack(const GUID_t& /*writer*/,
+                                            const GUID_t& /*reader*/) const { return SequenceNumber::ZERO(); }
+
   virtual bool is_leading(const GUID_t& /*writer*/,
                           const GUID_t& /*reader*/) const { return false; }
 

--- a/dds/DCPS/transport/framework/DataLinkSet.h
+++ b/dds/DCPS/transport/framework/DataLinkSet.h
@@ -87,6 +87,9 @@ public:
 
   void terminate_send_if_suspended();
 
+  SequenceNumber cur_cumulative_ack(const GUID_t& writer_id,
+                                    const GUID_t& reader_id) const;
+
   bool is_leading(const GUID_t& writer_id,
                   const GUID_t& reader_id) const;
 

--- a/dds/DCPS/transport/framework/TransportClient.cpp
+++ b/dds/DCPS/transport/framework/TransportClient.cpp
@@ -1182,6 +1182,12 @@ void TransportClient::data_acked(const GUID_t& remote)
   send_listener->data_acked(remote);
 }
 
+SequenceNumber TransportClient::cur_cumulative_ack(const GUID_t& reader_id) const
+{
+  OPENDDS_ASSERT(guid_ != GUID_UNKNOWN);
+  return links_.cur_cumulative_ack(guid_, reader_id);
+}
+
 bool TransportClient::is_leading(const GUID_t& reader_id) const
 {
   OPENDDS_ASSERT(guid_ != GUID_UNKNOWN);

--- a/dds/DCPS/transport/framework/TransportClient.h
+++ b/dds/DCPS/transport/framework/TransportClient.h
@@ -153,6 +153,7 @@ public:
 
   void data_acked(const GUID_t& remote);
 
+  SequenceNumber cur_cumulative_ack(const GUID_t& reader_id) const;
   bool is_leading(const GUID_t& reader_id) const;
 
 protected:

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -4541,6 +4541,19 @@ RtpsUdpDataLink::RtpsWriter::add_elem_awaiting_ack(TransportQueueElement* elemen
   elems_not_acked_.insert(SnToTqeMap::value_type(element->sequence(), element));
 }
 
+SequenceNumber
+RtpsUdpDataLink::RtpsWriter::cur_cumulative_ack(const GUID_t& reader_id) const
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, mutex_, false);
+
+  ReaderInfoMap::const_iterator iter = remote_readers_.find(reader_id);
+  if (iter != remote_readers_.end()) {
+    return iter->second->cur_cumulative_ack();
+  }
+
+  return SequenceNumber::ZERO();
+}
+
 bool
 RtpsUdpDataLink::RtpsWriter::is_leading(const GUID_t& reader_id) const
 {
@@ -4829,6 +4842,24 @@ RtpsUdpDataLink::get_ice_endpoint() const
 {
   TransportImpl_rch ti = impl();
   return ti ? ti->get_ice_endpoint() : WeakRcHandle<ICE::Endpoint>();
+}
+
+SequenceNumber
+RtpsUdpDataLink::cur_cumulative_ack(const GUID_t& writer_id,
+                                    const GUID_t& reader_id) const
+{
+  RtpsWriterMap::mapped_type writer;
+
+  {
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, g, writers_lock_, false);
+    RtpsWriterMap::const_iterator pos = writers_.find(writer_id);
+    if (pos == writers_.end()) {
+      return false;
+    }
+    writer = pos->second;
+  }
+
+  return writer->cur_cumulative_ack(reader_id);
 }
 
 bool RtpsUdpDataLink::is_leading(const GUID_t& writer_id,

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.h
@@ -217,6 +217,9 @@ public:
 #endif
   virtual DCPS::WeakRcHandle<ICE::Endpoint> get_ice_endpoint() const;
 
+  virtual SequenceNumber cur_cumulative_ack(const GUID_t& writer,
+                                            const GUID_t& reader) const;
+
   virtual bool is_leading(const GUID_t& writer_id,
                           const GUID_t& reader_id) const;
 
@@ -257,6 +260,9 @@ private:
   NetworkAddressSet get_addresses_i(const GUID_t& local) const;
 
   virtual void stop_i();
+
+  // Force path through customize_queue_element.
+  virtual bool handle_send_request_ack(TransportQueueElement*) { return false; }
 
   virtual TransportQueueElement* customize_queue_element(
     TransportQueueElement* element);
@@ -382,6 +388,7 @@ private:
     void expunge_durable_data();
     bool expecting_durable_data() const;
     SequenceNumber acked_sn() const { return cur_cumulative_ack_.previous(); }
+    SequenceNumber cur_cumulative_ack() const { return cur_cumulative_ack_; }
     bool reflects_heartbeat_count() const;
   };
 
@@ -544,6 +551,7 @@ private:
     bool add_reader(const ReaderInfo_rch& reader);
     bool has_reader(const GUID_t& id) const;
     bool is_leading(const GUID_t& id) const;
+    SequenceNumber cur_cumulative_ack(const GUID_t& id) const;
     bool remove_reader(const GUID_t& id);
     size_t reader_count() const;
     CORBA::Long inc_heartbeat_count();


### PR DESCRIPTION
Problem
-------

Enabling flexible types causes new publications and subscriptions to be written.  These are outside of the durable data which means they go through a delay, heartbeat, and acknack cycle.  This delays association since there is definitely a match but the local match cannot proceed without confirmation that the remote received the local publication/subscription.  The goal is to eliminate the delay.

Solution
--------

- Keep track of endpoints that write samples when enabling flexible types.
- Request acknowledgement on these endpoints.
  - Enable support for request acknowledgements in RTPS.
- Update the progressive association logic to only require the reader to acknowledge the relevant publication/subscription.