### PR TITLE
RtpsRelay stress test is misconfigured

### DIFF
--- a/tests/DCPS/RtpsRelay/Smoke/participant_relay_2.ini
+++ b/tests/DCPS/RtpsRelay/Smoke/participant_relay_2.ini
@@ -45,7 +45,18 @@ SpdpUserTag=0
 
 [transport/rtps]
 transport_type=rtps_udp
-use_multicast=0
-DataRtpsRelayAddress=127.0.0.1:5446
+SendBufferSize=65535
+RcvBufferSize=65535
+UseMulticast=0
+TTL=1
+AnticipatedFragments=63
+MaxMessageSize=1400
+NakDepth=0
+NakResponseDelay=200
+HeartbeatPeriod=1000
+ReceiveAddressDuration=5000
+ResponsiveMode=1
+SendDelay=10
 RtpsRelayOnly=1
-max_message_size=1400
+UseRtpsRelay=1
+DataRtpsRelayAddress=127.0.0.1:5446

--- a/tests/DCPS/RtpsRelay/Smoke/stress_relay_1.ini
+++ b/tests/DCPS/RtpsRelay/Smoke/stress_relay_1.ini
@@ -25,8 +25,8 @@ DiscoveryConfig=application_rtps_discovery
 [rtps_discovery/application_rtps_discovery]
 CheckSourceIp=0
 SedpMulticast=0
-SpdpRtpsRelayAddress=127.0.0.1:4445
-SedpRtpsRelayAddress=127.0.0.1:4446
+SpdpRtpsRelayAddress=127.0.0.1:4444
+SedpRtpsRelayAddress=127.0.0.1:4445
 RtpsRelayOnly=1
 MinResendDelay=0
 SedpMaxMessageSize=1400


### PR DESCRIPTION
Problem
-------

`stress_relay_1.ini` contains incorrect settings for `SpdpRtpsRelayAddress` and `SedpRtpsRelayAddress`.

`participant_relay_2.ini` doesn't match `participant_relay_1.ini`.

Solution
--------

Correct the settings and add missing settngs.