### PR TITLE
Workaround libiconv URL Timeout Read

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -150,8 +150,12 @@ class DocEnv:
         # Process link check results ourselves so we can print failures in one
         # place, ignore failures based on reason, and inspect things like
         # redirects with custom logic.
+        # This is regex of URL to a list of regex of messages to ignore.
         ignore_info = {
-            r'.*': [r'.*403 Client Error.*'],  # This is very common
+            r'.*': [
+                r'.*403 Client Error.*',  # This is very common
+                r'.*Read timed out.*',
+            ],
         }
         linkcheck_json = self.build_path / 'linkcheck/output.json'
         failed = False

--- a/docs/devguide/building/android.rst
+++ b/docs/devguide/building/android.rst
@@ -368,7 +368,7 @@ For API levels greater than or equal to 28, a transcoder -- GNU libiconv -- is i
 Before 28 any of the transcoders supported by Xerces would work but GNU libiconv was the one tested.
 If GNU libiconv is used, build it as an archive library (``--disable-shared``) so that the users of Xerces (ACE and OpenDDS) don't need it as an additional runtime dependency.
 
-Download `GNU libiconv <https://ftp.gnu.org/pub/gnu/libiconv>`__ version 1.16 source code and extract the archive.
+Download `GNU libiconv <https://ftp.gnu.org/pub/gnu/libiconv/>`__ version 1.16 source code and extract the archive.
 
 Cross-compiling on Windows
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Apparently the link we're using is a redirect, but to the same URL with a / at the end. That doesn't seem to be the problem though. Using curl to see what's happening, the link is resolving, it's just ftp.gnu.org is taking a time long to respond. Ignore read timeouts in general, also saw one on Strawberry Perl website while testing.