### PR TITLE
CMake: Set the FOLDER property on custom targets

### DIFF
--- a/cmake/dds_idl_sources.cmake
+++ b/cmake/dds_idl_sources.cmake
@@ -20,6 +20,7 @@ function(_opendds_target_idl_sources target)
     SKIP_OPENDDS_IDL
     AUTO_INCLUDES
     INCLUDE_BASE
+    FOLDER
   )
   set(multi_value_args TAO_IDL_FLAGS DDS_IDL_FLAGS IDL_FILES)
   cmake_parse_arguments(arg "" "${one_value_args}" "${multi_value_args}" ${ARGN})
@@ -274,7 +275,7 @@ function(_opendds_target_idl_sources target)
     set_target_properties(${target} PROPERTIES _OPENDDS_IDL_FILE_COUNT ${idl_file_count})
     set(idl_target "_opendds_codegen_${idl_file_count}_for_${target}")
     add_custom_target(${idl_target} DEPENDS ${generated_files})
-    set_target_properties(${idl_target} PROPERTIES FOLDER IDL)
+    set_target_properties(${idl_target} PROPERTIES FOLDER ${arg_FOLDER})
     add_dependencies(${target} ${idl_target})
 
     set_source_files_properties(${idl_files} ${h_files}

--- a/cmake/dds_idl_sources.cmake
+++ b/cmake/dds_idl_sources.cmake
@@ -274,6 +274,7 @@ function(_opendds_target_idl_sources target)
     set_target_properties(${target} PROPERTIES _OPENDDS_IDL_FILE_COUNT ${idl_file_count})
     set(idl_target "_opendds_codegen_${idl_file_count}_for_${target}")
     add_custom_target(${idl_target} DEPENDS ${generated_files})
+    set_target_properties(${idl_target} PROPERTIES FOLDER IDL)
     add_dependencies(${target} ${idl_target})
 
     set_source_files_properties(${idl_files} ${h_files}

--- a/cmake/init.cmake
+++ b/cmake/init.cmake
@@ -577,6 +577,8 @@ option(OPENDDS_AUTO_LINK_DCPS
 # TODO: Make this default ON in v4.0
 option(OPENDDS_USE_CORRECT_INCLUDE_SCOPE
   "Include using SCOPE specified in opendds_target_sources" OFF)
+set(OPENDDS_DEFAULT_GENERATED_FOLDER "IDL" CACHE STRING
+  "Default value used for the FOLDER CMake property of generated targets added in opendds_target_sources")
 
 if(OPENDDS_STATIC)
   set(OPENDDS_LIBRARY_TYPE STATIC)

--- a/cmake/opendds_target_sources.cmake
+++ b/cmake/opendds_target_sources.cmake
@@ -24,7 +24,8 @@ function(_opendds_get_sources_and_options
     auto_link
     include_base
     skip_tao_idl
-    skip_opendds_idl)
+    skip_opendds_idl
+    folder)
   set(no_value_options
     SKIP_TAO_IDL
     SKIP_OPENDDS_IDL
@@ -36,6 +37,7 @@ function(_opendds_get_sources_and_options
     GENERATE_SERVER_SKELETONS
     AUTO_LINK
     INCLUDE_BASE
+    FOLDER
   )
   set(multi_value_options
     PUBLIC PRIVATE INTERFACE
@@ -126,6 +128,11 @@ function(_opendds_get_sources_and_options
     set(arg_AUTO_LINK ${OPENDDS_AUTO_LINK_DCPS})
   endif()
   set(${auto_link} ${arg_AUTO_LINK} PARENT_SCOPE)
+
+  if(NOT DEFINED arg_FOLDER)
+    set(arg_FOLDER ${OPENDDS_DEFAULT_GENERATED_FOLDER})
+  endif()
+  set(${folder} ${arg_FOLDER} PARENT_SCOPE)
 
   set(all_idl_files)
   foreach(scope PUBLIC PRIVATE INTERFACE)
@@ -224,6 +231,7 @@ function(opendds_target_sources target)
     include_base
     skip_tao_idl
     skip_opendds_idl
+    folder
     ${ARGN})
 
   if(NOT opendds_options MATCHES "--(no-)?default-nested")
@@ -336,7 +344,8 @@ function(opendds_target_sources target)
         SCOPE ${scope}
         INCLUDE_BASE "${include_base}"
         AUTO_INCLUDES auto_includes
-        USE_EXPORT ${use_export})
+        USE_EXPORT ${use_export}
+        FOLDER ${folder})
       list(APPEND includes ${auto_includes})
     endif()
 

--- a/docs/devguide/building/cmake.rst
+++ b/docs/devguide/building/cmake.rst
@@ -394,6 +394,7 @@ Functions
       [INCLUDE_BASE <dir>]
       [SKIP_TAO_IDL]
       [SKIP_OPENDDS_IDL]
+      [FOLDER <string>]
     )
 
   A function that acts like `target_sources <https://cmake.org/cmake/help/latest/command/target_sources.html>`__, but it adds IDL files and the resulting generated code to a target.
@@ -509,6 +510,14 @@ Functions
     Skip invoking ``opendds_idl`` on the IDL files.
 
     .. versionadded:: 3.25
+
+  .. cmake:func:arg:: FOLDER <string>
+
+    Set the FOLDER CMake property of generated targets to this value.
+    This is used by some CMake Generators to group these targets in IDEs.
+    The default is set by :cmake:var:`OPENDDS_DEFAULT_GENERATED_FOLDER`.
+
+    .. versionadded:: 3.33
 
   After ``opendds_target_sources`` is run on a target, it will have these target properties set on it:
 
@@ -871,6 +880,13 @@ These variables can be used to override default behavior of the CMake package.
     This variable will be removed in OpenDDS 4.0 and the behavior will be the same as if this variable was set to ``TRUE``.
 
   .. versionadded:: 3.24
+
+.. cmake:var:: OPENDDS_DEFAULT_GENERATED_FOLDER
+
+  Value used for the FOLDER CMake property of generated targets added in :cmake:func:`opendds_target_sources` when no ``FOLDER`` argument is specified.
+  The default value of this variable is ``IDL``.
+
+  .. versionadded:: 3.33
 
 .. _cmake-config-vars:
 

--- a/docs/news.d/cmake-generated-target-folder.rst
+++ b/docs/news.d/cmake-generated-target-folder.rst
@@ -1,0 +1,7 @@
+.. news-prs: 5009
+
+.. news-start-section: Platform Support and Dependencies
+.. news-start-section: CMake
+- :cmake:func:`opendds_target_sources` now has a `FOLDER` argument which sets the CMake FOLDER property on generated targets.
+.. news-end-section
+.. news-end-section


### PR DESCRIPTION
When CMake generates projects for an IDE, all custom targets for IDL code generation will be grouped together in a folder.