### PR TITLE
RtpsRelay leaks memory for incomplete discoveries

### DIFF
--- a/tools/rtpsrelay/GuidPartitionTable.cpp
+++ b/tools/rtpsrelay/GuidPartitionTable.cpp
@@ -145,7 +145,7 @@ void GuidPartitionTable::lookup(StringSet& partitions, const OpenDDS::DCPS::GUID
     return;
   }
 
-  auto& c = guid_to_partitions_cache_[prefix];
+  StringSet c;
 
   for (auto pos = guid_to_partitions_.lower_bound(prefix), limit = guid_to_partitions_.end();
         pos != limit && std::memcmp(pos->first.guidPrefix, prefix.guidPrefix, sizeof(prefix.guidPrefix)) == 0; ++pos) {
@@ -158,7 +158,11 @@ void GuidPartitionTable::lookup(StringSet& partitions, const OpenDDS::DCPS::GUID
     c.erase("");
   }
 
-  relay_stats_reporter_.partition_guids(guid_to_partitions_.size(), guid_to_partitions_cache_.size());
+  // Only create a cache entry if there is something to cache.
+  if (!c.empty()) {
+    guid_to_partitions_cache_[prefix] = c;
+    relay_stats_reporter_.partition_guids(guid_to_partitions_.size(), guid_to_partitions_cache_.size());
+  }
 }
 
 void GuidPartitionTable::populate_replay(SpdpReplay& spdp_replay,


### PR DESCRIPTION
Problem
-------

Observations:

1. `GuidPartitionTable::lookup` creates a cache entry if it does not exist.
2. The discovery of a publication or subscription removes the cache entry if it exists and the partitions change.
3. The removal of a publication or subscription removes the cache entry if it exists.
4. `GuidPartitionTable::lookup` can be called before discovery completes.

In a scenario where discovery completes, the cache is eventually correct, that is, it is correct after the first lookup that follows the last publication or subscription.

In a scenario where dicovery doesn't complete, then the cache entry is created (1 and 4) but not removed (2 and 3).

Solution
--------

Only create a cache entry if the set of partitions is not empty which implies discovery is in progress or has completed.