### PR TITLE
Added detail fields to thread status

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -4511,6 +4511,8 @@ void Spdp::SpdpTransport::thread_status_task(const DCPS::MonotonicTimePoint& now
     data.thread_id = i->bit_key().c_str();
     data.utilization = i->utilization(now);
     data.monotonic_timestamp = i->last_update().to_idl_struct();
+    data.detail1 = i->detail1();
+    data.detail2 = i->detail2();
     outer->bit_subscriber_->add_thread_status(data, DDS::NEW_VIEW_STATE, i->timestamp());
   }
 

--- a/dds/DCPS/ThreadStatusManager.cpp
+++ b/dds/DCPS/ThreadStatusManager.cpp
@@ -20,7 +20,7 @@ void ThreadStatusManager::Thread::update(const MonotonicTimePoint& m_now,
                                          const SystemTimePoint& s_now,
                                          ThreadStatus next_status,
                                          const TimeDuration& bucket_limit,
-                                         bool nested)
+                                         bool nested, int detail1, int detail2)
 {
   timestamp_ = s_now;
 
@@ -56,6 +56,8 @@ void ThreadStatusManager::Thread::update(const MonotonicTimePoint& m_now,
     last_status_change_ = m_now;
     status_ = next_status;
   }
+  detail1_ = detail1;
+  detail2_ = detail2;
   last_update_ = m_now;
 }
 
@@ -114,7 +116,8 @@ void ThreadStatusManager::add_thread(const String& name)
   map_.insert(std::make_pair(thread_id, Thread(bit_key)));
 }
 
-void ThreadStatusManager::update_i(Thread::ThreadStatus status, bool finished, bool nested)
+void ThreadStatusManager::update_i(Thread::ThreadStatus status, bool finished,
+                                   bool nested, int detail1, int detail2)
 {
   if (!update_thread_status()) {
     return;
@@ -128,7 +131,7 @@ void ThreadStatusManager::update_i(Thread::ThreadStatus status, bool finished, b
 
   const Map::iterator pos = map_.find(thread_id);
   if (pos != map_.end()) {
-    pos->second.update(m_now, s_now, status, bucket_limit_, nested);
+    pos->second.update(m_now, s_now, status, bucket_limit_, nested, detail1, detail2);
     if (finished) {
       finished_.push_back(pos->second);
       map_.erase(pos);

--- a/dds/OpenddsDcpsExt.idl
+++ b/dds/OpenddsDcpsExt.idl
@@ -77,6 +77,9 @@ module OpenDDS
       BUILT_IN_TOPIC_KEY string thread_id;
       double utilization;
       MonotonicTime_t monotonic_timestamp;
+
+      // The "detail" members can provide additional information
+      // about the last-reported state of the thread in question.
       long detail1;
       long detail2;
     };

--- a/dds/OpenddsDcpsExt.idl
+++ b/dds/OpenddsDcpsExt.idl
@@ -77,6 +77,8 @@ module OpenDDS
       BUILT_IN_TOPIC_KEY string thread_id;
       double utilization;
       MonotonicTime_t monotonic_timestamp;
+      long detail1;
+      long detail2;
     };
 
     const long LOCATOR_KIND_INVALID = -1;

--- a/docs/devguide/built_in_topics.rst
+++ b/docs/devguide/built_in_topics.rst
@@ -316,3 +316,5 @@ The topic type InternalThreadBuiltinTopicData is defined in :ghfile:`dds/Opendds
 * ``utilization`` -- Estimated utilization of this thread (0.0-1.0).
 
 * ``monotonic_timestamp`` -- Time of most recent update (monotonic clock).  The SampleInfo's ``source_timestamp`` has the timestamp on the system clock.
+
+* ``detail1``, ``detail2`` -- Additional information reported by the thread in question during its latest update

--- a/docs/news.d/internal-thread-detail.rst
+++ b/docs/news.d/internal-thread-detail.rst
@@ -1,0 +1,6 @@
+.. news-prs: 5026
+
+.. news-start-section: Additions
+- The OpenDDSInternalThread built-in topic has additional detail fields which may be populated by internal threads.
+- The RtpsRelay's event handling threads make use of this feature.
+.. news-end-section

--- a/java/tests/internal_thread_status/InternalThreadListener.java
+++ b/java/tests/internal_thread_status/InternalThreadListener.java
@@ -36,7 +36,7 @@ public class InternalThreadListener extends DDS._DataReaderListenerLocalBase {
 
     InternalThreadBuiltinTopicDataHolder info =
       new InternalThreadBuiltinTopicDataHolder(
-        new InternalThreadBuiltinTopicData("", 0.0, new MonotonicTime_t()));
+        new InternalThreadBuiltinTopicData("", 0.0, new MonotonicTime_t(), 0, 0));
 
     SampleInfoHolder si = new SampleInfoHolder(new SampleInfo(0, 0, 0,
       new DDS.Time_t(), 0, 0, 0, 0, 0, 0, 0, false, 0));

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -112,7 +112,7 @@ int RelayHandler::open(const ACE_INET_Addr& address)
 
 int RelayHandler::handle_input(ACE_HANDLE handle)
 {
-  OpenDDS::DCPS::ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager(), READ_MASK, handle);
+  OpenDDS::DCPS::ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager(), READ_MASK, handle_to_int(handle));
 
   const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
 
@@ -169,12 +169,12 @@ int RelayHandler::handle_input(ACE_HANDLE handle)
 int RelayHandler::handle_output(ACE_HANDLE handle)
 {
   auto& statusManager = TheServiceParticipant->get_thread_status_manager();
-  OpenDDS::DCPS::ThreadStatusManager::Event ev(statusManager, WRITE_MASK, handle);
+  OpenDDS::DCPS::ThreadStatusManager::Event ev(statusManager, WRITE_MASK, handle_to_int(handle));
 
   const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
 
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, outgoing_mutex_, 0);
-  OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, WRITE_MASK | DONT_CALL, handle);
+  OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, WRITE_MASK | DONT_CALL, handle_to_int(handle));
 
   if (!outgoing_.empty()) {
     const auto& out = outgoing_.front();
@@ -306,11 +306,11 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
                                               MessageType& type)
 {
   auto& statusManager = TheServiceParticipant->get_thread_status_manager();
-  const auto handle = static_cast<int>(get_handle());
+  const auto handle_as_int = handle_to_int(get_handle());
   const auto msg_len = msg->length();
   {
     GuidAddrSet::Proxy proxy(guid_addr_set_);
-    OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, READ_MASK | DONT_CALL, handle);
+    OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, READ_MASK | DONT_CALL, handle_as_int);
     proxy.maintain_admission_queue(now);
     proxy.process_expirations(now);
     if (!proxy.check_address(remote_address)) {
@@ -335,7 +335,7 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
     }
 
     GuidAddrSet::Proxy proxy(guid_addr_set_);
-    OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, READ_MASK | SIGNAL_MASK, handle);
+    OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, READ_MASK | SIGNAL_MASK, handle_as_int);
     record_activity(proxy, addr_port, now, src_guid, type, msg_len);
 
     cache_message(proxy, src_guid, to, msg, now);
@@ -434,7 +434,7 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
 
     if (has_guid) {
       GuidAddrSet::Proxy proxy(guid_addr_set_);
-      OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, READ_MASK | GROUP_QOS_MASK, handle);
+      OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, READ_MASK | GROUP_QOS_MASK, handle_as_int);
 
       ParticipantStatisticsReporter& from_psr =
         record_activity(proxy, addr_port, now, src_guid, type, msg_len);
@@ -747,7 +747,8 @@ CORBA::ULong HorizontalHandler::process_message(const ACE_INET_Addr&,
   guid_partition_table_.lookup(guids, relay_header.to_partitions(), to_guids);
   GuidAddrSet::Proxy proxy(vertical_handler_->guid_addr_set());
   OpenDDS::DCPS::ThreadStatusManager::Event evLocked(TheServiceParticipant->get_thread_status_manager(),
-    READ_MASK | DONT_CALL, static_cast<int>(get_handle()));
+    READ_MASK | DONT_CALL, handle_to_int(get_handle()));
+
   CORBA::ULong sent = 0;
   for (const auto& guid : guids) {
     const auto p = proxy.find(guid);

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -112,7 +112,7 @@ int RelayHandler::open(const ACE_INET_Addr& address)
 
 int RelayHandler::handle_input(ACE_HANDLE handle)
 {
-  OpenDDS::DCPS::ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
+  OpenDDS::DCPS::ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager(), READ_MASK, handle);
 
   const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
 
@@ -166,13 +166,15 @@ int RelayHandler::handle_input(ACE_HANDLE handle)
   return 0;
 }
 
-int RelayHandler::handle_output(ACE_HANDLE)
+int RelayHandler::handle_output(ACE_HANDLE handle)
 {
-  OpenDDS::DCPS::ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
+  auto& statusManager = TheServiceParticipant->get_thread_status_manager();
+  OpenDDS::DCPS::ThreadStatusManager::Event ev(statusManager, WRITE_MASK, handle);
 
   const auto now = OpenDDS::DCPS::MonotonicTimePoint::now();
 
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, outgoing_mutex_, 0);
+  OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, WRITE_MASK | DONT_CALL, handle);
 
   if (!outgoing_.empty()) {
     const auto& out = outgoing_.front();
@@ -303,9 +305,12 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
                                               const OpenDDS::DCPS::Lockable_Message_Block_Ptr& msg,
                                               MessageType& type)
 {
+  auto& statusManager = TheServiceParticipant->get_thread_status_manager();
+  const auto handle = static_cast<int>(get_handle());
   const auto msg_len = msg->length();
   {
     GuidAddrSet::Proxy proxy(guid_addr_set_);
+    OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, READ_MASK | DONT_CALL, handle);
     proxy.maintain_admission_queue(now);
     proxy.process_expirations(now);
     if (!proxy.check_address(remote_address)) {
@@ -330,6 +335,7 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
     }
 
     GuidAddrSet::Proxy proxy(guid_addr_set_);
+    OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, READ_MASK | SIGNAL_MASK, handle);
     record_activity(proxy, addr_port, now, src_guid, type, msg_len);
 
     cache_message(proxy, src_guid, to, msg, now);
@@ -428,6 +434,8 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
 
     if (has_guid) {
       GuidAddrSet::Proxy proxy(guid_addr_set_);
+      OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, READ_MASK | GROUP_QOS_MASK, handle);
+
       ParticipantStatisticsReporter& from_psr =
         record_activity(proxy, addr_port, now, src_guid, type, msg_len);
       if (bytes_sent) {
@@ -713,13 +721,11 @@ void HorizontalHandler::enqueue_or_send_message(const ACE_INET_Addr& addr,
   RelayHandler::enqueue_message(addr, header_block, now, MessageType::Rtps);
 }
 
-CORBA::ULong HorizontalHandler::process_message(const ACE_INET_Addr& from,
+CORBA::ULong HorizontalHandler::process_message(const ACE_INET_Addr&,
                                                 const OpenDDS::DCPS::MonotonicTimePoint& now,
                                                 const OpenDDS::DCPS::Lockable_Message_Block_Ptr& msg,
                                                 MessageType& type)
 {
-  ACE_UNUSED_ARG(from);
-
   type = MessageType::Rtps;
 
   OpenDDS::RTPS::MessageParser mp(*msg);
@@ -740,6 +746,8 @@ CORBA::ULong HorizontalHandler::process_message(const ACE_INET_Addr& from,
 
   guid_partition_table_.lookup(guids, relay_header.to_partitions(), to_guids);
   GuidAddrSet::Proxy proxy(vertical_handler_->guid_addr_set());
+  OpenDDS::DCPS::ThreadStatusManager::Event evLocked(TheServiceParticipant->get_thread_status_manager(),
+    READ_MASK | DONT_CALL, static_cast<int>(get_handle()));
   CORBA::ULong sent = 0;
   for (const auto& guid : guids) {
     const auto p = proxy.find(guid);

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -33,6 +33,8 @@ public:
 
   Port port() const { return port_; }
 
+  ACE_HANDLE get_handle() const override { return socket_.get_handle(); }
+
 protected:
   RelayHandler(const Config& config,
                const std::string& name,
@@ -48,8 +50,6 @@ protected:
                        const OpenDDS::DCPS::Lockable_Message_Block_Ptr& msg,
                        const OpenDDS::DCPS::MonotonicTimePoint& now,
                        MessageType type);
-
-  ACE_HANDLE get_handle() const override { return socket_.get_handle(); }
 
   virtual CORBA::ULong process_message(const ACE_INET_Addr& remote,
                                        const OpenDDS::DCPS::MonotonicTimePoint& now,

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -293,6 +293,15 @@ public:
               HandlerStatisticsReporter& stats_reporter);
 };
 
+inline int handle_to_int(ACE_HANDLE handle)
+{
+#ifdef ACE_WIN32
+  return static_cast<int>(reinterpret_cast<intptr_t>(handle));
+#else
+  return handle;
+#endif
+}
+
 }
 
 #endif /* RTPSRELAY_RELAY_HANDLER_H_ */

--- a/tools/rtpsrelay/RelayStatusReporter.cpp
+++ b/tools/rtpsrelay/RelayStatusReporter.cpp
@@ -7,6 +7,7 @@ RelayStatusReporter::RelayStatusReporter(const Config& config,
                                          RelayStatusDataWriter_var writer,
                                          ACE_Reactor* reactor)
   : ACE_Event_Handler(reactor)
+  , config_(config)
   , guid_addr_set_(guid_addr_set)
   , writer_(writer)
 {
@@ -19,7 +20,10 @@ RelayStatusReporter::RelayStatusReporter(const Config& config,
 
 int RelayStatusReporter::handle_timeout(const ACE_Time_Value&, const void*)
 {
-  OpenDDS::DCPS::ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
+  if (config_.log_activity()) {
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) RelayStatusReporter::handle_timeout\n"));
+  }
+  OpenDDS::DCPS::ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager(), TIMER_MASK);
 
   GuidAddrSet::Proxy proxy(guid_addr_set_);
   relay_status_.admitting(proxy.admitting());

--- a/tools/rtpsrelay/RelayStatusReporter.h
+++ b/tools/rtpsrelay/RelayStatusReporter.h
@@ -18,6 +18,7 @@ public:
 private:
   int handle_timeout(const ACE_Time_Value& now, const void* token) override;
 
+  const Config& config_;
   GuidAddrSet& guid_addr_set_;
   RelayStatusDataWriter_var writer_;
   RelayStatus relay_status_;

--- a/tools/rtpsrelay/RelayThreadMonitor.cpp
+++ b/tools/rtpsrelay/RelayThreadMonitor.cpp
@@ -103,9 +103,9 @@ int RelayThreadMonitor::svc()
 
     for (const auto idx : late_thread_indexes) {
       const SystemTimePoint timestamp(infos[idx].source_timestamp);
-      ACE_ERROR((LM_ERROR,
-                  "(%P|%t) ERROR: RelayThreadMonitor::svc thread %C last update %#T.  Aborting...\n",
-                  datas[idx].thread_id.in(), &timestamp.value()));
+      const auto& thread = datas[idx];
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RelayThreadMonitor::svc thread %C (%d, %d) last update %#T.  Aborting...\n",
+                 thread.thread_id.in(), thread.detail1, thread.detail2, &timestamp.value()));
     }
 
     if (!late_thread_indexes.empty()) {

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -836,17 +836,17 @@ int run(int argc, ACE_TCHAR* argv[])
   ACE_DEBUG((LM_INFO, "(%P|%t) INFO: Application Participant GUID %C\n",
     OpenDDS::DCPS::LogGuid(config.application_participant_guid()).c_str()));
   ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SPDP Horizontal %d listening on %C\n",
-    static_cast<int>(spdp_horizontal_handler.get_handle()), OpenDDS::DCPS::LogAddr(spdp_horizontal_addr).c_str()));
+    handle_to_int(spdp_horizontal_handler.get_handle()), OpenDDS::DCPS::LogAddr(spdp_horizontal_addr).c_str()));
   ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SEDP Horizontal %d listening on %C\n",
-    static_cast<int>(sedp_horizontal_handler.get_handle()), OpenDDS::DCPS::LogAddr(sedp_horizontal_addr).c_str()));
+    handle_to_int(sedp_horizontal_handler.get_handle()), OpenDDS::DCPS::LogAddr(sedp_horizontal_addr).c_str()));
   ACE_DEBUG((LM_INFO, "(%P|%t) INFO: Data Horizontal %d listening on %C\n",
-    static_cast<int>(data_horizontal_handler.get_handle()), OpenDDS::DCPS::LogAddr(data_horizontal_addr).c_str()));
+    handle_to_int(data_horizontal_handler.get_handle()), OpenDDS::DCPS::LogAddr(data_horizontal_addr).c_str()));
   ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SPDP Vertical %d listening on %C\n",
-    static_cast<int>(spdp_vertical_handler.get_handle()), OpenDDS::DCPS::LogAddr(spdp_vertical_addr).c_str()));
+    handle_to_int(spdp_vertical_handler.get_handle()), OpenDDS::DCPS::LogAddr(spdp_vertical_addr).c_str()));
   ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SEDP Vertical %d listening on %C\n",
-    static_cast<int>(sedp_vertical_handler.get_handle()), OpenDDS::DCPS::LogAddr(sedp_vertical_addr).c_str()));
+    handle_to_int(sedp_vertical_handler.get_handle()), OpenDDS::DCPS::LogAddr(sedp_vertical_addr).c_str()));
   ACE_DEBUG((LM_INFO, "(%P|%t) INFO: Data Vertical %d listening on %C\n",
-    static_cast<int>(data_vertical_handler.get_handle()), OpenDDS::DCPS::LogAddr(data_vertical_addr).c_str()));
+    handle_to_int(data_vertical_handler.get_handle()), OpenDDS::DCPS::LogAddr(data_vertical_addr).c_str()));
 
   // Write about the relay.
   DDS::DataWriterListener_var relay_address_writer_listener =

--- a/tools/rtpsrelay/RtpsRelay.cpp
+++ b/tools/rtpsrelay/RtpsRelay.cpp
@@ -833,13 +833,20 @@ int run(int argc, ACE_TCHAR* argv[])
     return EXIT_FAILURE;
   }
 
-  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: Application Participant GUID %C\n", OpenDDS::DCPS::LogGuid(config.application_participant_guid()).c_str()));
-  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SPDP Horizontal listening on %C\n", OpenDDS::DCPS::LogAddr(spdp_horizontal_addr).c_str()));
-  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SEDP Horizontal listening on %C\n", OpenDDS::DCPS::LogAddr(sedp_horizontal_addr).c_str()));
-  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: Data Horizontal listening on %C\n", OpenDDS::DCPS::LogAddr(data_horizontal_addr).c_str()));
-  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SPDP Vertical listening on %C\n", OpenDDS::DCPS::LogAddr(spdp_vertical_addr).c_str()));
-  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SEDP Vertical listening on %C\n", OpenDDS::DCPS::LogAddr(sedp_vertical_addr).c_str()));
-  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: Data Vertical listening on %C\n", OpenDDS::DCPS::LogAddr(data_vertical_addr).c_str()));
+  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: Application Participant GUID %C\n",
+    OpenDDS::DCPS::LogGuid(config.application_participant_guid()).c_str()));
+  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SPDP Horizontal %d listening on %C\n",
+    static_cast<int>(spdp_horizontal_handler.get_handle()), OpenDDS::DCPS::LogAddr(spdp_horizontal_addr).c_str()));
+  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SEDP Horizontal %d listening on %C\n",
+    static_cast<int>(sedp_horizontal_handler.get_handle()), OpenDDS::DCPS::LogAddr(sedp_horizontal_addr).c_str()));
+  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: Data Horizontal %d listening on %C\n",
+    static_cast<int>(data_horizontal_handler.get_handle()), OpenDDS::DCPS::LogAddr(data_horizontal_addr).c_str()));
+  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SPDP Vertical %d listening on %C\n",
+    static_cast<int>(spdp_vertical_handler.get_handle()), OpenDDS::DCPS::LogAddr(spdp_vertical_addr).c_str()));
+  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: SEDP Vertical %d listening on %C\n",
+    static_cast<int>(sedp_vertical_handler.get_handle()), OpenDDS::DCPS::LogAddr(sedp_vertical_addr).c_str()));
+  ACE_DEBUG((LM_INFO, "(%P|%t) INFO: Data Vertical %d listening on %C\n",
+    static_cast<int>(data_vertical_handler.get_handle()), OpenDDS::DCPS::LogAddr(data_vertical_addr).c_str()));
 
   // Write about the relay.
   DDS::DataWriterListener_var relay_address_writer_listener =


### PR DESCRIPTION
This allows the ThreadStatusManager to track checkpoints of progress on event processing in each thread.
The RtpsRelay's RelayThreadMonitor reports the latest values on error.