### PR TITLE
[v4] Removed support for ACE version 7

### DIFF
--- a/acetao.ini
+++ b/acetao.ini
@@ -19,23 +19,6 @@ tar.bz2-filename=ACE+TAO-src-6.5.21.tar.bz2
 tar.bz2-url=https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-6_5_21/ACE%2BTAO-src-6.5.21.tar.bz2
 tar.bz2-md5=7b04201352aefa4cdd3938adef86cde6
 
-[ace7tao3]
-hold=1
-desc=ACE 7/TAO 3
-version=7.1.3
-repo=https://github.com/DOCGroup/ACE_TAO.git
-branch=master
-url=https://github.com/DOCGroup/ACE_TAO/releases/tag/ACE%2BTAO-7_1_3
-zip-filename=ACE+TAO-src-7.1.3.zip
-zip-url=https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_3/ACE%2BTAO-src-7.1.3.zip
-zip-md5=53d2d45961087ab87029993ffa1c7ec3
-tar.gz-filename=ACE+TAO-src-7.1.3.tar.gz
-tar.gz-url=https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_3/ACE%2BTAO-src-7.1.3.tar.gz
-tar.gz-md5=6bbd4ef19fda1ff6a69fa8df33e72d06
-tar.bz2-filename=ACE+TAO-src-7.1.3.tar.bz2
-tar.bz2-url=https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_1_3/ACE%2BTAO-src-7.1.3.tar.bz2
-tar.bz2-md5=a4a2cbb7c5eaec50f1fae041f0b4ee0d
-
 [ace8tao4]
 hold=0
 desc=ACE 8/TAO 4

--- a/cmake/get_ace_tao.cmake
+++ b/cmake/get_ace_tao.cmake
@@ -97,7 +97,7 @@ if(NOT DEFINED OPENDDS_ACE_TAO_SRC)
   _opendds_read_ini("${OPENDDS_SOURCE_DIR}/acetao.ini" PREFIX _OPENDDS_ACE_TAO)
 
   if(NOT DEFINED OPENDDS_ACE_TAO_KIND)
-    set(OPENDDS_ACE_TAO_KIND ace7tao3)
+    set(OPENDDS_ACE_TAO_KIND ace8tao4)
   endif()
   set(prefix "_OPENDDS_ACE_TAO_${OPENDDS_ACE_TAO_KIND}_")
   set(url_var "${prefix}${ext}-url")

--- a/configure
+++ b/configure
@@ -224,9 +224,9 @@ my @specs =
     'tao=s', 'TAO (use TAO_ROOT, ACE_ROOT/TAO, or download)',
     'mpc=s', 'MPC (use MPC_ROOT, ACE_ROOT/MPC, or download)',
     'doc-group|doc_group!', 'Use the DOC Group release of TAO 2.5.x (yes)',
-    'doc-group3|doc_group3!', 'Use the DOC Group release of TAO 3.x (no)',
     'ace-tao=s', 'Use the ACE/TAO version from acetao.ini',
     'ace-github-latest!', 'Clone latest ACE/TAO/MPC from GitHub (no)',
+    'doc-master-branch!', 'When using --ace-github-latest, get master branch (no)',
     'force-ace-tao', 'Force configuration of ACE/TAO (no)',
     'no-disable-deprecated', 'Turn off disabling deprecated interfaces when' .
                              $argIndent . 'configuring ACE/TAO (no)',
@@ -983,7 +983,7 @@ if (!$ace_src || !$tao_src) {
 
     my $urlbase = 'https://github.com/DOCGroup';
     my $branch = 'ace6tao2';
-    if ($opts{'doc-group3'}) {
+    if ($opts{'doc-master-branch'}) {
       $branch = 'master';
     }
 
@@ -1004,7 +1004,7 @@ if (!$ace_src || !$tao_src) {
   else {
     # Get ACE/TAO version info
     my ($section_names, $sections) = read_ini_file("$FindBin::RealBin/acetao.ini");
-    my $ace_tao_version = $opts{'doc-group3'} ? $sections->{ace7tao3} : $sections->{ace6tao2};
+    my $ace_tao_version = $sections->{ace6tao2};
     if ($opts{'ace-tao'}) {
       $ace_tao_version = $sections->{$opts{'ace-tao'}};
       die "ERROR: No entry named '$opts{'ace-tao'}' in acetao.ini" unless $ace_tao_version;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ is_release = opendds_version_info.is_release
 if is_release:
     github_links_release_tag = opendds_version_info.tag
 ace6tao2_version = opendds_version_info.ace6tao2_version
-ace7tao3_version = opendds_version_info.ace7tao3_version
+ace8tao4_version = opendds_version_info.ace8tao4_version
 if opendds_version_info.release_year:
     copyright = f'{opendds_version_info.release_year} {copyright}'
 

--- a/docs/devguide/building/android.rst
+++ b/docs/devguide/building/android.rst
@@ -137,7 +137,7 @@ OpenDDS can be configured and built with the Android NDK using the following com
 
 .. code-block:: shell
 
-  ./configure --doc-group3 --target=android --macros=android_abi=$ABI --macros=android_api=$MIN_API --macros=android_ndk=$NDK
+  ./configure --ace-tao=ace8tao4 --target=android --macros=android_abi=$ABI --macros=android_api=$MIN_API --macros=android_ndk=$NDK
   make # Pass -j/--jobs with an appropriate value or this'll take a while...
 
 .. _android-using-a-standalone-toolchain:
@@ -221,8 +221,8 @@ android_abi
 -----------
 
 The architecture to cross-target.
-When using ACE6/TAO2 it is optional as it defaults to ``armeabi-v7a``.
-When using ACE7/ACE3 it is required.
+When using ACE version 6 it is optional as it defaults to ``armeabi-v7a``.
+When using ACE version 7 or later, it is required.
 
 The valid options are:
 

--- a/docs/devguide/building/dependencies.rst
+++ b/docs/devguide/building/dependencies.rst
@@ -61,25 +61,17 @@ DOC Group :acetaorel:`ace6tao2`
   This also clones the ``master`` branch of MPC as is.
   :ref:`CMake <cmake-building>` will do the same if :cmake:var:`OPENDDS_ACE_TAO_KIND` is set to ``ace6tao2`` and :cmake:var:`OPENDDS_ACE_TAO_GIT` is set to ``TRUE``.
 
-.. _ace7tao3:
-
-DOC Group :acetaorel:`ace7tao3`
-  Pass ``--doc-group3`` to the configure script to download this version.
-  :ref:`CMake <cmake-building>` will download this version by default.
-
-  This version requires a C++14-capable compiler.
-
-  Pass ``--ace-github-latest`` to the configure script to clone the ``master`` branch of ACE/TAO as is.
-  This also clones the ``master`` branch of MPC as is.
-  :ref:`CMake <cmake-building>` will do the same if :cmake:var:`OPENDDS_ACE_TAO_GIT` is set to ``TRUE``.
-
 .. _ace8tao4:
 
 DOC Group :acetaorel:`ace8tao4`
   Pass ``--ace-tao=ace8tao4`` to the configure script to download this version.
-  :ref:`CMake <cmake-building>` will download this version if :cmake:var:`OPENDDS_ACE_TAO_KIND` is set to ``ace8tao4``.
+  :ref:`CMake <cmake-building>` will download this version by defaut.
 
   This version requires a C++17-capable compiler.
+
+  Pass ``--ace-github-latest --doc-master-branch`` to the configure script to clone the ``master`` branch of ACE/TAO as is.
+  This also clones the ``master`` branch of MPC as is.
+  :ref:`CMake <cmake-building>` will do the same if :cmake:var:`OPENDDS_ACE_TAO_GIT` is set to ``TRUE``.
 
 .. _deps-ace:
 

--- a/docs/devguide/building/index.rst
+++ b/docs/devguide/building/index.rst
@@ -660,7 +660,7 @@ These are all the variables that are exclusive to building OpenDDS with CMake:
 
 .. cmake:var:: OPENDDS_ACE_TAO_KIND
 
-  The default is ``ace7tao3`` for :ref:`ACE 7/TAO 3 <ace7tao3>`.
+  The default is ``ace8tao4`` for :ref:`ACE 8/TAO 4 <ace8tao4>`.
   See :ref:`here <deps-ace-tao>` for other versions of ACE/TAO.
 
   .. versionadded:: 3.27

--- a/docs/internal/docs.rst
+++ b/docs/internal/docs.rst
@@ -208,13 +208,13 @@ These come in the form of `RST roles <https://docutils.sourceforge.io/docs/ref/r
 
     See :acetaorel:`ace6tao2`
 
-    Also see :acetaorel:`this <ace7tao3>`
+    Also see :acetaorel:`this <ace8tao4>`
 
   Turns into:
 
-    See :acetaorel:`ace6tao2`
+    See :acetaorel:`ace8tao4`
 
-    Also see :acetaorel:`this <ace7tao3>`
+    Also see :acetaorel:`this <ace8tao4>`
 
 .. rst:role:: omgissue
 


### PR DESCRIPTION
As of this PR, ACE version 6.5.x (latest release on that branch) and ACE version 8 (master branch) are both still supported.
In a future PR for the v4 branch, ACE version 6.5.x will also be removed.