### PR TITLE
GHA Annotations and Better Link Check for Sphinx

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -242,7 +242,7 @@ Read [the documentation for this release on Read the Docs](https://opendds.readt
 
 ### Documentation
 
-- [Run-time Configuration](https://opendds.readthedocs.io/en/dds-3.28/devguide/run_time_configuration.html#config) ([PR #4464](https://github.com/OpenDDS/OpenDDS/pull/4464), [PR #4570](https://github.com/OpenDDS/OpenDDS/pull/4570), [PR #4467](https://github.com/OpenDDS/OpenDDS/pull/4467), [PR #4588](https://github.com/OpenDDS/OpenDDS/pull/4588))
+- [Run-time Configuration](https://opendds.readthedocs.io/en/dds-3.28/devguide/run_time_configuration.html#config) ([PR #4564](https://github.com/OpenDDS/OpenDDS/pull/4564), [PR #4570](https://github.com/OpenDDS/OpenDDS/pull/4570), [PR #4467](https://github.com/OpenDDS/OpenDDS/pull/4467), [PR #4588](https://github.com/OpenDDS/OpenDDS/pull/4588))
   - Restructured configuration properties so they can be linked to directly.
     Also reviewed each property description to correct or add missing context as needed.
 - [Introduction to OpenDDS](https://opendds.readthedocs.io/en/dds-3.28/devguide/introduction.html#introduction) ([PR #4467](https://github.com/OpenDDS/OpenDDS/pull/4467))
@@ -327,25 +327,25 @@ Read [the documentation for this release on Read the Docs](https://opendds.readt
 
 ### Additions
 
-* OpenDDS can now be built using CMake for most common scenarios. ([PR #4203](https://github.com/OpenDDS/OpenDDS/pull/4203), [PR #4214](https://github.com/OpenDDS/OpenDDS/pull/4214))
+* OpenDDS can now be built using CMake for most common scenarios. ([PR #4203](https://github.com/OpenDDS/OpenDDS/pull/4203), [PR #4314](https://github.com/OpenDDS/OpenDDS/pull/4314))
     * This is still considered somewhat experimental as it doesn't support [everything that an MPC-built OpenDDS currently can](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/index.html#cmake-known-limitations).
     * See [Building OpenDDS Using CMake](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/index.html#cmake-building) for details.
 
 * Convert transport configurations (`rtps_udp`, `multicast`, `shmem`, `tcp`, `udp`) uses key-value store. ([PR #4162](https://github.com/OpenDDS/OpenDDS/pull/4162), [PR #4270](https://github.com/OpenDDS/OpenDDS/pull/4270), [PR #4272](https://github.com/OpenDDS/OpenDDS/pull/4272), [PR #4241](https://github.com/OpenDDS/OpenDDS/pull/4241), [PR #4242](https://github.com/OpenDDS/OpenDDS/pull/4242), [PR #4243](https://github.com/OpenDDS/OpenDDS/pull/4243), [PR #4249](https://github.com/OpenDDS/OpenDDS/pull/4249), [PR #4255](https://github.com/OpenDDS/OpenDDS/pull/4255))
 * CMake Config Package
-    * Added [`opendds_install_interface_files`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#func-opendds_install_interface_files) to help install IDL files and the files generated from them. ([PR #4203](https://github.com/OpenDDS/OpenDDS/pull/4203), [PR #4214](https://github.com/OpenDDS/OpenDDS/pull/4214))
-    * Added [`OPENDDS_HOST_TOOLS`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#var-OPENDDS_HOST_TOOLS) and [`OPENDDS_ACE_TAO_HOST_TOOLS`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#var-OPENDDS_ACE_TAO_HOST_TOOLS) to allow cross compiling applications with both MPC and CMake-built OpenDDS. ([PR #4203](https://github.com/OpenDDS/OpenDDS/pull/4203), [PR #4214](https://github.com/OpenDDS/OpenDDS/pull/4214))
+    * Added [`opendds_install_interface_files`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#func-opendds_install_interface_files) to help install IDL files and the files generated from them. ([PR #4203](https://github.com/OpenDDS/OpenDDS/pull/4203), [PR #4314](https://github.com/OpenDDS/OpenDDS/pull/4314))
+    * Added [`OPENDDS_HOST_TOOLS`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#var-OPENDDS_HOST_TOOLS) and [`OPENDDS_ACE_TAO_HOST_TOOLS`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#var-OPENDDS_ACE_TAO_HOST_TOOLS) to allow cross compiling applications with both MPC and CMake-built OpenDDS. ([PR #4203](https://github.com/OpenDDS/OpenDDS/pull/4203), [PR #4314](https://github.com/OpenDDS/OpenDDS/pull/4314))
     * [`opendds_target_sources`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#func-opendds_target_sources):
 
-        * Added [`opendds_target_sources(INCLUDE_BASE)`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#func-arg-opendds_target_sources-INCLUDE_BASE) to preserve the directory structure of the IDL files for compiling the resulting generated files and installing everything using [`opendds_install_interface_files`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#func-opendds_install_interface_files). ([PR #4203](https://github.com/OpenDDS/OpenDDS/pull/4203), [PR #4214](https://github.com/OpenDDS/OpenDDS/pull/4214))
-        * Added [`opendds_target_sources(USE_VERSIONED_NAMESPACE)`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#func-arg-opendds_target_sources-USE_VERSIONED_NAMESPACE) as a shortcut to the `-Wb,versioning_\*` IDL compiler options. ([PR #4203](https://github.com/OpenDDS/OpenDDS/pull/4203), [PR #4214](https://github.com/OpenDDS/OpenDDS/pull/4214))
+        * Added [`opendds_target_sources(INCLUDE_BASE)`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#func-arg-opendds_target_sources-INCLUDE_BASE) to preserve the directory structure of the IDL files for compiling the resulting generated files and installing everything using [`opendds_install_interface_files`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#func-opendds_install_interface_files). ([PR #4203](https://github.com/OpenDDS/OpenDDS/pull/4203), [PR #4314](https://github.com/OpenDDS/OpenDDS/pull/4314))
+        * Added [`opendds_target_sources(USE_VERSIONED_NAMESPACE)`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#func-arg-opendds_target_sources-USE_VERSIONED_NAMESPACE) as a shortcut to the `-Wb,versioning_\*` IDL compiler options. ([PR #4203](https://github.com/OpenDDS/OpenDDS/pull/4203), [PR #4314](https://github.com/OpenDDS/OpenDDS/pull/4314))
 
 * Support sending DynamicDataAdapter sample via DynamicDataWriter ([PR #4226](https://github.com/OpenDDS/OpenDDS/pull/4226))
 * Added export macro to ConditionImpl ([PR #4295](https://github.com/OpenDDS/OpenDDS/pull/4295))
 
 ### Deprecations
 
-* Deprecated [`OPENDDS_FILENAME_ONLY_INCLUDES`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#var-OPENDDS_FILENAME_ONLY_INCLUDES) in favor of [`opendds_target_sources(INCLUDE_BASE)`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#func-arg-opendds_target_sources-INCLUDE_BASE). ([PR #4203](https://github.com/OpenDDS/OpenDDS/pull/4203), [PR #4214](https://github.com/OpenDDS/OpenDDS/pull/4214))
+* Deprecated [`OPENDDS_FILENAME_ONLY_INCLUDES`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#var-OPENDDS_FILENAME_ONLY_INCLUDES) in favor of [`opendds_target_sources(INCLUDE_BASE)`](https://opendds.readthedocs.io/en/dds-3.26/devguide/building/cmake.html#func-arg-opendds_target_sources-INCLUDE_BASE). ([PR #4203](https://github.com/OpenDDS/OpenDDS/pull/4203), [PR #4314](https://github.com/OpenDDS/OpenDDS/pull/4314))
 
 ### Fixes
 

--- a/docs/build.py
+++ b/docs/build.py
@@ -9,12 +9,18 @@ import os
 import venv
 import webbrowser
 import itertools
-from subprocess import check_call
+import json
+import re
+from subprocess import check_call, CalledProcessError
 from shutil import rmtree
 from argparse import ArgumentParser
 from pathlib import Path
 
 docs_path = Path(__file__).parent
+sys.path.append(str((docs_path / 'sphinx_extensions').resolve()))
+
+from opendds_logging import github_actions, AnsiColors, create_gha_annotation
+
 abs_docs_path = docs_path.resolve()
 reqs_path = abs_docs_path / 'requirements.txt'
 default_venv_path = docs_path / '.venv'
@@ -25,9 +31,9 @@ python = 'python3'
 def log(*args, **kwargs):
     error = kwargs.pop('error', False)
     f = sys.stderr if error else sys.stdout
-    prefix = 'build.py: '
+    prefix = f'{AnsiColors.Purple}build.py:{AnsiColors.End} '
     if error:
-        prefix += 'ERROR: '
+        prefix += f'{AnsiColors.Red}ERROR:{AnsiColors.End} '
     print(prefix, end='', file=f)
     print(*args, **kwargs, file=f, flush=True)
 
@@ -48,16 +54,17 @@ class DocEnv:
         self.debug = debug
         self.done = set()
 
-    def run(self, *cmd, cwd=abs_docs_path):
+    def run(self, *cmd, cwd=abs_docs_path, add_env={}):
         env = os.environ.copy()
         env['VIRUTAL_ENV'] = str(self.abs_venv_path)
         env['PATH'] = str(self.bin_path) + os.pathsep + env['PATH']
-        if os.environ.get('GITHUB_ACTIONS', 'false') == 'true':
+        if github_actions:
             # Github actions doesn't act as a TTY:
             # https://github.com/actions/runner/issues/241
             # This should force at least sphinx-builder to use color for the
             # link check so it's easier to see errors.
             env['FORCE_COLOR'] = 'true'
+        env.update(add_env)
         log('Running', repr(' '.join(cmd)), 'in', repr(str(cwd)))
         check_call(cmd, env=env, cwd=cwd)
 
@@ -82,13 +89,18 @@ class DocEnv:
             self.venv_path.touch()
             self.rm_build()
 
-    def sphinx_build(self, builder, *args, defines=[]):
+    def sphinx_build(self, builder, *args, defines=[], exit_on_fail=True, add_env={}):
         args = ['-M', builder, '.', str(self.abs_build_path)] + list(args)
         for define in itertools.chain(self.conf_defines, defines):
             args.append('-D' + define)
         if self.debug:
             args += ['-vv', '--jobs', '1', '--pdb']
-        self.run('sphinx-build', *args)
+        try:
+            self.run('sphinx-build', *args, add_env=add_env)
+        except CalledProcessError as e:
+            log('sphinx-build failed', error=True)
+            if exit_on_fail:
+                sys.exit(1)
 
     def do(self, actions, because_of=None, open_result=False):
         for action in actions:
@@ -128,7 +140,72 @@ class DocEnv:
         return None
 
     def do_linkcheck(self):
-        self.sphinx_build('linkcheck', defines=['gen_all_omg_spec_links=0'])
+        self.sphinx_build(
+            'linkcheck',
+            defines=['gen_all_omg_spec_links=0'],
+            exit_on_fail=False,
+            add_env={'LINK_CHECK': 'true'},
+        )
+
+        # Process link check results ourselves so we can print failures in one
+        # place, ignore failures based on reason, and inspect things like
+        # redirects with custom logic.
+        ignore_info = {
+            r'.*': [r'.*403 Client Error.*'],  # This is very common
+        }
+        linkcheck_json = self.build_path / 'linkcheck/output.json'
+        failed = False
+        with linkcheck_json.open() as f:
+            for line in f:
+                r = json.loads(line)
+                filename = docs_path.name + '/' + r['filename']
+                lineno = r['lineno']
+                status = r['status']
+                uri = r['uri']
+                info = r['info']
+                extra_info = None
+
+                match status:
+                    case 'ignored' | 'unchecked' | 'working':
+                        continue
+                    case 'redirected':
+                        if re.fullmatch(r'https://github.com/OpenDDS/OpenDDS/(pull|issue)/.*', uri):
+                            # GitHub issues and PRs should not redirect,
+                            # because it means it's the wrong type or number.
+                            extra_info = 'PR/issue nub or type is wrong'
+                        else:
+                            continue
+                    case _:
+                        ignore = False
+                        for uri_regex, info_regex_list in ignore_info.items():
+                            if re.fullmatch(uri_regex, uri):
+                                for info_regex in info_regex_list:
+                                    if re.fullmatch(info_regex, info):
+                                        ignore = True
+                                        break
+                            if ignore:
+                                break
+                        if ignore:
+                            continue
+
+                failed = True
+
+                part1 = f'{uri} is '
+                part2 = status
+                if extra_info:
+                    part2 += f' ({extra_info})'
+                part3 = ''
+                if info:
+                    part2 += ': ' + info
+                log(f'{filename}:{lineno}', f'{part1}{AnsiColors.Red}{part2}{AnsiColors.End}{part3}', error=True)
+                anno = create_gha_annotation('error', f'{part1}{part2}{part3}',
+                    title='linkcheck', file=filename, line=lineno, for_link_check=True)
+                if anno:
+                    print(anno)
+
+        if failed:
+            sys.exit(1)
+
         return None
 
     def do_html(self):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,10 +7,13 @@
 import sys
 import os
 import re
+import logging
 from pathlib import Path
 
 from docutils.transforms import Transform
 from docutils import nodes
+
+from sphinx.util.logging import NAMESPACE as sphinx_root_logger
 
 docs_path = Path(__file__).parent
 opendds_root_path = docs_path.parent
@@ -18,10 +21,17 @@ ext = (docs_path / 'sphinx_extensions').resolve()
 sys.path.append(str(ext))
 github_links_root_path = str(opendds_root_path)
 
+import newsd
 from mpc_lexer import MpcLexer
-from newsd import print_all_news, parse_newsd
 from version_info import VersionInfo
 from links import add_omg_spec
+from opendds_logging import GhaAnnotationHandler, create_gha_annotation, replace_files
+
+
+# Make Sphinx output GitHub Actions annotations
+logging.getLogger(sphinx_root_logger).addHandler(
+    GhaAnnotationHandler(replace_files=replace_files))
+
 
 # Custom Values ---------------------------------------------------------------
 
@@ -89,14 +99,22 @@ ace7tao3_version = opendds_version_info.ace7tao3_version
 if opendds_version_info.release_year:
     copyright = f'{opendds_version_info.release_year} {copyright}'
 
-# Generate news for all releases
-with (docs_path / 'news.rst').open('w') as f:
-    print_all_news(file=f)
+# Handle News Generation
+try:
+    # Generate news for all releases
+    with (docs_path / 'news.rst').open('w') as f:
+        newsd.print_all_news(file=f)
 
-# Generate news used for NEWS.md and Markdown release notes for GitHub
-with (docs_path / 'this-release.rst').open('w') as f:
-    print(':orphan:\n', file=f)
-    parse_newsd().print_all(file=f)
+    # Generate news used for NEWS.md and Markdown release notes for GitHub
+    with (docs_path / 'this-release.rst').open('w') as f:
+        print(':orphan:\n', file=f)
+        newsd.parse_newsd().print_all(file=f)
+except newsd.ParseError as e:
+    anno = create_gha_annotation(
+        'error', e.message, title='news', file=e.path, line=e.lineno, replace_files=replace_files)
+    if anno:
+        print(anno)
+    raise
 
 
 # -- General configuration ---------------------------------------------------
@@ -145,17 +163,10 @@ numfig = False
 
 highlight_language = 'none'
 
+linkcheck_retries = 3
 linkcheck_ignore = [
     # Linkcheck doesn't work with GitHub anchors
     r'^https?://github\.com/.*#.+$',
-    # Returns 403 for some reason
-    r'^https?://docs\.github\.com/.*$',
-    r'^https://www.dds-foundation.org/.*$',
-    r'^https://www.corba.org/.*$',
-    # UTF-8 decode errors (trying to parse PDF as HTML?), shouldn't check these anyways
-    r'^https?://www\.omg\.org/spec/.*/PDF.*$',
-    # OMG Member link, will always redirect to a login page
-    r'https://issues.omg.org/browse/.*$'
 ]
 
 intersphinx_mapping = {

--- a/docs/news.d/_releases/v3.24.2.rst
+++ b/docs/news.d/_releases/v3.24.2.rst
@@ -14,7 +14,7 @@ Security
 Fixes
 =====
 
-- Fixed leaked shared memory by the shared memory transport. (:ghpr:`#4171`)
+- Fixed leaked shared memory by the shared memory transport. (:ghpr:`4171`)
 
   - For a 100% fix, a new ACE version including https://github.com/DOCGroup/ACE_TAO/pull/2077 must be used.
 

--- a/docs/news.d/_releases/v3.26.0.rst
+++ b/docs/news.d/_releases/v3.26.0.rst
@@ -7,7 +7,7 @@ Read `the documentation for this release on Read the Docs <https://opendds.readt
 Additions
 =========
 
-- OpenDDS can now be built using CMake for most common scenarios. (:ghpr:`4203`, :ghpr:`4214`)
+- OpenDDS can now be built using CMake for most common scenarios. (:ghpr:`4203`, :ghpr:`4314`)
 
   - This is still considered somewhat experimental as it doesn't support :ref:`everything that an MPC-built OpenDDS currently can <cmake-known-limitations>`.
   - See :ref:`cmake-building` for details.
@@ -16,13 +16,13 @@ Additions
 
 - CMake Config Package
 
-  - Added :cmake:func:`opendds_install_interface_files` to help install IDL files and the files generated from them. (:ghpr:`4203`, :ghpr:`4214`)
-  - Added :cmake:var:`OPENDDS_HOST_TOOLS` and :cmake:var:`OPENDDS_ACE_TAO_HOST_TOOLS` to allow cross compiling applications with both MPC and CMake-built OpenDDS. (:ghpr:`4203`, :ghpr:`4214`)
+  - Added :cmake:func:`opendds_install_interface_files` to help install IDL files and the files generated from them. (:ghpr:`4203`, :ghpr:`4314`)
+  - Added :cmake:var:`OPENDDS_HOST_TOOLS` and :cmake:var:`OPENDDS_ACE_TAO_HOST_TOOLS` to allow cross compiling applications with both MPC and CMake-built OpenDDS. (:ghpr:`4203`, :ghpr:`4314`)
 
   - :cmake:func:`opendds_target_sources`:
 
-    - Added :cmake:func:`opendds_target_sources(INCLUDE_BASE)` to preserve the directory structure of the IDL files for compiling the resulting generated files and installing everything using :cmake:func:`opendds_install_interface_files`. (:ghpr:`4203`, :ghpr:`4214`)
-    - Added :cmake:func:`opendds_target_sources(USE_VERSIONED_NAMESPACE)` as a shortcut to the ``-Wb,versioning_*`` IDL compiler options. (:ghpr:`4203`, :ghpr:`4214`)
+    - Added :cmake:func:`opendds_target_sources(INCLUDE_BASE)` to preserve the directory structure of the IDL files for compiling the resulting generated files and installing everything using :cmake:func:`opendds_install_interface_files`. (:ghpr:`4203`, :ghpr:`4314`)
+    - Added :cmake:func:`opendds_target_sources(USE_VERSIONED_NAMESPACE)` as a shortcut to the ``-Wb,versioning_*`` IDL compiler options. (:ghpr:`4203`, :ghpr:`4314`)
 
 - Support sending DynamicDataAdapter sample via DynamicDataWriter (:ghpr:`4226`)
 - Added export macro to ConditionImpl (:ghpr:`4295`)
@@ -30,7 +30,7 @@ Additions
 Deprecations
 ============
 
-- Deprecated :cmake:var:`OPENDDS_FILENAME_ONLY_INCLUDES` in favor of :cmake:func:`opendds_target_sources(INCLUDE_BASE)`. (:ghpr:`4203`, :ghpr:`4214`)
+- Deprecated :cmake:var:`OPENDDS_FILENAME_ONLY_INCLUDES` in favor of :cmake:func:`opendds_target_sources(INCLUDE_BASE)`. (:ghpr:`4203`, :ghpr:`4314`)
 
 Fixes
 =====

--- a/docs/news.d/_releases/v3.28.0.rst
+++ b/docs/news.d/_releases/v3.28.0.rst
@@ -71,7 +71,7 @@ Fixes
 Documentation
 =============
 
-- :ref:`config` (:ghpr:`4464`, :ghpr:`4570`, :ghpr:`4467`, :ghpr:`4588`)
+- :ref:`config` (:ghpr:`4564`, :ghpr:`4570`, :ghpr:`4467`, :ghpr:`4588`)
 
   - Restructured configuration properties so they can be linked to directly.
     Also reviewed each property description to correct or add missing context as needed.

--- a/docs/sphinx_extensions/links.py
+++ b/docs/sphinx_extensions/links.py
@@ -1,9 +1,8 @@
 import subprocess
-from pathlib import Path
 import re
-from urllib.request import urlopen
-from urllib.error import URLError
 import shutil
+from pathlib import Path
+from urllib.request import urlopen
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -27,6 +26,13 @@ def get_config(inliner):
     return inliner.document.settings.env.app.config
 
 
+def ignore_url_in_linkcheck(config, url, full=True):
+    regex = '^' + re.escape(url)
+    if not full:
+        regex += '.*'
+    config.linkcheck_ignore.append(regex + '$')
+
+
 def get_commitish(config):
     if config.github_links_commitish is None:
         if config.github_links_release_tag is not None:
@@ -41,8 +47,8 @@ def get_commitish(config):
     return config.github_links_commitish
 
 
-def rst_error(rawtext, text, lineno, inliner, message, *fmtargs, **fmtkwargs):
-    error = inliner.reporter.error(message.format(*fmtargs, **fmtkwargs), line=lineno)
+def rst_error(rawtext, text, lineno, inliner, message):
+    error = inliner.reporter.error(message, line=lineno)
     return [inliner.problematic(text, rawtext, error)], [error]
 
 
@@ -97,8 +103,7 @@ def ghfile_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     # Seperate path and possible URL fragment
     m = ghfile_arg_re.match(target)
     if not m:
-        return rst_error(rawtext, text, lineno, inliner,
-            '{} is an invalid target', repr(target))
+        return rst_error(rawtext, text, lineno, inliner, f'{target!r} is an invalid target')
     path = m.group(1)
     fragment = m.group(2) if m.group(2) is not None else ''
 
@@ -106,12 +111,13 @@ def ghfile_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     local_path = Path(config.github_links_root_path) / path
     if not local_path.exists():
         return rst_error(rawtext, text, lineno, inliner,
-            '"{}" doesn\'t exist. Checked for existence of "{}"',
-                path, str(local_path)),
+            f'"{path}" doesn\'t exist. Checked for existence of "{local_path!s}"')
 
     # Create the main link
     kind = 'tree' if local_path.is_dir() else 'blob'
     url = '/'.join([gh_url_base, config.github_links_repo, kind, get_commitish(config), path]) + fragment
+    # We know the file exists locally, we don't really have to check the link.
+    ignore_url_in_linkcheck(config, url)
     rv = []
     main_link = link_node(rawtext, lineno, inliner,
         title if explicit_title else '', explicit_title, url, options)
@@ -129,28 +135,26 @@ def ghfile_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     return rv
 
 
+def github_numbered_link(role, title, slug, rawtext, text, lineno, inliner, options):
+    config = get_config(inliner)
+    explicit_title, title, target = process_title_target(text, f'{title} #{text}')
+    if not target.isdigit():
+        return rst_error(rawtext, text, lineno, inliner,
+            f'{role} target {target!r} is not a valid number')
+    return link_node(rawtext, lineno, inliner, title, explicit_title,
+        '/'.join((gh_url_base, config.github_links_repo, slug, target)), options)
+
+
 # Turns :ghissue:`213` into the equivalent of:
 #   `Issue #213 <https://github.com/OpenDDS/OpenDDS/issues/213>`_
 def ghissue_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
-    config = get_config(inliner)
-    explicit_title, title, target = process_title_target(
-        text, 'Issue #{}'.format(text))
-    return link_node(rawtext, lineno, inliner,
-        title, explicit_title,
-        '{}/{}/issues/{}'.format(gh_url_base, config.github_links_repo, target),
-        options)
+    return github_numbered_link(name, 'Issue', 'issues', rawtext, text, lineno, inliner, options)
 
 
 # Turns :ghpr:`1` into the equivalent of:
 #   `PR #1 <https://github.com/OpenDDS/OpenDDS/pull/1>`_
 def ghpr_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
-    config = get_config(inliner)
-    explicit_title, title, target = process_title_target(
-        text, 'PR #{}'.format(text))
-    return link_node(rawtext, lineno, inliner,
-        title, explicit_title,
-        '{}/{}/pull/{}'.format(gh_url_base, config.github_links_repo, target),
-        options)
+    return github_numbered_link(name, 'PR', 'pull', rawtext, text, lineno, inliner, options)
 
 
 # If this is a release, turns :ghrelease:`Release Text` into "Release Text"
@@ -185,6 +189,7 @@ def acetaorel_role(name, rawtext, text, lineno, inliner, options={}, content=[])
 
 
 def omgissue_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    config = get_config(inliner)
     explicit_title, title, target = process_title_target(
         text, 'OMG Issue {}'.format(text))
     rv = []
@@ -193,23 +198,27 @@ def omgissue_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         '{}/issues/{}'.format(omg_url_base, target),
         options))
     append(rv, text_node(rawtext, lineno, ' ', options))
+    member_link = f'{omg_url_base}/browse/{target}'
+    # OMG Member link will always redirect to a login page
+    ignore_url_in_linkcheck(config, member_link)
     append(rv, link_node(rawtext, lineno, inliner,
         '(Member Link)', False,
-        '{}/browse/{}'.format(omg_url_base, target),
+        member_link,
         options))
     return rv
 
 
 def add_omg_spec(app, slug, version, our_name=None, display_name=None):
-    '''To be used in conf.py to declare sepcs based on links like https://www.omg.org/spec/DDS/1.4.
+    '''To be used in conf.py to declare specs based on links like https://www.omg.org/spec/DDS/1.4.
     slug is the OMG name in their URL.
     version must also match the URL.
     our_name is the name to use with :omgspec:.
     display_name is the name of the spec to be used in output.
     '''
 
+    config = app.config
     our_name = slug.lower() if our_name is None else our_name
-    omg_specs = app.config.omg_specs
+    omg_specs = config.omg_specs
     if our_name in omg_specs:
         raise KeyError('Already a spec named ' + our_name)
     display_name = slug.replace('-', ' ') if display_name is None else display_name
@@ -220,6 +229,10 @@ def add_omg_spec(app, slug, version, our_name=None, display_name=None):
     pdf_path = dir_path / '{}-{}.pdf'.format(slug, version)
     url = 'https://www.omg.org/spec/{}/{}'.format(slug, version)
     pdf_url = url + '/PDF'
+    # Trying to check the PDF links results in UTF-8 decode errors (trying to
+    # parse PDF as HTML?). We shouldn't check these anyways because we're
+    # parsing the PDF upfront and checking things in the role.
+    ignore_url_in_linkcheck(config, pdf_url, full=False)
     if not pdf_path.is_file():
         logger.info('Downloading spec %s from %s', our_name, pdf_url)
         try:
@@ -302,13 +315,13 @@ def omgspec_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         section_key = args[1]
     else:
         return rst_error(rawtext, text, lineno, inliner,
-            'omgspec target must be of the form SPEC[:SECTION], not {}', repr(target))
+            f'omgspec target must be of the form SPEC[:SECTION], not {target!r}')
 
     spec = config.omg_specs.get(spec_name)
     if spec is None:
+        valid_specs = ', '.join(config.omg_specs.keys())
         return rst_error(rawtext, text, lineno, inliner,
-            '{} is not a valid omgspec spec name, must be one of: {}',
-            repr(spec_name), ', '.join(config.omg_specs.keys()))
+            f'{spec_name!r} is not a valid omgspec spec name, must be one of: {valid_specs}')
 
     section = None
     if section_key is None or spec['sections'] is None:
@@ -328,7 +341,7 @@ def omgspec_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
                     break
         if section is None:
             return rst_error(rawtext, text, lineno, inliner,
-                '{} is not a valid section in the {} spec', repr(section_key), spec_name)
+                f'{section_key!r} is not a valid section in the {spec_name} spec')
         url = section_link(spec, section)
 
     if not explicit_title:

--- a/docs/sphinx_extensions/opendds_logging.py
+++ b/docs/sphinx_extensions/opendds_logging.py
@@ -1,0 +1,113 @@
+import re
+import os
+import logging
+from pathlib import Path
+
+try:
+    # If we don't derive from this class, we will can get double output because
+    # Sphinx buffers warnings and errors while reading.
+    from sphinx.util.logging import WarningStreamHandler as BaseStreamHandler
+except ModuleNotFoundError:
+    from logging import StreamHandler as BaseStreamHandler
+
+
+opendds_root_path = Path(__file__).resolve().parent.parent.parent
+github_actions = os.environ.get('GITHUB_ACTIONS', 'false') == 'true'
+link_check = os.environ.get('LINK_CHECK', 'false') == 'true'
+no_source_loc = ('docs/index.rst', 1)
+replace_files = {
+    None: no_source_loc,
+    'docs/news.rst': no_source_loc,
+    'docs/this-release.rst': no_source_loc,
+}
+
+
+def create_gha_annotation(kind, message,
+      title=None, file=None, col=None, endColumn=None, line=None, endLine=None,
+      for_link_check=False, replace_files={}):
+    if not github_actions or (link_check and not for_link_check):
+        return None
+
+    # See if we should replace the location
+    if file:
+        file = str(file)
+    file, line = replace_files.get(file, (file, line))
+
+    if kind not in ('debug', 'notice', 'warning', 'error'):
+        raise ValueError('{kind!r} is an invalid kind')
+    if kind == 'debug':
+        return None
+    # Except for debug (which we will ignore), all the params are the same:
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message
+    params = dict(
+        title=title,
+        file=file,
+        col=col,
+        endColumn=endColumn,
+        line=line,
+        endLine=endLine,
+    )
+    param_list = [f'{k}={v}' for k, v in params.items() if v is not None]
+    param_str = ''
+    if param_list:
+        param_str += ' ' + ','.join(param_list)
+    return f'::{kind}{param_str}::{message}'
+
+
+class GhaAnnotationHandler(BaseStreamHandler):
+    '''
+    Used to make Sphinx loggers output GitHub Action annotations.
+    '''
+
+    def __init__(self, level=logging.WARNING, stream=None, replace_files={}):
+        super().__init__(stream)
+        self.setLevel(level)
+        self.replace_files = replace_files
+
+    def emit(self, record):
+        try:
+            # Use the raw getMessage to avoid location and the ERROR:/WARNING: prefixes.
+            message = logging.LogRecord.getMessage(record)
+            file = None
+            line = None
+            location = getattr(record, 'location', None)
+            if location:
+                match = re.fullmatch(r'(.*):(\d+)', location)
+                if match:
+                    file = Path(match.group(1)).resolve()
+                    try:
+                        file = file.relative_to(opendds_root_path)
+                    except ValueError:
+                        pass
+                    line = int(match.group(2))
+
+            # Sphinx and docutils don't distinguish between a warning and an
+            # error in the log level, so just say it's all errors.
+            msg = create_gha_annotation('error', message, title=record.name,
+                file=file, line=line, replace_files=self.replace_files)
+            if msg:
+                self.stream.write(msg + self.terminator)
+                self.flush()
+        except RecursionError:
+            raise
+        except Exception:
+            self.handleError(record)
+
+
+# Based on https://gist.github.com/rene-d/9e584a7dd2935d0f461904b9f2950007
+class AnsiColors:
+    Red = "\033[0;31m"
+    Purple = "\033[0;35m"
+    Yellow = "\033[1;33m"
+    End = "\033[0m"
+    # cancel SGR codes if we don't write to a terminal
+    if not (__import__("sys").stdout.isatty() or github_actions):
+        for _ in dir():
+            if isinstance(_, str) and _[0] != "_":
+                locals()[_] = ""
+    else:
+        # set Windows console in VT mode
+        if __import__("platform").system() == "Windows":
+            kernel32 = __import__("ctypes").windll.kernel32
+            kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+            del kernel32


### PR DESCRIPTION
This should make Sphinx output the correct annotation in RST files in the PR in most situations except for when the content causing the error is in a news fragment. News fragments are used to generate two files at runtime, so the source info that Sphinx has for these files doesn't lead the correct annotation in the PR. See below for what the workaround looks like.

Also tried to improve link checking so it fails less often. This includes:

- Ignoring `:ghfile:` links. It's not really needed because they're checked locally. There's also a lot of them so it takes a while to check them and there's a greater chance for something going wrong.
- Ignoring links that fail with 409 HTTP status code. They happen a lot.
- Turning redirects on GitHub PR and issue links into errors because that means something is wrong with the link.