### PR TITLE
SPDP enhancements to avoid unneeded discovery traffic

### DIFF
--- a/dds/DCPS/ConfigStoreImpl.cpp
+++ b/dds/DCPS/ConfigStoreImpl.cpp
@@ -539,6 +539,56 @@ ConfigStoreImpl::get(const char* key,
 
 void
 ConfigStoreImpl::set(const char* key,
+                     const UInt32List& value)
+{
+  String s;
+  for (UInt32List::const_iterator pos = value.begin(), limit = value.end(); pos != limit; ++pos) {
+    if (!s.empty()) {
+      s += ',';
+    }
+    s += to_dds_string(*pos);
+  }
+
+  set(key, s);
+}
+
+ConfigStoreImpl::UInt32List
+ConfigStoreImpl::get(const char* key,
+                     const UInt32List& value) const
+{
+  // Join the default.
+  String s;
+  for (UInt32List::const_iterator pos = value.begin(), limit = value.end(); pos != limit; ++pos) {
+    if (!s.empty()) {
+      s += ',';
+    }
+    s += to_dds_string(*pos);
+  }
+
+  const String t = get(key, s);
+
+  UInt32List retval;
+
+  const char* start = t.c_str();
+  while (const char* next_comma = std::strchr(start, ',')) {
+    const size_t size = static_cast<size_t>(next_comma - start);
+    DDS::UInt32 val = 0;
+    if (convertToInteger(String(start, size), val)) {
+      retval.push_back(val);
+    }
+    start = next_comma + 1;
+  }
+  // Append everything after last comma
+  DDS::UInt32 val = 0;
+  if (convertToInteger(start, val)) {
+    retval.push_back(val);
+  }
+
+  return retval;
+}
+
+void
+ConfigStoreImpl::set(const char* key,
                      const TimeDuration& value,
                      TimeFormat format)
 {

--- a/dds/DCPS/ConfigStoreImpl.h
+++ b/dds/DCPS/ConfigStoreImpl.h
@@ -166,6 +166,12 @@ public:
   StringList get(const char* key,
                  const StringList& value) const;
 
+  typedef OPENDDS_VECTOR(DDS::UInt32) UInt32List;
+  void set(const char* key,
+           const UInt32List& value);
+  UInt32List get(const char* key,
+                 const UInt32List& value) const;
+
   template<typename T, size_t count>
   T get(const char* key,
         T value,

--- a/dds/DCPS/RTPS/MessageUtils.h
+++ b/dds/DCPS/RTPS/MessageUtils.h
@@ -175,6 +175,13 @@ inline void append_submessage(RTPS::Message& message, const RTPS::DataFragSubmes
   DCPS::push_back(message.submessages, sm);
 }
 
+inline void append_submessage(RTPS::Message& message, const RTPS::UserTagSubmessage& submessage)
+{
+  RTPS::Submessage sm;
+  sm.unknown_sm(submessage.smHeader);
+  DCPS::push_back(message.submessages, sm);
+}
+
 #if OPENDDS_CONFIG_SECURITY
 inline DDS::Security::ParticipantSecurityAttributesMask
 security_attributes_to_bitmask(const DDS::Security::ParticipantSecurityAttributes& sec_attr)

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -1171,6 +1171,20 @@ RtpsDiscoveryConfig::spdp_user_tag(ACE_CDR::ULong tag)
                                                     tag);
 }
 
+RtpsDiscoveryConfig::UserTagList
+RtpsDiscoveryConfig::ignored_spdp_user_tags() const
+{
+  return TheServiceParticipant->config_store()->get(config_key("IGNORED_SPDP_USER_TAGS").c_str(),
+                                                    UserTagList());
+}
+
+void
+RtpsDiscoveryConfig::ignored_spdp_user_tags(const UserTagList& tags)
+{
+  TheServiceParticipant->config_store()->set(config_key("IGNORED_SPDP_USER_TAGS").c_str(),
+                                             tags);
+}
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
@@ -252,6 +252,10 @@ public:
   ACE_CDR::ULong spdp_user_tag() const;
   void spdp_user_tag(ACE_CDR::ULong tag);
 
+  typedef OPENDDS_VECTOR(ACE_CDR::ULong) UserTagList;
+  UserTagList ignored_spdp_user_tags() const;
+  void ignored_spdp_user_tags(const UserTagList& tags);
+
 private:
   const String config_prefix_;
 };

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -861,6 +861,12 @@ Spdp::handle_participant_data(DCPS::MessageId id,
 
 #if OPENDDS_CONFIG_SECURITY
     std::pair<DiscoveredParticipantIter, bool> p = participants_.insert(std::make_pair(guid, DiscoveredParticipant(pdata, seq, auth_resend_period_)));
+    p.first->second.identity_token_ = pdata.ddsParticipantDataSecure.base.identity_token;
+    p.first->second.permissions_token_ = pdata.ddsParticipantDataSecure.base.permissions_token;
+    p.first->second.property_qos_ = pdata.ddsParticipantDataSecure.base.property;
+    p.first->second.security_info_ = pdata.ddsParticipantDataSecure.base.security_info;
+    p.first->second.extended_builtin_endpoints_ = pdata.ddsParticipantDataSecure.base.extended_builtin_endpoints;
+
     DDS::Security::SecurityException sec_except = {"", 0, 0};
     const DDS::Security::ValidationResult_t validation_result = pre_check_auth(p.first, sec_except);
     if (is_security_enabled() && security_config_ &&
@@ -944,12 +950,6 @@ Spdp::handle_participant_data(DCPS::MessageId id,
           match_unauthenticated(iter);
         }
       } else {
-        iter->second.identity_token_ = pdata.ddsParticipantDataSecure.base.identity_token;
-        iter->second.permissions_token_ = pdata.ddsParticipantDataSecure.base.permissions_token;
-        iter->second.property_qos_ = pdata.ddsParticipantDataSecure.base.property;
-        iter->second.security_info_ = pdata.ddsParticipantDataSecure.base.security_info;
-        iter->second.extended_builtin_endpoints_ = pdata.ddsParticipantDataSecure.base.extended_builtin_endpoints;
-
         // The remote needs to see our SPDP before attempting authentication.
         tport_->write_i(guid, iter->second.last_recv_address_, from_relay ? SpdpTransport::SEND_RELAY : SpdpTransport::SEND_DIRECT);
 

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -857,17 +857,16 @@ Spdp::handle_participant_data(DCPS::MessageId id,
 
     pdata.leaseDuration.seconds = static_cast<ACE_CDR::Long>(effective_lease.value().sec());
 
-    if (tport_->directed_send_task_) {
-      if (tport_->directed_guids_.empty()) {
-        tport_->directed_send_task_->schedule(TimeDuration::zero_value);
-      }
-      tport_->directed_guids_.push_back(guid);
-    }
-
     // add a new participant
 
 #if OPENDDS_CONFIG_SECURITY
     std::pair<DiscoveredParticipantIter, bool> p = participants_.insert(std::make_pair(guid, DiscoveredParticipant(pdata, seq, auth_resend_period_)));
+    DDS::Security::SecurityException sec_except = {"", 0, 0};
+    const DDS::Security::ValidationResult_t validation_result = pre_check_auth(p.first, sec_except);
+    if (is_security_enabled() && !participant_sec_attr_.allow_unauthenticated_participants && validation_result == DDS::Security::VALIDATION_FAILED) {
+      participants_.erase(p.first);
+      return; // must authenticate and can't
+    }
     ++n_participants_in_authentication_;
     if (DCPS::security_debug.auth_debug) {
       ACE_DEBUG((LM_DEBUG,
@@ -879,6 +878,14 @@ Spdp::handle_participant_data(DCPS::MessageId id,
 #endif
     iter = p.first;
     iter->second.discovered_at_ = now;
+
+    if (tport_->directed_send_task_) {
+      if (tport_->directed_guids_.empty()) {
+        tport_->directed_send_task_->schedule(TimeDuration::zero_value);
+      }
+      tport_->directed_guids_.push_back(guid);
+    }
+
     update_lease_expiration_i(iter, now);
     update_rtps_relay_application_participant_i(iter, p.second);
 
@@ -945,7 +952,7 @@ Spdp::handle_participant_data(DCPS::MessageId id,
         // The remote needs to see our SPDP before attempting authentication.
         tport_->write_i(guid, iter->second.last_recv_address_, from_relay ? SpdpTransport::SEND_RELAY : SpdpTransport::SEND_DIRECT);
 
-        attempt_authentication(iter, true);
+        attempt_authentication(iter, true, &validation_result, &sec_except);
 
         if (iter->second.auth_state_ == AUTH_STATE_UNAUTHENTICATED) {
           if (!participant_sec_attr_.allow_unauthenticated_participants) {
@@ -1389,8 +1396,22 @@ Spdp::send_handshake_request(const DCPS::GUID_t& guid, DiscoveredParticipant& dp
   }
 }
 
+DDS::Security::ValidationResult_t Spdp::pre_check_auth(const DiscoveredParticipantIter& iter,
+                                                       DDS::Security::SecurityException& se)
+{
+  const DCPS::GUID_t& guid = iter->first;
+  DiscoveredParticipant& dp = iter->second;
+  DDS::Security::Authentication_var auth = security_config_->get_authentication();
+
+  return auth->validate_remote_identity(
+    dp.identity_handle_, dp.local_auth_request_token_, dp.remote_auth_request_token_,
+    identity_handle_, dp.identity_token_, guid, se);
+}
+
 void
-Spdp::attempt_authentication(const DiscoveredParticipantIter& iter, bool from_discovery)
+Spdp::attempt_authentication(const DiscoveredParticipantIter& iter, bool from_discovery,
+                             const DDS::Security::ValidationResult_t* validation,
+                             const DDS::Security::SecurityException* sec_except)
 {
   const DCPS::GUID_t& guid = iter->first;
   DiscoveredParticipant& dp = iter->second;
@@ -1417,12 +1438,15 @@ Spdp::attempt_authentication(const DiscoveredParticipantIter& iter, bool from_di
   handshake_deadlines_.insert(std::make_pair(dp.handshake_deadline_, guid));
   tport_->handshake_deadline_task_->schedule(max_auth_time_);
 
-  DDS::Security::Authentication_var auth = security_config_->get_authentication();
-  DDS::Security::SecurityException se = {"", 0, 0};
-
-  const DDS::Security::ValidationResult_t vr = auth->validate_remote_identity(
-    dp.identity_handle_, dp.local_auth_request_token_, dp.remote_auth_request_token_,
-    identity_handle_, dp.identity_token_, guid, se);
+  DDS::Security::ValidationResult_t vr = validation ? *validation : DDS::Security::VALIDATION_FAILED;
+  static const DDS::Security::SecurityException default_sec_except = {"", 0, 0};
+  DDS::Security::SecurityException se = sec_except ? *sec_except : default_sec_except;
+  if (!validation) {
+    DDS::Security::Authentication_var auth = security_config_->get_authentication();
+    vr = auth->validate_remote_identity(
+      dp.identity_handle_, dp.local_auth_request_token_, dp.remote_auth_request_token_,
+      identity_handle_, dp.identity_token_, guid, se);
+  }
 
   dp.have_auth_req_msg_ = !(dp.local_auth_request_token_ == DDS::Security::Token());
   if (dp.have_auth_req_msg_) {

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -448,7 +448,11 @@ private:
                                            const DDS::Security::ParticipantStatelessMessage& msg);
   DCPS::MonotonicTimePoint schedule_handshake_resend(const DCPS::TimeDuration& time, const DCPS::GUID_t& guid);
   bool match_authenticated(const DCPS::GUID_t& guid, DiscoveredParticipantIter& iter);
-  void attempt_authentication(const DiscoveredParticipantIter& iter, bool from_discovery);
+  DDS::Security::ValidationResult_t pre_check_auth(const DiscoveredParticipantIter& iter,
+                                                   DDS::Security::SecurityException& se);
+  void attempt_authentication(const DiscoveredParticipantIter& iter, bool from_discovery,
+                              const DDS::Security::ValidationResult_t* validation = 0,
+                              const DDS::Security::SecurityException* sec_except = 0);
   void update_agent_info(const DCPS::GUID_t& local_guid, const ICE::AgentInfo& agent_info);
   void remove_agent_info(const DCPS::GUID_t& local_guid);
 #endif

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -216,6 +216,8 @@ public:
 
   VendorId_t get_vendor_id_i(const GUID_t& guid) const;
 
+  OPENDDS_SET(DDS::UInt32) get_ignored_user_tags() const;
+
   void ignore_domain_participant(const GUID_t& ignoreId);
 
   void remove_domain_participant(const GUID_t& removeId);
@@ -595,6 +597,7 @@ private:
 #endif
     bool network_is_unreachable_;
     bool ice_endpoint_added_;
+    OPENDDS_SET(DDS::UInt32) ignored_user_tags_;
 
     DCPS::MonotonicTimePoint last_thread_status_harvest_;
     DCPS::ConfigReader_rch config_reader_;

--- a/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
+++ b/dds/DCPS/security/AuthenticationBuiltInImpl.cpp
@@ -254,6 +254,15 @@ AuthenticationBuiltInImpl::~AuthenticationBuiltInImpl()
     return DDS::Security::VALIDATION_FAILED;
   }
 
+  std::string local_identity_ca;
+  if (local_data->credentials && local_data->credentials->get_ca_cert().subject_name_to_str(local_identity_ca) == 0) {
+    const char* const remote_identity_ca = TokenReader(remote_identity_token).get_property_value(dds_ca_sn);
+    if (remote_identity_ca && remote_identity_ca != local_identity_ca) {
+      set_security_error(ex, -1, 0, "Remote identity token's dds.ca.sn doesn't match local");
+      return DDS::Security::VALIDATION_FAILED;
+    }
+  }
+
   // Make sure that a remote_participant_guid has not already been assigned a
   // remote-identity-handle before creating a new one.
   RemoteParticipantMap::iterator begin = local_data->validated_remotes.begin(),

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -1503,6 +1503,11 @@ Those properties, along with options specific to OpenDDS's RTPS discovery implem
     Otherwise this submessage's content is the 4-byte unsigned integer ``<i>``.
     User tags from received SPDP messages are available to the application using the ParticipantLocation built-in topic.
 
+  .. prop:: IgnoredSpdpUserTags=<t1>[,<t2>]...
+    :default: Empty list
+
+    Incoming :ref:`SPDP <spdp>` messages with a UserTag matching any of these values will be ignored.
+
 .. _config-ports-used-by-rtps-disc:
 
 Ports Used by RTPS Discovery

--- a/docs/news.d/spdp-enhance.rst
+++ b/docs/news.d/spdp-enhance.rst
@@ -1,0 +1,7 @@
+.. news-prs: 5046
+
+.. news-start-section: Additions
+- Added :cfg:prop:`[rtps_discovery]IgnoredSpdpUserTags`.
+- When DDS Security is configured to require authentication and an incoming SPDP
+  message has a different Identity CA, authentication is not attempted.
+.. news-end-section

--- a/tests/unit-tests/dds/DCPS/ConfigStoreImpl.cpp
+++ b/tests/unit-tests/dds/DCPS/ConfigStoreImpl.cpp
@@ -239,6 +239,22 @@ TEST(dds_DCPS_ConfigStoreImpl, set_get_StringList)
   EXPECT_EQ(store.get("key", default_list), other_list);
 }
 
+TEST(dds_DCPS_ConfigStoreImpl, set_get_IntList)
+{
+  ConfigTopic_rch topic = make_rch<ConfigTopic>();
+  ConfigStoreImpl store(topic);
+  ConfigStoreImpl::UInt32List default_list;
+  default_list.push_back(1);
+  default_list.push_back(2);
+  default_list.push_back(3);
+  EXPECT_EQ(store.get("key", default_list), default_list);
+
+  ConfigStoreImpl::UInt32List other_list;
+  other_list.push_back(4);
+  store.set("key", other_list);
+  EXPECT_EQ(store.get("key", default_list), other_list);
+}
+
 enum MyConfigStoreEnum {
   ALPHA,
   BETA,


### PR DESCRIPTION
* Incoming SPDP can be ignored based on user tag 
* When requiring authentication, incoming SPDP using a different CA can be dropped