### PR TITLE
Don't Run Dependabot Jobs on Push 

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -2,6 +2,26 @@ name: Android CI
 
 on:
   pull_request:
+    paths:
+      - '**'
+      - '!AUTHORS'
+      - '!PROBLEM-REPORT-FORM'
+      - '!LICENSE'
+      - '!Dockerfile**'
+      - '!.dockerignore'
+      - '!.mailmap'
+      - '!.github/workflows/lint.yml'
+      - '!.github/workflows/sphinx_strict.yml'
+      - '!etc/**'
+      - '!docs/**'
+      - '!hooks/**'
+      - '!tools/scripts/gitrelease.pl'
+      - '!tools/scripts/lint.pl'
+      - '!**.md'
+      - '!**.rst'
+      - '!**/.gitignore'
+      - '!**/.lint_config'
+      - '!**/README*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/android-matrix.yml
+++ b/.github/workflows/android-matrix.yml
@@ -1,10 +1,6 @@
 name: Android Matrix
 
 on:
-  push:
-    branches:
-      - '**'
-      - '!no-gha/**'
   schedule:
     - cron: "0 3 * * 5"
   workflow_dispatch:

--- a/.github/workflows/android-matrix.yml
+++ b/.github/workflows/android-matrix.yml
@@ -1,6 +1,9 @@
 name: Android Matrix
 
 on:
+  pull_request:
+    types:
+      - closed
   schedule:
     - cron: "0 3 * * 5"
   workflow_dispatch:
@@ -14,6 +17,8 @@ permissions:
 
 jobs:
   matrix:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.merged == true }}
+
     runs-on: ${{ matrix.os }}
 
     name: ${{ matrix.name }}

--- a/.github/workflows/android-matrix.yml
+++ b/.github/workflows/android-matrix.yml
@@ -1,11 +1,30 @@
 name: Android Matrix
 
 on:
-  pull_request:
-    types:
-      - closed
-  schedule:
-    - cron: "0 3 * * 5"
+  push:
+    branches:
+      - 'master'
+      - '**android**'
+    paths:
+      - '**'
+      - '!AUTHORS'
+      - '!PROBLEM-REPORT-FORM'
+      - '!LICENSE'
+      - '!Dockerfile**'
+      - '!.dockerignore'
+      - '!.mailmap'
+      - '!.github/workflows/lint.yml'
+      - '!.github/workflows/sphinx_strict.yml'
+      - '!etc/**'
+      - '!docs/**'
+      - '!hooks/**'
+      - '!tools/scripts/gitrelease.pl'
+      - '!tools/scripts/lint.pl'
+      - '!**.md'
+      - '!**.rst'
+      - '!**/.gitignore'
+      - '!**/.lint_config'
+      - '!**/README*'
   workflow_dispatch:
 
 concurrency:
@@ -17,8 +36,6 @@ permissions:
 
 jobs:
   matrix:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.merged == true }}
-
     runs-on: ${{ matrix.os }}
 
     name: ${{ matrix.name }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,6 +2,9 @@ name: "MPC Builds"
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'workflows/**'
     paths:
       - '**'
       # Don't run this workflow if the only files that changed are the

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,6 +2,9 @@ name: "CMake Builds"
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'workflows/**'
     paths:
       - '**'
       # Don't run this workflow if the only files that changed are the

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: lint
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'workflows/**'
   pull_request:
   schedule:
     - cron: '0 1 * * SUN'

--- a/.github/workflows/sphinx_strict.yml
+++ b/.github/workflows/sphinx_strict.yml
@@ -2,6 +2,9 @@ name: Sphinx Tests
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'workflows/**'
   pull_request:
   schedule:
     - cron: '0 1 * * SUN'


### PR DESCRIPTION
Otherwise they double up with pull request jobs.

Also:
- Also ignore `workflows/**` for any future custom workflow created
  branches.
- Run Android Matrix after merge.