### PR TITLE
Add EventDispatcher thread count config flags

### DIFF
--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2718,6 +2718,11 @@ Spdp::SpdpTransport::close(const DCPS::ReactorTask_rch& reactor_task)
   DCPS::RcHandle<Spdp> outer = outer_.lock();
   if (!outer) return;
 
+  DCPS::ConfigListener::job_queue(DCPS::JobQueue_rch());
+  DCPS::InternalDataReaderListener<DCPS::NetworkInterfaceAddress>::job_queue(DCPS::JobQueue_rch());
+  if (network_interface_updates_event_) {
+    network_interface_updates_event_->disable();
+  }
   TheServiceParticipant->network_interface_address_topic()->disconnect(network_interface_address_reader_);
 
 #if OPENDDS_CONFIG_SECURITY
@@ -3726,7 +3731,7 @@ void Spdp::SpdpTransport::handle_network_interface_updates()
   }
 }
 
-void Spdp::SpdpTransport::on_data_available(DCPS::ConfigReader_rch)
+void Spdp::SpdpTransport::on_data_available(DCPS::ConfigReader_rch reader)
 {
   DCPS::RcHandle<Spdp> outer = outer_.lock();
   if (!outer) return;
@@ -3744,8 +3749,11 @@ void Spdp::SpdpTransport::on_data_available(DCPS::ConfigReader_rch)
 
   DCPS::InternalDataReader<DCPS::ConfigPair>::SampleSequence samples;
   DCPS::InternalSampleInfoSequence infos;
-  config_reader_->take(samples, infos, DDS::LENGTH_UNLIMITED,
-                       DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE);
+  if (!reader) {
+    return;
+  }
+  reader->take(samples, infos, DDS::LENGTH_UNLIMITED,
+               DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE);
   for (size_t idx = 0; idx != samples.size(); ++idx) {
     const DCPS::ConfigPair& sample = samples[idx];
     if (sample.key() == DCPS::COMMON_DCPS_THREAD_STATUS_INTERVAL) {

--- a/dds/DCPS/ReactorEvent.cpp
+++ b/dds/DCPS/ReactorEvent.cpp
@@ -24,8 +24,9 @@ ReactorEvent::ReactorEvent(ACE_Reactor* reactor, EventBase_rch event)
 
 void ReactorEvent::handle_event()
 {
-  if (reactor_) {
-    reactor_->notify(this);
+  ACE_Reactor* reactor = reactor_.load();
+  if (reactor) {
+    reactor->notify(this);
   }
 }
 
@@ -33,6 +34,11 @@ int ReactorEvent::handle_exception(ACE_HANDLE)
 {
   event_->handle_event();
   return 0;
+}
+
+void ReactorEvent::disable()
+{
+  reactor_ = 0;
 }
 
 } // DCPS

--- a/dds/DCPS/ReactorEvent.h
+++ b/dds/DCPS/ReactorEvent.h
@@ -9,6 +9,7 @@
 #define OPENDDS_DCPS_REACTOR_EVENT_H
 
 #include "EventDispatcher.h"
+#include "Atomic.h"
 #include "RcEventHandler.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -36,11 +37,13 @@ public:
    */
   void handle_event();
 
+  void disable();
+
 private:
 
   int handle_exception(ACE_HANDLE fd);
 
-  ACE_Reactor* reactor_;
+  Atomic<ACE_Reactor*> reactor_;
   RcHandle<EventBase> event_;
 };
 

--- a/dds/DCPS/ReactorTask.cpp
+++ b/dds/DCPS/ReactorTask.cpp
@@ -657,6 +657,10 @@ void RegisterHandler::execute(ReactorWrapper& reactor_wrapper)
 
 void RemoveHandler::execute(ReactorWrapper& reactor_wrapper)
 {
+  if (io_handle_ == ACE_INVALID_HANDLE) {
+    return;
+  }
+
   if (reactor_wrapper.remove_handler(io_handle_, mask_) != 0) {
     if (log_level >= LogLevel::Error) {
       ACE_ERROR((LM_ERROR,

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -1779,6 +1779,8 @@ Service_Participant::event_dispatcher_thread_count() const
                  value,
                  COMMON_DCPS_EVENT_DISPATCHER_THREADS_default));
     }
+    config_store_->set_uint32(COMMON_DCPS_EVENT_DISPATCHER_THREADS,
+                              static_cast<DDS::UInt32>(COMMON_DCPS_EVENT_DISPATCHER_THREADS_default));
     return COMMON_DCPS_EVENT_DISPATCHER_THREADS_default;
   }
 

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -38,6 +38,8 @@
 #include <ace/Configuration_Import_Export.h>
 #include <ace/Malloc_Allocator.h>
 #include <ace/OS_NS_ctype.h>
+
+#include <limits>
 #include <ace/OS_NS_sys_utsname.h>
 #include <ace/OS_NS_unistd.h>
 #include <ace/Reactor.h>
@@ -2447,6 +2449,21 @@ Service_Participant::ConfigReaderListener::on_data_available(InternalDataReader_
         Transport_debug_level = static_cast<unsigned int>(ACE_OS::atoi(p.value().c_str()));
       } else if (p.key() == COMMON_DCPS_THREAD_STATUS_INTERVAL) {
         service_participant_.thread_status_manager_.thread_status_interval(TimeDuration(ACE_OS::atoi(p.value().c_str())));
+      } else if (p.key() == COMMON_DCPS_EVENT_DISPATCHER_THREADS) {
+        DDS::Int64 value = 0;
+        if (!convertToInteger(p.value(), value)
+            || value < static_cast<DDS::Int64>(COMMON_DCPS_EVENT_DISPATCHER_THREADS_default)
+            || value > static_cast<DDS::Int64>(std::numeric_limits<DDS::UInt32>::max())) {
+          if (log_level >= LogLevel::Warning) {
+            ACE_ERROR((LM_WARNING,
+                       ACE_TEXT("(%P|%t) WARNING: ConfigReaderListener::on_data_available: ")
+                       ACE_TEXT("configured value %C for %C is invalid, using %B\n"),
+                       p.value().c_str(),
+                       COMMON_DCPS_EVENT_DISPATCHER_THREADS,
+                       COMMON_DCPS_EVENT_DISPATCHER_THREADS_default));
+          }
+          service_participant_.event_dispatcher_thread_count(COMMON_DCPS_EVENT_DISPATCHER_THREADS_default);
+        }
 #if OPENDDS_CONFIG_SECURITY
       } else if (p.key() == COMMON_DCPS_SECURITY_DEBUG_LEVEL) {
         security_debug.set_debug_level(static_cast<unsigned int>(ACE_OS::atoi(p.value().c_str())));

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -457,7 +457,7 @@ Service_Participant::get_domain_participant_factory(int &argc,
 
       dp_factory_servant_ = make_rch<DomainParticipantFactoryImpl>();
 
-      event_dispatcher_ = make_rch<ServiceEventDispatcher>(1u);
+      event_dispatcher_ = make_rch<ServiceEventDispatcher>(event_dispatcher_thread_count());
 
       reactor_task_->open_reactor_task(&thread_status_manager_, "Service_Participant");
       job_queue_ = make_rch<JobQueue>(event_dispatcher_);
@@ -1751,6 +1751,36 @@ Service_Participant::liveliness_factor() const
 {
   return config_store_->get_int32(COMMON_DCPS_LIVELINESS_FACTOR,
                                   COMMON_DCPS_LIVELINESS_FACTOR_default);
+}
+
+void
+Service_Participant::event_dispatcher_thread_count(size_t value)
+{
+  const size_t actual = value < COMMON_DCPS_EVENT_DISPATCHER_THREADS_default
+    ? COMMON_DCPS_EVENT_DISPATCHER_THREADS_default
+    : value;
+  config_store_->set_uint32(COMMON_DCPS_EVENT_DISPATCHER_THREADS,
+                            static_cast<DDS::UInt32>(actual));
+}
+
+size_t
+Service_Participant::event_dispatcher_thread_count() const
+{
+  const size_t value =
+    config_store_->get_uint32(COMMON_DCPS_EVENT_DISPATCHER_THREADS,
+                              static_cast<DDS::UInt32>(COMMON_DCPS_EVENT_DISPATCHER_THREADS_default));
+  if (value < COMMON_DCPS_EVENT_DISPATCHER_THREADS_default) {
+    if (log_level >= LogLevel::Warning) {
+      ACE_ERROR((LM_WARNING,
+                 "(%P|%t) WARNING: Service_Participant::event_dispatcher_thread_count: "
+                 "configured value %B is invalid, using %B\n",
+                 value,
+                 COMMON_DCPS_EVENT_DISPATCHER_THREADS_default));
+    }
+    return COMMON_DCPS_EVENT_DISPATCHER_THREADS_default;
+  }
+
+  return value;
 }
 
 void

--- a/dds/DCPS/Service_Participant.h
+++ b/dds/DCPS/Service_Participant.h
@@ -99,6 +99,9 @@ const Discovery::RepoKey COMMON_DCPS_DEFAULT_DISCOVERY_default = Discovery::DEFA
 # endif
 #endif
 
+const char COMMON_DCPS_EVENT_DISPATCHER_THREADS[] = "COMMON_DCPS_EVENT_DISPATCHER_THREADS";
+const size_t COMMON_DCPS_EVENT_DISPATCHER_THREADS_default = 1u;
+
 const char COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG[] = "COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG";
 const String COMMON_DCPS_GLOBAL_TRANSPORT_CONFIG_default = "";
 
@@ -340,6 +343,13 @@ public:
   /// @return % of lease period before sending a liveliness
   ///         message.
   int liveliness_factor() const;
+
+  /// Accessors for the global service event dispatcher thread count.
+  /// The minimum valid value is 1.
+  //@{
+  void event_dispatcher_thread_count(size_t value);
+  size_t event_dispatcher_thread_count() const;
+  //@}
 
   ///
   void add_discovery(Discovery_rch discovery);

--- a/dds/DCPS/transport/framework/TransportImpl.cpp
+++ b/dds/DCPS/transport/framework/TransportImpl.cpp
@@ -33,11 +33,33 @@ namespace DCPS {
 TransportImpl::TransportImpl(TransportInst_rch config,
                              DDS::DomainId_t domain)
   : config_(config)
-  , event_dispatcher_(make_rch<ServiceEventDispatcher>(1u))
+  , owns_event_dispatcher_(false)
   , is_shut_down_(false)
   , domain_(domain)
 {
   DBG_ENTRY_LVL("TransportImpl", "TransportImpl", 6);
+
+  const size_t event_dispatcher_threads = config->event_dispatcher_threads();
+  if (event_dispatcher_threads == 0) {
+    event_dispatcher_ = TheServiceParticipant->event_dispatcher();
+    if (!event_dispatcher_) {
+      const size_t global_thread_count = TheServiceParticipant->event_dispatcher_thread_count();
+      if (log_level >= LogLevel::Warning) {
+        ACE_ERROR((LM_WARNING,
+                   "(%P|%t) WARNING: TransportImpl::TransportImpl: "
+                   "global event dispatcher requested by transport %C before it was initialized; "
+                   "creating a private dispatcher with %B thread(s)\n",
+                   config->name().c_str(),
+                   global_thread_count));
+      }
+      event_dispatcher_ = make_rch<ServiceEventDispatcher>(global_thread_count);
+      owns_event_dispatcher_ = true;
+    }
+  } else {
+    event_dispatcher_ = make_rch<ServiceEventDispatcher>(event_dispatcher_threads);
+    owns_event_dispatcher_ = true;
+  }
+
   if (TheServiceParticipant->monitor_factory_) {
     monitor_.reset(TheServiceParticipant->monitor_factory_->create_transport_monitor(this));
   }
@@ -61,7 +83,9 @@ TransportImpl::shutdown()
 
   is_shut_down_ = true;
 
-  event_dispatcher_->shutdown(false);
+  if (owns_event_dispatcher_ && event_dispatcher_) {
+    event_dispatcher_->shutdown(false);
+  }
 
   if (!this->reactor_task_.is_nil()) {
     this->reactor_task_->stop();

--- a/dds/DCPS/transport/framework/TransportImpl.h
+++ b/dds/DCPS/transport/framework/TransportImpl.h
@@ -300,6 +300,7 @@ private:
 
   /// smart ptr to the associated DL cleanup task
   EventDispatcher_rch event_dispatcher_;
+  bool owns_event_dispatcher_;
 
   /// Monitor object for this entity
   unique_ptr<Monitor> monitor_;

--- a/dds/DCPS/transport/framework/TransportInst.cpp
+++ b/dds/DCPS/transport/framework/TransportInst.cpp
@@ -79,6 +79,7 @@ TransportInst::dump_to_str(DDS::DomainId_t) const
   ret += formatNameForDump("max_samples_per_packet")  + to_dds_string(unsigned(max_samples_per_packet())) + '\n';
   ret += formatNameForDump("optimum_packet_size")     + to_dds_string(unsigned(optimum_packet_size())) + '\n';
   ret += formatNameForDump("thread_per_connection")   + (thread_per_connection() ? "true" : "false") + '\n';
+  ret += formatNameForDump("event_dispatcher_threads") + to_dds_string(unsigned(event_dispatcher_threads())) + '\n';
   ret += formatNameForDump("datalink_release_delay")  + to_dds_string(datalink_release_delay()) + '\n';
   ret += formatNameForDump("datalink_control_chunks") + to_dds_string(unsigned(datalink_control_chunks())) + '\n';
   ret += formatNameForDump("fragment_reassembly_timeout") + fragment_reassembly_timeout().str() + '\n';
@@ -149,6 +150,20 @@ bool
 TransportInst::thread_per_connection() const
 {
   return TheServiceParticipant->config_store()->get_boolean(config_key("THREAD_PER_CONNECTION").c_str(), false);
+}
+
+void
+TransportInst::event_dispatcher_threads(size_t edt)
+{
+  TheServiceParticipant->config_store()->set_uint32(config_key("EVENT_DISPATCHER_THREADS").c_str(),
+                                                    static_cast<DDS::UInt32>(edt));
+}
+
+size_t
+TransportInst::event_dispatcher_threads() const
+{
+  return TheServiceParticipant->config_store()->get_uint32(config_key("EVENT_DISPATCHER_THREADS").c_str(),
+                                                           static_cast<DDS::UInt32>(DEFAULT_EVENT_DISPATCHER_THREADS));
 }
 
 void

--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -62,6 +62,7 @@ public:
 
   static const long DEFAULT_DATALINK_RELEASE_DELAY = 10000;
   static const size_t DEFAULT_DATALINK_CONTROL_CHUNKS = 32u;
+  static const size_t DEFAULT_EVENT_DISPATCHER_THREADS = 1u;
 
   const String& name() const { return name_; }
   const String& config_prefix() const { return config_prefix_; }
@@ -98,6 +99,11 @@ public:
   /// send without backpressure.
   void thread_per_connection(bool tpc);
   bool thread_per_connection() const;
+
+  /// Number of threads used by this transport's EventDispatcher.
+  /// A value of 0 reuses the Service_Participant EventDispatcher.
+  void event_dispatcher_threads(size_t edt);
+  size_t event_dispatcher_threads() const;
 
   /// Delay in milliseconds that the datalink should be released after all
   /// associations are removed. The default value is 10 seconds.

--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -62,7 +62,7 @@ public:
 
   static const long DEFAULT_DATALINK_RELEASE_DELAY = 10000;
   static const size_t DEFAULT_DATALINK_CONTROL_CHUNKS = 32u;
-  static const size_t DEFAULT_EVENT_DISPATCHER_THREADS = 0u;
+  static const size_t DEFAULT_EVENT_DISPATCHER_THREADS = 1u;
 
   const String& name() const { return name_; }
   const String& config_prefix() const { return config_prefix_; }

--- a/dds/DCPS/transport/framework/TransportInst.h
+++ b/dds/DCPS/transport/framework/TransportInst.h
@@ -62,7 +62,7 @@ public:
 
   static const long DEFAULT_DATALINK_RELEASE_DELAY = 10000;
   static const size_t DEFAULT_DATALINK_CONTROL_CHUNKS = 32u;
-  static const size_t DEFAULT_EVENT_DISPATCHER_THREADS = 1u;
+  static const size_t DEFAULT_EVENT_DISPATCHER_THREADS = 0u;
 
   const String& name() const { return name_; }
   const String& config_prefix() const { return config_prefix_; }

--- a/dds/DCPS/transport/multicast/BestEffortSession.cpp
+++ b/dds/DCPS/transport/multicast/BestEffortSession.cpp
@@ -71,6 +71,7 @@ BestEffortSession::start(bool active, bool /*acked*/)
 
   if (this->started_) return true;  // already started
 
+  reset_stopped();
   this->active_ = active;
   set_acked();
 

--- a/dds/DCPS/transport/multicast/MulticastSession.cpp
+++ b/dds/DCPS/transport/multicast/MulticastSession.cpp
@@ -38,6 +38,7 @@ MulticastSession::MulticastSession(RcHandle<EventDispatcher> event_dispatcher,
   , active_(true)
   , reassembly_(link->config()->fragment_reassembly_timeout())
   , acked_(false)
+  , stopped_(false)
   , syn_watchdog_(make_rch<SporadicEvent>(event_dispatcher,
                                           make_rch<MulticastSessionEvent>(rchandle_from(this),
                                                                           &MulticastSession::send_all_syn)))
@@ -67,6 +68,9 @@ MulticastSession::set_acked()
 void
 MulticastSession::start_syn()
 {
+  if (is_stopped()) {
+    return;
+  }
   syn_watchdog_->cancel();
   syn_delay_ = initial_syn_delay_;
   syn_watchdog_->schedule(TimeDuration(0));
@@ -75,6 +79,9 @@ MulticastSession::start_syn()
 void
 MulticastSession::send_control(char submessage_id, Message_Block_Ptr data)
 {
+  if (is_stopped()) {
+    return;
+  }
   DataSampleHeader header;
   Message_Block_Ptr control(this->link_->create_control(submessage_id, header, OPENDDS_MOVE_NS::move(data)));
   if (!control) {
@@ -100,6 +107,10 @@ bool
 MulticastSession::control_received(char submessage_id,
                                    const Message_Block_Ptr& control)
 {
+  if (is_stopped()) {
+    return true;
+  }
+
   switch (submessage_id) {
   case MULTICAST_SYN:
     syn_received(control);
@@ -119,7 +130,7 @@ MulticastSession::control_received(char submessage_id,
 void
 MulticastSession::syn_received(const Message_Block_Ptr& control)
 {
-  if (this->active_) return; // pub send syn, then doesn't receive them.
+  if (is_stopped() || this->active_) return; // pub send syn, then doesn't receive them.
 
   const TransportHeader& header =
     this->link_->receive_strategy()->received_header();
@@ -189,6 +200,10 @@ MulticastSession::syn_received(const Message_Block_Ptr& control)
 void
 MulticastSession::send_all_syn()
 {
+  if (is_stopped()) {
+    return;
+  }
+
   ACE_GUARD(ACE_SYNCH_MUTEX, guard, this->ack_lock_);
   for (PendingRemoteMap::const_iterator pos1 = pending_remote_map_.begin(), limit1 = pending_remote_map_.end();
        pos1 != limit1; ++pos1) {
@@ -201,7 +216,9 @@ MulticastSession::send_all_syn()
 
   // Exponential back-off.
   syn_delay_ *= 2;
-  syn_watchdog_->schedule(syn_delay_);
+  if (!is_stopped()) {
+    syn_watchdog_->schedule(syn_delay_);
+  }
 }
 
 void
@@ -237,7 +254,7 @@ MulticastSession::send_syn(const GUID_t& local_writer,
 void
 MulticastSession::synack_received(const Message_Block_Ptr& control)
 {
-  if (!this->active_) return; // sub send synack, then doesn't receive them.
+  if (is_stopped() || !this->active_) return; // sub send synack, then doesn't receive them.
 
   // Already received ack.
   //if (this->acked()) return;
@@ -317,6 +334,7 @@ MulticastSession::send_synack(const GUID_t& local_reader,
 void
 MulticastSession::stop()
 {
+  stopped_ = true;
   this->syn_watchdog_->cancel();
 }
 
@@ -332,6 +350,10 @@ MulticastSession::reassemble(ReceivedDataSample& data,
 void
 MulticastSession::add_remote(const GUID_t& local)
 {
+  if (is_stopped()) {
+    return;
+  }
+
   const GuidConverter conv(local);
   if (conv.isWriter()) {
     // Active peers schedule a watchdog timer to initiate a 2-way
@@ -347,6 +369,10 @@ void
 MulticastSession::add_remote(const GUID_t& local,
                              const GUID_t& remote)
 {
+  if (is_stopped()) {
+    return;
+  }
+
   const GuidConverter conv(local);
 
   {

--- a/dds/DCPS/transport/multicast/MulticastSession.h
+++ b/dds/DCPS/transport/multicast/MulticastSession.h
@@ -16,6 +16,7 @@
 #include "ace/Message_Block.h"
 #include "ace/Synch_Traits.h"
 
+#include "dds/DCPS/AtomicBool.h"
 #include "dds/DCPS/RcObject.h"
 #include "dds/DCPS/EventDispatcher.h"
 #include "dds/DCPS/transport/framework/TransportHeader.h"
@@ -92,6 +93,16 @@ protected:
 
   virtual void syn_hook(const SequenceNumber& /*seq*/) {}
 
+  bool is_stopped() const
+  {
+    return stopped_;
+  }
+
+  void reset_stopped()
+  {
+    stopped_ = false;
+  }
+
   ACE_Thread_Mutex start_lock_;
   typedef ACE_Reverse_Lock<ACE_Thread_Mutex> Reverse_Lock_t;
   Reverse_Lock_t reverse_start_lock_;
@@ -121,6 +132,7 @@ private:
 
 
   ACE_Thread_Mutex ack_lock_;
+  AtomicBool stopped_;
 
   typedef PmfEvent<MulticastSession> MulticastSessionEvent;
   SporadicEvent_rch syn_watchdog_;

--- a/dds/DCPS/transport/multicast/ReliableSession.cpp
+++ b/dds/DCPS/transport/multicast/ReliableSession.cpp
@@ -15,7 +15,6 @@
 #include "ace/Truncate.h"
 
 #include "dds/DCPS/GuidConverter.h"
-#include "dds/DCPS/ReactorEvent.h"
 #include "dds/DCPS/Serializer.h"
 #include "dds/DCPS/TimeTypes.h"
 
@@ -36,10 +35,11 @@ ReliableSession::ReliableSession(RcHandle<EventDispatcher> event_dispatcher,
                                  MulticastDataLink* link,
                                  MulticastPeer remote_peer)
   : MulticastSession(event_dispatcher, link, remote_peer)
+  , nak_process_event_(make_rch<ReactorEvent>(reactor,
+                                              make_rch<ReliableSessionEvent>(rchandle_from(this),
+                                                                             &ReliableSession::process_naks)))
   , nak_watchdog_(make_rch<SporadicEvent>(event_dispatcher,
-                                          make_rch<ReactorEvent>(reactor,
-                                                                 make_rch<ReliableSessionEvent>(rchandle_from(this),
-                                                                                                &ReliableSession::process_naks))))
+                                          nak_process_event_))
   , nak_timeout_(link->config()->nak_timeout())
   , nak_delay_intervals_(link->config()->nak_delay_intervals())
   , nak_max_(link->config()->nak_max())
@@ -49,6 +49,7 @@ ReliableSession::ReliableSession(RcHandle<EventDispatcher> event_dispatcher,
 ReliableSession::~ReliableSession()
 {
   nak_watchdog_->cancel();
+  nak_process_event_->disable();
 }
 
 bool
@@ -656,6 +657,7 @@ ReliableSession::start(bool active, bool acked)
     return true;  // already started
   }
 
+  reset_stopped();
   this->active_  = active;
   {
     //can't call accept_datalink while holding lock due to possible reactor deadlock with passive_connection
@@ -680,6 +682,7 @@ void
 ReliableSession::stop()
 {
   MulticastSession::stop();
+  nak_process_event_->disable();
   this->nak_watchdog_->cancel();
 }
 
@@ -698,6 +701,10 @@ ReliableSession::nak_delay()
 void
 ReliableSession::process_naks()
 {
+  if (is_stopped()) {
+    return;
+  }
+
   // Expire outstanding repair requests that have not yet been
   // fulfilled; this prevents NAK implosions due to remote
   // peers becoming unresponsive:
@@ -707,7 +714,9 @@ ReliableSession::process_naks()
   // to remote peers from which we are missing data:
   send_naks();
 
-  nak_watchdog_->schedule(nak_delay());
+  if (!is_stopped()) {
+    nak_watchdog_->schedule(nak_delay());
+  }
 }
 
 } // namespace DCPS

--- a/dds/DCPS/transport/multicast/ReliableSession.h
+++ b/dds/DCPS/transport/multicast/ReliableSession.h
@@ -17,6 +17,7 @@
 
 #include "dds/DCPS/DisjointSequence.h"
 #include "dds/DCPS/PoolAllocator.h"
+#include "dds/DCPS/ReactorEvent.h"
 #include "dds/DCPS/RcEventHandler.h"
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -62,6 +63,7 @@ public:
 
 private:
   typedef PmfEvent<ReliableSession> ReliableSessionEvent;
+  RcHandle<ReactorEvent> nak_process_event_;
   SporadicEvent_rch nak_watchdog_;
   TimeDuration nak_delay();
   void process_naks();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -428,22 +428,35 @@ RtpsUdpDataLink::open(const ACE_SOCK_Dgram& unicast_socket
 
 void RtpsUdpDataLink::on_data_available(RcHandle<InternalDataReader<NetworkInterfaceAddress> >)
 {
+  const RtpsUdpTransport_rch tport = transport();
+  if (!tport || tport->is_shut_down()) {
+    return;
+  }
+
   event_dispatcher_->dispatch(network_interface_updates_event_);
 }
 
 void RtpsUdpDataLink::handle_network_interface_updates()
 {
+  const RtpsUdpTransport_rch tport = transport();
+  if (!tport || tport->is_shut_down()) {
+    return;
+  }
+
+  const RcHandle<InternalDataReader<NetworkInterfaceAddress> > reader = network_interface_address_reader_;
+  if (!reader) {
+    return;
+  }
+
   InternalDataReader<NetworkInterfaceAddress>::SampleSequence samples;
   InternalSampleInfoSequence infos;
 
-  network_interface_address_reader_->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
+  reader->take(samples, infos, DDS::LENGTH_UNLIMITED, DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
 
   RtpsUdpInst_rch cfg = config();
   if (!cfg || !cfg->use_multicast()) {
     return;
   }
-
-  RtpsUdpTransport_rch tport = transport();
 
   multicast_manager_.process(samples,
                              infos,
@@ -1004,6 +1017,10 @@ RtpsUdpDataLink::release_reservations_i(const GUID_t& remote_id,
 void
 RtpsUdpDataLink::stop_i()
 {
+  InternalDataReaderListener<NetworkInterfaceAddress>::job_queue(JobQueue_rch());
+  if (network_interface_updates_event_) {
+    network_interface_updates_event_->disable();
+  }
   TheServiceParticipant->network_interface_address_topic()->disconnect(network_interface_address_reader_);
 
   heartbeat_->disable();

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -755,6 +755,7 @@ RtpsUdpTransport::shutdown_i()
   relay_stun_event_->cancel();
 #endif
 
+  ConfigListener::job_queue(JobQueue_rch());
   if (config_reader_) {
     TheServiceParticipant->config_topic()->disconnect(config_reader_);
     config_reader_.reset();
@@ -776,8 +777,12 @@ RtpsUdpTransport::release_datalink(DataLink* /*link*/)
 }
 
 void
-RtpsUdpTransport::on_data_available(ConfigReader_rch)
+RtpsUdpTransport::on_data_available(ConfigReader_rch reader)
 {
+  if (is_shut_down()) {
+    return;
+  }
+
   const RtpsUdpInst_rch cfg = config();
   OPENDDS_ASSERT(cfg);
   const String& config_prefix = cfg->config_prefix();
@@ -785,8 +790,11 @@ RtpsUdpTransport::on_data_available(ConfigReader_rch)
 
   DCPS::InternalDataReader<ConfigPair>::SampleSequence samples;
   DCPS::InternalSampleInfoSequence infos;
-  config_reader_->take(samples, infos, DDS::LENGTH_UNLIMITED,
-                       DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE);
+  if (!reader) {
+    return;
+  }
+  reader->take(samples, infos, DDS::LENGTH_UNLIMITED,
+               DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ALIVE_INSTANCE_STATE);
   for (size_t idx = 0; idx != samples.size(); ++idx) {
     const ConfigPair& sample = samples[idx];
 

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -479,6 +479,7 @@ For example:
 
     Number of threads used by the process-wide ``EventDispatcher`` created by ``Service_Participant``.
     This dispatcher is used by OpenDDS internal services and must always have at least one thread.
+    Note: This value is currently only read and used at startup for EventDispatcher creation.
 
   .. prop:: DCPSGlobalTransportConfig=<name>|$file
     :default: The default configuration is used as described in :ref:`run_time_configuration--overview`.
@@ -2444,6 +2445,7 @@ See :ref:`plugins` for more information.
     Number of threads used by the transport instance's ``EventDispatcher``.
     Set this to ``0`` to reuse the global ``Service_Participant`` event dispatcher instead of creating a transport-local dispatcher.
     This can reduce thread counts when a process contains many transport instances.
+    Note: This value is currently only read and used at startup for EventDispatcher creation.
 
   .. prop:: datalink_release_delay=<msec>
     :default: ``10000`` (10 sec)

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -474,6 +474,12 @@ For example:
 
     See :ref:`config-disc` for details about configuring discovery.
 
+  .. prop:: DCPSEventDispatcherThreads=<n>
+    :default: ``1``
+
+    Number of threads used by the process-wide ``EventDispatcher`` created by ``Service_Participant``.
+    This dispatcher is used by OpenDDS internal services and must always have at least one thread.
+
   .. prop:: DCPSGlobalTransportConfig=<name>|$file
     :default: The default configuration is used as described in :ref:`run_time_configuration--overview`.
 
@@ -2431,6 +2437,13 @@ See :ref:`plugins` for more information.
     This option will increase performance when writing to multiple data readers on different process as long as the overhead of thread context switching does not outweigh the benefits of parallel writes.
     This balance of network performance to context switching overhead is best determined by experimenting.
     If a machine has multiple network cards, it may improve performance by creating a transport for each network card.
+
+  .. prop:: event_dispatcher_threads=<n>
+    :default: ``1``
+
+    Number of threads used by the transport instance's ``EventDispatcher``.
+    Set this to ``0`` to reuse the global ``Service_Participant`` event dispatcher instead of creating a transport-local dispatcher.
+    This can reduce thread counts when a process contains many transport instances.
 
   .. prop:: datalink_release_delay=<msec>
     :default: ``10000`` (10 sec)

--- a/docs/news.d/event-dispatcher-thread-config.rst
+++ b/docs/news.d/event-dispatcher-thread-config.rst
@@ -1,0 +1,7 @@
+.. news-prs: 5208
+
+.. news-start-section: Additions
+- Added ``DCPSEventDispatcherThreads`` and transport ``event_dispatcher_threads`` runtime-configuration options to control ``EventDispatcher`` thread counts.
+  Setting transport ``event_dispatcher_threads=0`` reuses the global dispatcher instead of creating a transport-local dispatcher.
+
+.. news-end-section

--- a/tests/DCPS/ConfigFile/ConfigFile.cpp
+++ b/tests/DCPS/ConfigFile/ConfigFile.cpp
@@ -56,6 +56,7 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     TEST_CHECK(TheServiceParticipant->publisher_content_filter() == false);
     TEST_CHECK(TheServiceParticipant->get_default_discovery() == "MyDefaultDiscovery");
     TEST_CHECK(TheServiceParticipant->default_address() == NetworkAddress(u_short(0), "127.0.0.1"));
+    TEST_CHECK(TheServiceParticipant->event_dispatcher_thread_count() == 4);
     TEST_CHECK(TheServiceParticipant->federation_recovery_duration() == 800);
     TEST_CHECK(TheServiceParticipant->federation_initial_backoff_seconds() == 2);
     TEST_CHECK(TheServiceParticipant->federation_backoff_multiplier() == 3);
@@ -74,6 +75,7 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     TEST_CHECK(tcp_inst->max_samples_per_packet() == 3);
     TEST_CHECK(tcp_inst->optimum_packet_size() == 2048);
     TEST_CHECK(tcp_inst->thread_per_connection() == true);
+    TEST_CHECK(tcp_inst->event_dispatcher_threads() == 3);
     TEST_CHECK(tcp_inst->datalink_release_delay() == 5000);
     TEST_CHECK(tcp_inst->datalink_control_chunks() == 16);
     TEST_CHECK(tcp_inst->local_address() == "localhost:");
@@ -87,6 +89,13 @@ ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     TransportInst_rch inst2 = TransportRegistry::instance()->get_inst("anothertcp");
     TEST_CHECK(inst2);
     TEST_CHECK(inst2->name() == "anothertcp");
+    TEST_CHECK(inst2->event_dispatcher_threads() == 0);
+
+    const EventDispatcher_rch global_event_dispatcher =
+      TheServiceParticipant->event_dispatcher();
+    TEST_CHECK(global_event_dispatcher);
+    TEST_CHECK(tcp_inst->event_dispatcher(0, GUID_UNKNOWN) != global_event_dispatcher);
+    TEST_CHECK(inst2->event_dispatcher(0, GUID_UNKNOWN) == global_event_dispatcher);
 
     TransportConfig_rch config = TransportRegistry::instance()->get_config("myconfig");
     TEST_CHECK(config);

--- a/tests/DCPS/ConfigFile/test1.ini
+++ b/tests/DCPS/ConfigFile/test1.ini
@@ -15,6 +15,7 @@ DCPSPendingTimeout=10
 DCPSPublisherContentFilter=0
 DCPSDefaultDiscovery=MyDefaultDiscovery
 DCPSDefaultAddress=127.0.0.1
+DCPSEventDispatcherThreads=4
 FederationRecoveryDuration=800
 FederationInitialBackoffSeconds=2
 FederationBackoffMultiplier=3
@@ -32,6 +33,7 @@ max_packet_size=2000000000
 max_samples_per_packet=3
 optimum_packet_size=2048
 thread_per_connection=1
+event_dispatcher_threads=3
 datalink_release_delay=5000
 datalink_control_chunks=16
 local_address=localhost:
@@ -43,6 +45,7 @@ passive_reconnect_duration=4000
 max_output_pause_period=1000
 [transport/anothertcp]
 transport_type=tcp
+event_dispatcher_threads=0
 [transport/tcp1]
 transport_type=tcp
 [transport/tcp2]

--- a/tests/DCPS/ConfigFile/test1_nobits.ini
+++ b/tests/DCPS/ConfigFile/test1_nobits.ini
@@ -15,6 +15,7 @@ DCPSPendingTimeout=10
 DCPSPublisherContentFilter=0
 DCPSDefaultDiscovery=MyDefaultDiscovery
 DCPSDefaultAddress=127.0.0.1
+DCPSEventDispatcherThreads=4
 FederationRecoveryDuration=800
 FederationInitialBackoffSeconds=2
 FederationBackoffMultiplier=3
@@ -32,6 +33,7 @@ max_packet_size=2000000000
 max_samples_per_packet=3
 optimum_packet_size=2048
 thread_per_connection=1
+event_dispatcher_threads=3
 datalink_release_delay=5000
 datalink_control_chunks=16
 local_address=localhost:
@@ -43,6 +45,7 @@ passive_reconnect_duration=4000
 max_output_pause_period=1000
 [transport/anothertcp]
 transport_type=tcp
+event_dispatcher_threads=0
 [transport/tcp1]
 transport_type=tcp
 [transport/tcp2]

--- a/tests/unit-tests/dds/DCPS/Service_Participant.cpp
+++ b/tests/unit-tests/dds/DCPS/Service_Participant.cpp
@@ -13,3 +13,19 @@ TEST(dds_DCPS_Service_Participant, type_object_encoding) {
   sp.type_object_encoding("ReadOldFormat");
   EXPECT_EQ(sp.type_object_encoding(), Service_Participant::Encoding_ReadOldFormat);
 }
+
+TEST(dds_DCPS_Service_Participant, event_dispatcher_thread_count)
+{
+  Service_Participant sp;
+
+  EXPECT_EQ(sp.event_dispatcher_thread_count(), COMMON_DCPS_EVENT_DISPATCHER_THREADS_default);
+
+  sp.event_dispatcher_thread_count(4);
+  EXPECT_EQ(sp.event_dispatcher_thread_count(), 4u);
+
+  sp.event_dispatcher_thread_count(0);
+  EXPECT_EQ(sp.event_dispatcher_thread_count(), COMMON_DCPS_EVENT_DISPATCHER_THREADS_default);
+
+  sp.config_store()->set_uint32(COMMON_DCPS_EVENT_DISPATCHER_THREADS, 0);
+  EXPECT_EQ(sp.event_dispatcher_thread_count(), COMMON_DCPS_EVENT_DISPATCHER_THREADS_default);
+}


### PR DESCRIPTION
Problems:
 - EventDispatcher thread counts were hard-coded at one for both global and per-transport EventDispatcher instances. This doesn't allow much control over thread creation.

Solution:
 - Add two configuration flags:
   - DCPSEventDispatcherThreads - specify the number of threads created by the global (Service_Participant) EventDispatcher instance. Default and minimum value remains one.
   - event_dispatcher_threads (per transport) - specify the number of threads created by the transport instance's EventDispatcher instance. Defaults to one. A value of zero replaces use of the local per-transport EventDispatcher instance with use of the global (Service_Participant) EventDispatcher instance.