### PR TITLE
Use `SafeBool_T` for `RcHandle`

### DIFF
--- a/dds/DCPS/RcHandle_T.h
+++ b/dds/DCPS/RcHandle_T.h
@@ -9,6 +9,7 @@
 #include "dds/Versioned_Namespace.h"
 #include "Definitions.h"
 #include "unique_ptr.h"
+#include "SafeBool_T.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -21,7 +22,7 @@ struct keep_count {};
 /// Templated Reference counted handle to a pointer.
 /// A non-DDS specific helper class.
 template <typename T>
-class RcHandle {
+class RcHandle : public SafeBool_T<RcHandle<T> > {
 public:
   RcHandle()
     : ptr_(0)
@@ -151,7 +152,7 @@ public:
     return retval;
   }
 
-  operator bool() const
+  bool boolean_test() const
   {
     return in() != 0;
   }

--- a/dds/DCPS/RcHandle_T.h
+++ b/dds/DCPS/RcHandle_T.h
@@ -84,7 +84,7 @@ public:
     return *this;
   }
 
-  template <class U>
+  template <typename U>
   RcHandle& operator=(const RcHandle<U>& b)
   {
     RcHandle<T> tmp(b);
@@ -157,12 +157,14 @@ public:
     return in() != 0;
   }
 
-  bool operator==(const RcHandle& rhs) const
+  template <typename U>
+  bool operator==(const RcHandle<U>& rhs) const
   {
     return in() == rhs.in();
   }
 
-  bool operator!=(const RcHandle& rhs) const
+  template <typename U>
+  bool operator!=(const RcHandle<U>& rhs) const
   {
     return in() != rhs.in();
   }
@@ -218,7 +220,7 @@ RcHandle<T> dynamic_rchandle_cast(const RcHandle<U>& h)
 }
 
 
-template< class T >
+template <typename T>
 class reference_wrapper{
 public:
   // types
@@ -307,7 +309,7 @@ RcHandle<T> make_rch(U0 const& u0, U1 const& u1, U2 const& u2, U3 const& u3, U4 
   return RcHandle<T>(new T(unwrap_reference(u0), unwrap_reference(u1), unwrap_reference(u2), unwrap_reference(u3), unwrap_reference(u4), unwrap_reference(u5), unwrap_reference(u6), unwrap_reference(u7)), keep_count());
 }
 
-template<typename T>
+template <typename T>
 RcHandle<T> rchandle_from(T* pointer)
 {
   OPENDDS_ASSERT(pointer == 0 || pointer->ref_count() > 0);

--- a/dds/DCPS/RcObject.h
+++ b/dds/DCPS/RcObject.h
@@ -124,8 +124,7 @@ namespace DCPS {
   }
 
   template <typename T>
-  class WeakRcHandle
-  {
+  class WeakRcHandle : public SafeBool_T<WeakRcHandle<T> > {
   public:
     WeakRcHandle()
       : weak_object_(0)
@@ -208,9 +207,9 @@ namespace DCPS {
       return weak_object_ < rhs.weak_object_;
     }
 
-    operator bool() const
+    bool boolean_test() const
     {
-      return weak_object_;
+      return weak_object_ != 0;
     }
 
     void reset()

--- a/dds/DCPS/SafeBool_T.h
+++ b/dds/DCPS/SafeBool_T.h
@@ -2,7 +2,8 @@
  * \file
  * Implements the "Safe Bool" idiom, which is a safer alternative to operator
  * bool. Based on:
- *   https://www.artima.com/articles/the-safe-bool-idiom
+ *   https://www.artima.com/articles/the-safe-bool-idiom, and
+ *   https://en.wikibooks.org/wiki/More_C++_Idioms/Safe_bool
  * TLDR: We may want to be able to use `operator bool()` to check an object's
  * abstract truthfulness using `if (object) {...}`, but that opens up implicit
  * casting and comparisons that come with the bool type that are almost
@@ -45,7 +46,7 @@ protected:
 };
 
 template <typename DerivedNonVirtual = void>
-class SafeBool_T : public SafeBoolBase {
+class SafeBool_T : private SafeBoolBase {
 public:
   operator BoolType() const
   {
@@ -58,7 +59,7 @@ protected:
 };
 
 template<>
-class SafeBool_T<void> : public SafeBoolBase {
+class SafeBool_T<void> : private SafeBoolBase {
 public:
   operator BoolType() const
   {

--- a/dds/DCPS/transport/multicast/MulticastDataLink.cpp
+++ b/dds/DCPS/transport/multicast/MulticastDataLink.cpp
@@ -180,25 +180,25 @@ MulticastDataLink::find_or_create_session(MulticastPeer remote_peer)
   if (mt) {
     session = session_factory_->create(mt->event_dispatcher(), mt->reactor_task()->get_reactor(), this, remote_peer);
     if (session.is_nil()) {
-      ACE_ERROR_RETURN((LM_ERROR,
+      ACE_ERROR((LM_ERROR,
           ACE_TEXT("(%P|%t) ERROR: ")
           ACE_TEXT("MulticastDataLink::find_or_create_session: ")
           ACE_TEXT("failed to create session for remote peer: %#08x%08x!\n"),
           (unsigned int) (remote_peer >> 32),
-          (unsigned int) remote_peer),
-          MulticastSession_rch());
+          (unsigned int) remote_peer));
+      return MulticastSession_rch();
     }
 
     std::pair<MulticastSessionMap::iterator, bool> pair = this->sessions_.insert(
         MulticastSessionMap::value_type(remote_peer, session));
     if (pair.first == this->sessions_.end()) {
-      ACE_ERROR_RETURN((LM_ERROR,
+      ACE_ERROR((LM_ERROR,
           ACE_TEXT("(%P|%t) ERROR: ")
           ACE_TEXT("MulticastDataLink::find_or_create_session: ")
           ACE_TEXT("failed to insert session for remote peer: %#08x%08x!\n"),
           (unsigned int) (remote_peer >> 32),
-          (unsigned int) remote_peer),
-          MulticastSession_rch());
+          (unsigned int) remote_peer));
+      return MulticastSession_rch();
     }
   }
   return session;

--- a/dds/DCPS/transport/multicast/MulticastTransport.cpp
+++ b/dds/DCPS/transport/multicast/MulticastTransport.cpp
@@ -94,38 +94,38 @@ MulticastTransport::start_session(const MulticastDataLink_rch& link,
   MulticastInst_rch cfg = config();
 
   if (link.is_nil()) {
-    ACE_ERROR_RETURN((LM_ERROR,
-                      ACE_TEXT("(%P|%t) ERROR: ")
-                      ACE_TEXT("MulticastTransport[%C]::start_session: ")
-                      ACE_TEXT("link is nil\n"),
-                      cfg ? cfg->name().c_str() : ""),
-                     MulticastSession_rch());
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("(%P|%t) ERROR: ")
+               ACE_TEXT("MulticastTransport[%C]::start_session: ")
+               ACE_TEXT("link is nil\n"),
+               cfg ? cfg->name().c_str() : ""));
+    return MulticastSession_rch();
   }
 
   MulticastSession_rch session(link->find_or_create_session(remote_peer));
 
   if (session.is_nil()) {
-    ACE_ERROR_RETURN((LM_ERROR,
-                      ACE_TEXT("(%P|%t) ERROR: ")
-                      ACE_TEXT("MulticastTransport[%C]::start_session: ")
-                      ACE_TEXT("failed to create session for remote peer: %#08x%08x!\n"),
-                      cfg ? cfg->name().c_str() : "",
-                      (unsigned int)(remote_peer >> 32),
-                      (unsigned int) remote_peer),
-                     MulticastSession_rch());
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("(%P|%t) ERROR: ")
+               ACE_TEXT("MulticastTransport[%C]::start_session: ")
+               ACE_TEXT("failed to create session for remote peer: %#08x%08x!\n"),
+               cfg ? cfg->name().c_str() : "",
+               (unsigned int)(remote_peer >> 32),
+               (unsigned int) remote_peer));
+    return MulticastSession_rch();
   }
 
   const bool acked = this->connections_.count(std::make_pair(remote_peer, link->local_peer()));
 
   if (!session->start(active, acked)) {
-    ACE_ERROR_RETURN((LM_ERROR,
-                      ACE_TEXT("(%P|%t) ERROR: ")
-                      ACE_TEXT("MulticastTransport[%C]::start_session: ")
-                      ACE_TEXT("failed to start session for remote peer: %#08x%08x!\n"),
-                      cfg ? cfg->name().c_str() : "",
-                      (unsigned int)(remote_peer >> 32),
-                      (unsigned int) remote_peer),
-                     MulticastSession_rch());
+    ACE_ERROR((LM_ERROR,
+               ACE_TEXT("(%P|%t) ERROR: ")
+               ACE_TEXT("MulticastTransport[%C]::start_session: ")
+               ACE_TEXT("failed to start session for remote peer: %#08x%08x!\n"),
+               cfg ? cfg->name().c_str() : "",
+               (unsigned int)(remote_peer >> 32),
+               (unsigned int) remote_peer));
+    return MulticastSession_rch();
   }
 
   return session;

--- a/performance-tests/bench/worker/ReadAction.cpp
+++ b/performance-tests/bench/worker/ReadAction.cpp
@@ -14,6 +14,7 @@ ReadAction::ReadAction(OpenDDS::DCPS::EventDispatcher_rch event_dispatcher)
 , stop_condition_(new DDS::GuardCondition())
 , dr_listener_(0)
 , read_period_(1, 0)
+, timer_id_(-1)
 , in_do_read_(false)
 {
 }
@@ -80,7 +81,10 @@ void ReadAction::test_start()
     ws_ = new DDS::WaitSet();
     ws_->attach_condition(stop_condition_);
     ws_->attach_condition(read_condition_);
-    event_dispatcher_->dispatch(event_);
+    timer_id_ = event_dispatcher_->schedule(event_);
+    if (timer_id_ < 0) {
+      std::cerr << "Failed to schedule event in ReadAction::test_start" << std::endl;
+    }
   }
 }
 
@@ -93,7 +97,7 @@ void ReadAction::action_stop()
   std::unique_lock<std::mutex> lock(mutex_);
   if (started_ && !stopped_) {
     stopped_ = true;
-    event_dispatcher_->cancel(event_);
+    event_dispatcher_->cancel(timer_id_);
     stop_condition_->set_trigger_value(true);
     while (in_do_read_) {
       cv_.wait(lock);
@@ -156,7 +160,10 @@ void ReadAction::do_read()
     }
 
     if (!stopped_) {
-      event_dispatcher_->dispatch(event_);
+      timer_id_ = event_dispatcher_->schedule(event_);
+      if (timer_id_ < 0) {
+        std::cerr << "Failed to schedule event in ReadAction::do_read" << std::endl;
+      }
     }
   }
 }

--- a/performance-tests/bench/worker/ReadAction.h
+++ b/performance-tests/bench/worker/ReadAction.h
@@ -35,6 +35,7 @@ protected:
   WorkerDataReaderListener* dr_listener_;
   OpenDDS::DCPS::TimeDuration read_period_;
   OpenDDS::DCPS::EventBase_rch event_;
+  long timer_id_;
   bool in_do_read_;
 };
 

--- a/performance-tests/bench/worker/SetCftParametersAction.cpp
+++ b/performance-tests/bench/worker/SetCftParametersAction.cpp
@@ -14,6 +14,7 @@ SetCftParametersAction::SetCftParametersAction(OpenDDS::DCPS::EventDispatcher_rc
 , param_count_(0)
 , random_order_(false)
 , instance_(0)
+, timer_id_(-1)
 , set_call_count_(0)
 {
 }
@@ -124,7 +125,10 @@ void SetCftParametersAction::test_start()
   if (!started_) {
     started_ = true;
     last_scheduled_time_ = OpenDDS::DCPS::MonotonicTimePoint::now();
-    event_dispatcher_->dispatch(event_);
+    timer_id_ = event_dispatcher_->schedule(event_);
+    if (timer_id_ < 0) {
+      std::cerr << "Failed to schedule event in SetCftParametersAction::test_start" << std::endl;
+    }
   }
 }
 
@@ -133,7 +137,7 @@ void SetCftParametersAction::test_stop()
   std::unique_lock<std::mutex> lock(mutex_);
   if (started_ && !stopped_) {
     stopped_ = true;
-    event_dispatcher_->cancel(event_);
+    event_dispatcher_->cancel(timer_id_);
   }
 }
 
@@ -158,7 +162,10 @@ void SetCftParametersAction::do_set_expression_parameters()
 #endif
     }
     last_scheduled_time_ += set_period_;
-    event_dispatcher_->schedule(event_, last_scheduled_time_);
+    timer_id_ = event_dispatcher_->schedule(event_, last_scheduled_time_);
+    if (timer_id_ < 0) {
+      std::cerr << "Failed to schedule event in SetCftParametersAction::do_set_expression_parameters" << std::endl;
+    }
   }
 }
 

--- a/performance-tests/bench/worker/SetCftParametersAction.h
+++ b/performance-tests/bench/worker/SetCftParametersAction.h
@@ -35,6 +35,7 @@ protected:
   DDS::InstanceHandle_t instance_;
   OpenDDS::DCPS::MonotonicTimePoint last_scheduled_time_;
   OpenDDS::DCPS::EventBase_rch event_;
+  long timer_id_;
   std::mt19937_64 mt_;
   size_t set_call_count_;
 #ifndef OPENDDS_NO_CONTENT_FILTERED_TOPIC

--- a/performance-tests/bench/worker/WriteAction.cpp
+++ b/performance-tests/bench/worker/WriteAction.cpp
@@ -15,6 +15,7 @@ WriteAction::WriteAction(OpenDDS::DCPS::EventDispatcher_rch event_dispatcher)
 , new_key_count_(0)
 , new_key_probability_(0)
 , instance_(0)
+, timer_id_(-1)
 , filter_class_start_value_(0)
 , filter_class_stop_value_(0)
 , filter_class_increment_(0)
@@ -171,7 +172,10 @@ void WriteAction::test_start()
     started_ = true;
 
     last_scheduled_time_ = OpenDDS::DCPS::MonotonicTimePoint::now();
-    event_dispatcher_->dispatch(event_);
+    timer_id_ = event_dispatcher_->schedule(event_);
+    if (timer_id_ < 0) {
+      std::cerr << "Failed to schedule event in WriteAction::test_start" << std::endl;
+    }
   }
 }
 
@@ -180,7 +184,7 @@ void WriteAction::test_stop()
   std::unique_lock<std::mutex> lock(mutex_);
   if (started_ && !stopped_) {
     stopped_ = true;
-    event_dispatcher_->cancel(event_);
+    event_dispatcher_->cancel(timer_id_);
     data_dw_->wait_for_acknowledgments(final_wait_for_ack_);
     data_dw_->unregister_instance(data_, instance_);
     data_dw_->wait_for_acknowledgments(final_wait_for_ack_);
@@ -215,7 +219,10 @@ void WriteAction::do_write()
       }
       last_scheduled_time_ += write_period_;
 
-      event_dispatcher_->schedule(event_, last_scheduled_time_);
+      timer_id_ = event_dispatcher_->schedule(event_, last_scheduled_time_);
+      if (timer_id_ < 0) {
+        std::cerr << "Failed to schedule event in WriteAction::do_write" << std::endl;
+      }
     }
   }
 }

--- a/performance-tests/bench/worker/WriteAction.h
+++ b/performance-tests/bench/worker/WriteAction.h
@@ -33,6 +33,7 @@ protected:
   uint64_t new_key_probability_;
   DDS::InstanceHandle_t instance_;
   OpenDDS::DCPS::EventBase_rch event_;
+  long timer_id_;
   std::mt19937_64 mt_;
   size_t filter_class_start_value_;
   size_t filter_class_stop_value_;

--- a/tests/unit-tests/dds/DCPS/RTPS/AssociationRecord.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/AssociationRecord.cpp
@@ -182,7 +182,7 @@ TEST(dds_DCPS_RTPS_AssociationRecord, WriterAssociationRecord_ctor)
 
   EXPECT_EQ(uut.writer_id(), writer_id);
   EXPECT_EQ(uut.reader_id(), reader_association.readerId);
-  EXPECT_EQ(uut.callbacks_, callbacks);
+  EXPECT_EQ(uut.callbacks_.lock(), callbacks);
   EXPECT_EQ(uut.writer_id_, writer_id);
   // IDL defined type.
   //EXPECT_EQ(uut.reader_association_, reader_association);
@@ -239,7 +239,7 @@ TEST(dds_DCPS_RTPS_AssociationRecord, ReaderAssociationRecord_ctor)
 
   EXPECT_EQ(uut.reader_id(), reader_id);
   EXPECT_EQ(uut.writer_id(), writer_association.writerId);
-  EXPECT_EQ(uut.callbacks_, callbacks);
+  EXPECT_EQ(uut.callbacks_.lock(), callbacks);
   EXPECT_EQ(uut.reader_id_, reader_id);
   // IDL defined type.
   //EXPECT_EQ(uut.writer_association_, writer_association);

--- a/tests/unit-tests/dds/DCPS/RcObject.cpp
+++ b/tests/unit-tests/dds/DCPS/RcObject.cpp
@@ -15,7 +15,7 @@ TEST(dds_DCPS_RcObject, ctors_weak)
 {
   RcHandle<Counted> h1 = make_rch<Counted>();
   WeakRcHandle<Counted> w1(h1);
-  EXPECT_EQ(w1, h1);
+  EXPECT_EQ(w1.lock(), h1);
 
   WeakRcHandle<Counted> w2;
   EXPECT_FALSE(w2);
@@ -30,7 +30,7 @@ TEST(dds_DCPS_RcObject, assign_weak)
   WeakRcHandle<Counted> w1, w2, w3;
 
   w1 = h1;
-  EXPECT_EQ(w1, h1);
+  EXPECT_EQ(w1.lock(), h1);
 
   w2 = w1;
   EXPECT_TRUE(w2);

--- a/tests/unit-tests/dds/DCPS/RcObject.cpp
+++ b/tests/unit-tests/dds/DCPS/RcObject.cpp
@@ -15,7 +15,7 @@ TEST(dds_DCPS_RcObject, ctors_weak)
 {
   RcHandle<Counted> h1 = make_rch<Counted>();
   WeakRcHandle<Counted> w1(h1);
-  EXPECT_EQ(h1, w1);
+  EXPECT_EQ(w1, h1);
 
   WeakRcHandle<Counted> w2;
   EXPECT_FALSE(w2);
@@ -30,7 +30,7 @@ TEST(dds_DCPS_RcObject, assign_weak)
   WeakRcHandle<Counted> w1, w2, w3;
 
   w1 = h1;
-  EXPECT_EQ(h1, w1);
+  EXPECT_EQ(w1, h1);
 
   w2 = w1;
   EXPECT_TRUE(w2);

--- a/tests/unit-tests/dds/DCPS/SafeBool_T.cpp
+++ b/tests/unit-tests/dds/DCPS/SafeBool_T.cpp
@@ -50,3 +50,21 @@ TEST(dds_DCPS_SafeBool_T, non_virtual_method)
   EXPECT_TRUE(NonVirtualMethod(true));
   EXPECT_FALSE(NonVirtualMethod(false));
 }
+
+// Implicit test case: these comparisons should not compile since
+// SafeBool_T explicitly prevents them.
+//
+// TEST(dds_DCPS_SafeBool_T, comparisons_not_supported)
+// {
+//   VirtualMethod vm1, vm2;
+//   if (vm1 == vm2) {}
+//   if (vm1 != vm2) {}
+
+//   DerivedVirtualMethod dvm1, dvm2;
+//   if (dvm1 == dvm2) {}
+//   if (dvm1 != dvm2) {}
+
+//   NonVirtualMethod nvm1(true), nvm2(true);
+//   if (nvm1 == nvm2) {}
+//   if (nvm1 != nvm2) {}
+// }

--- a/tests/unit-tests/dds/DCPS/SafeBool_T.cpp
+++ b/tests/unit-tests/dds/DCPS/SafeBool_T.cpp
@@ -67,4 +67,8 @@ TEST(dds_DCPS_SafeBool_T, non_virtual_method)
 //   NonVirtualMethod nvm1(true), nvm2(true);
 //   if (nvm1 == nvm2) {}
 //   if (nvm1 != nvm2) {}
+
+//   if (vm1 == dvm1) {}
+//   if (dvm1 == nvm1) {}
+//   if (nvm1 == vm1) {}
 // }


### PR DESCRIPTION
- Avoid implicit conversion from `RcHandle` to types such as integer by making it a `SafeBool_T`
- Better following the safe bool pattern by disallowing comparison operators by default. Derived classes can still define comparison operators as member functions.