### PR TITLE
Improve RtpsSampleHeader Length Checking

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
@@ -160,7 +160,8 @@ RtpsSampleHeader::init(ACE_Message_Block& mb)
 #undef CASE_SMKIND
 
   if (valid_) {
-    if (message_length_ < SMHDR_SZ) {
+    const size_t available_size = message_length_ ? message_length_ : starting_length;
+    if (available_size < SMHDR_SZ) {
       valid_ = false;
       return;
     }
@@ -171,13 +172,13 @@ RtpsSampleHeader::init(ACE_Message_Block& mb)
     // serialized_size_ is # of bytes of submessage we have read from "mb"
     serialized_size_ = starting_length - mb.total_length();
 
-    const ACE_CDR::UShort remaining = static_cast<ACE_CDR::UShort>(message_length_ - SMHDR_SZ);
+    const size_t remaining = available_size - SMHDR_SZ;
 
     if (octetsToNextHeader == 0 && kind != PAD && kind != INFO_TS) {
       // see RTPS v2.1 section 9.4.5.1.3
       // In this case the current Submessage extends to the end of Message,
       // so we will use the message_length_ that was set in pdu_remaining().
-      octetsToNextHeader = remaining;
+      octetsToNextHeader = static_cast<ACE_CDR::UShort>(remaining);
 
     } else if (octetsToNextHeader > remaining) {
       valid_ = false;

--- a/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
@@ -38,11 +38,6 @@ namespace {
     STATUS_INFO_DISPOSE = { { 0, 0, 0, 1 } },
     STATUS_INFO_UNREGISTER = { { 0, 0, 0, 2 } },
     STATUS_INFO_DISPOSE_UNREGISTER = { { 0, 0, 0, 3 } };
-
-  bool has_valid_cursor(const ACE_Message_Block& mb)
-  {
-    return mb.rd_ptr() && mb.wr_ptr() && mb.rd_ptr() <= mb.wr_ptr();
-  }
 }
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -64,6 +59,12 @@ operator==(const StatusInfo_t& lhs, const StatusInfo_t& rhs)
 
 }
 namespace DCPS {
+
+bool
+RtpsSampleHeader::has_valid_cursor(const ACE_Message_Block& mb)
+{
+  return mb.rd_ptr() && mb.wr_ptr() && mb.rd_ptr() <= mb.wr_ptr();
+}
 
 void
 RtpsSampleHeader::init(ACE_Message_Block& mb)

--- a/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
@@ -74,21 +74,30 @@ RtpsSampleHeader::init(ACE_Message_Block& mb)
   // valid_ is false here, it will only be set to true if there is a Submessage
 
   // Do not trust length() when rd_ptr() has already been advanced out of range.
-  if (!has_valid_cursor(mb)) {
+  ACE_Message_Block* mb_ptr = &mb;
+  while (mb_ptr) {
+    if (!has_valid_cursor(*mb_ptr)) {
+      return;
+    }
+    mb_ptr = mb_ptr->cont();
+  }
+
+  const size_t starting_length = mb.total_length();
+
+  if (starting_length < SMHDR_SZ) {
     return;
   }
 
   const size_t contiguous_length = static_cast<size_t>(mb.wr_ptr() - mb.rd_ptr());
-  if (contiguous_length == 0 || mb.total_length() < SMHDR_SZ) {
-    return;
-  }
 
   // Manually grab the first two bytes for the SubmessageKind and the byte order.
+
+  // The first byte is SubmessageKind
   const SubmessageKind kind =
     static_cast<SubmessageKind>(static_cast<ACE_CDR::Octet>(*mb.rd_ptr()));
 
+  // The second byte is flags
   ACE_CDR::Octet flags = 0;
-
   if (contiguous_length > 1) {
     flags = static_cast<ACE_CDR::Octet>(mb.rd_ptr()[1]);
   } else if (mb.cont() && mb.cont()->length() > 0) {
@@ -97,7 +106,6 @@ RtpsSampleHeader::init(ACE_Message_Block& mb)
     return;
   }
 
-  const size_t starting_length = mb.total_length();
   Serializer ser(&mb, Encoding::KIND_XCDR1,
     (flags & FLAG_E) ? ENDIAN_LITTLE : ENDIAN_BIG);
 

--- a/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
@@ -38,6 +38,11 @@ namespace {
     STATUS_INFO_DISPOSE = { { 0, 0, 0, 1 } },
     STATUS_INFO_UNREGISTER = { { 0, 0, 0, 2 } },
     STATUS_INFO_DISPOSE_UNREGISTER = { { 0, 0, 0, 3 } };
+
+  bool has_valid_cursor(const ACE_Message_Block& mb)
+  {
+    return mb.rd_ptr() && mb.wr_ptr() && mb.rd_ptr() <= mb.wr_ptr();
+  }
 }
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -67,16 +72,23 @@ RtpsSampleHeader::init(ACE_Message_Block& mb)
 
   // valid_ is false here, it will only be set to true if there is a Submessage
 
-  // Manually grab the first two bytes for the SubmessageKind and the byte order
-  if (mb.length() == 0) {
+  // Do not trust length() when rd_ptr() has already been advanced out of range.
+  if (!has_valid_cursor(mb)) {
     return;
   }
 
-  const SubmessageKind kind = static_cast<SubmessageKind>(*mb.rd_ptr());
+  const size_t contiguous_length = static_cast<size_t>(mb.wr_ptr() - mb.rd_ptr());
+  if (contiguous_length == 0 || mb.total_length() < SMHDR_SZ) {
+    return;
+  }
+
+  // Manually grab the first two bytes for the SubmessageKind and the byte order.
+  const SubmessageKind kind =
+    static_cast<SubmessageKind>(static_cast<ACE_CDR::Octet>(*mb.rd_ptr()));
 
   ACE_CDR::Octet flags = 0;
 
-  if (mb.length() > 1) {
+  if (contiguous_length > 1) {
     flags = static_cast<ACE_CDR::Octet>(mb.rd_ptr()[1]);
   } else if (mb.cont() && mb.cont()->length() > 0) {
     flags = static_cast<ACE_CDR::Octet>(mb.cont()->rd_ptr()[0]);
@@ -148,6 +160,10 @@ RtpsSampleHeader::init(ACE_Message_Block& mb)
 #undef CASE_SMKIND
 
   if (valid_) {
+    if (message_length_ < SMHDR_SZ) {
+      valid_ = false;
+      return;
+    }
 
     frag_ = (kind == DATA_FRAG);
     data_ = (kind == DATA);

--- a/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.h
@@ -100,6 +100,8 @@ public:
   static FragmentNumber last_fragment(const RTPS::DataFragSubmessage& df);
   static ACE_UINT32 total_fragments(const RTPS::DataFragSubmessage& df);
 
+  static bool has_valid_cursor(const ACE_Message_Block& mb);
+
 private:
   static void process_iqos(DataSampleHeader& opendds,
                            const RTPS::ParameterList& iqos);

--- a/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.inl
+++ b/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.inl
@@ -37,8 +37,8 @@ RtpsSampleHeader::operator=(ACE_Message_Block& mb)
   valid_ = false;
   frag_ = false;
   data_ = false;
+  serialized_size_ = 0;
   // message_length_ should not be reset here
-  // serialized_size_ doesn't need to be reset, init() will set it (if valid_)
   init(mb);
   return *this;
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -32,6 +32,13 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
+namespace {
+  bool has_valid_cursor(const ACE_Message_Block& mb)
+  {
+    return mb.rd_ptr() && mb.wr_ptr() && mb.rd_ptr() <= mb.wr_ptr();
+  }
+}
+
 RtpsUdpReceiveStrategy::RtpsUdpReceiveStrategy(RtpsUdpDataLink* link,
                                                const GuidPrefix_t& local_prefix,
                                                ThreadStatusManager& thread_status_manager)
@@ -154,8 +161,16 @@ RtpsUdpReceiveStrategy::handle_input(ACE_HANDLE fd)
     while (bytes_remaining_unsigned > 0) {
       data_sample_header_.pdu_remaining(bytes_remaining_unsigned);
       data_sample_header_ = *cur_rb;
-      bytes_remaining_unsigned -= static_cast<ACE_UINT32>(data_sample_header_.get_serialized_size());
       if (!check_header(data_sample_header_)) {
+        return 0;
+      }
+      const ACE_UINT32 serialized_size = static_cast<ACE_UINT32>(data_sample_header_.get_serialized_size());
+      if (!has_valid_cursor(*cur_rb) || serialized_size > bytes_remaining_unsigned) {
+        return 0;
+      }
+      bytes_remaining_unsigned -= serialized_size;
+      const ACE_UINT32 message_length = data_sample_header_.message_length();
+      if (message_length > bytes_remaining_unsigned) {
         return 0;
       }
       ReceivedDataSample rds = data_sample_header_.message_length() ? ReceivedDataSample(*cur_rb) : ReceivedDataSample();
@@ -175,8 +190,8 @@ RtpsUdpReceiveStrategy::handle_input(ACE_HANDLE fd)
           deliver_sample(rds, remote_address);
         }
       }
-      cur_rb->rd_ptr(data_sample_header_.message_length());
-      bytes_remaining_unsigned -= static_cast<ACE_UINT32>(data_sample_header_.message_length());
+      cur_rb->rd_ptr(message_length);
+      bytes_remaining_unsigned -= message_length;
 
       // For the reassembly algorithm, the 'last_fragment_' header bit only
       // applies to the first DataSampleHeader in the TransportHeader
@@ -1041,17 +1056,20 @@ RtpsUdpReceiveStrategy::check_header(const RtpsTransportHeader& header)
 bool
 RtpsUdpReceiveStrategy::check_header(const RtpsSampleHeader& header)
 {
+  if (!header.valid()) {
+    return false;
+  }
 
 #if OPENDDS_CONFIG_SECURITY
   if (secure_prefix_.smHeader.submessageId) {
-    return header.valid();
+    return true;
   }
 #endif
 
   receiver_.submsg(header.submessage_);
 
   // save fragmentation details for use in reassemble()
-  if (header.valid() && header.submessage_._d() == RTPS::DATA_FRAG) {
+  if (header.submessage_._d() == RTPS::DATA_FRAG) {
     const RTPS::DataFragSubmessage& rtps = header.submessage_.data_frag_sm();
     frags_.first = rtps.fragmentStartingNum.value;
     frags_.second = RtpsSampleHeader::last_fragment(rtps);
@@ -1059,7 +1077,7 @@ RtpsUdpReceiveStrategy::check_header(const RtpsSampleHeader& header)
     total_frags_ = RtpsSampleHeader::total_fragments(rtps);
   }
 
-  return header.valid();
+  return true;
 }
 
 void

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -32,13 +32,6 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace DCPS {
 
-namespace {
-  bool has_valid_cursor(const ACE_Message_Block& mb)
-  {
-    return mb.rd_ptr() && mb.wr_ptr() && mb.rd_ptr() <= mb.wr_ptr();
-  }
-}
-
 RtpsUdpReceiveStrategy::RtpsUdpReceiveStrategy(RtpsUdpDataLink* link,
                                                const GuidPrefix_t& local_prefix,
                                                ThreadStatusManager& thread_status_manager)
@@ -165,7 +158,7 @@ RtpsUdpReceiveStrategy::handle_input(ACE_HANDLE fd)
         return 0;
       }
       const ACE_UINT32 serialized_size = static_cast<ACE_UINT32>(data_sample_header_.get_serialized_size());
-      if (!has_valid_cursor(*cur_rb) || serialized_size > bytes_remaining_unsigned) {
+      if (!RtpsSampleHeader::has_valid_cursor(*cur_rb) || serialized_size > bytes_remaining_unsigned) {
         return 0;
       }
       bytes_remaining_unsigned -= serialized_size;

--- a/tests/unit-tests/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
+++ b/tests/unit-tests/dds/DCPS/transport/rtps_udp/RtpsSampleHeader.cpp
@@ -11,6 +11,8 @@
 
 #include <dds/DCPS/Message_Block_Ptr.h>
 
+#include <cstring>
+
 using namespace OpenDDS::DCPS;
 
 namespace {
@@ -103,3 +105,47 @@ TEST(dds_DCPS_transport_rtps_udp_RtpsSampleHeader, DataFragInvalidEnd)
   ASSERT_FALSE(rsh.valid());
 }
 
+TEST(dds_DCPS_transport_rtps_udp_RtpsSampleHeader, SubmessageHeaderTooShort)
+{
+  static const unsigned char x[] = {
+    0x15, 0x05, 0x28 // less than an RTPS submessage header
+  };
+  Message_Block_Ptr mb(array_to_mb(x));
+  RtpsSampleHeader rsh;
+  rsh.pdu_remaining(sizeof x);
+  rsh = *mb;
+  EXPECT_FALSE(rsh.valid());
+  EXPECT_EQ(0u, rsh.get_serialized_size());
+}
+
+TEST(dds_DCPS_transport_rtps_udp_RtpsSampleHeader, ReadPointerPastWritePointer)
+{
+  static const unsigned char valid[] = {
+    0x16,0x01,0x00,0x00, // Submessage Header: DATA_FRAG, FLAG_E, 0 octets to next hdr
+    0x00,0x00,0x1c,0x00, // extraFlags, octetsToInlineQoS
+    0x00,0x00,0x00,0x00, // readerId
+    0x00,0x01,0x02,0x03, // writerId
+    0x00,0x00,0x00,0x00, // seq#-high
+    0x01,0x00,0x00,0x00, // seq#-low
+    0x01,0x00,0x00,0x00, // frag#-start
+    0x01,0x00,0x00,0x04, // numFrags, fragSize
+    0x99,0x00,0x00,0x00, // sampleSize
+  };
+  Message_Block_Ptr valid_mb(array_to_mb(valid));
+  RtpsSampleHeader rsh;
+  rsh.pdu_remaining(0x99 + sizeof valid);
+  rsh = *valid_mb;
+  ASSERT_TRUE(rsh.valid());
+  ASSERT_LT(0u, rsh.get_serialized_size());
+
+  ACE_Message_Block invalid_mb(8);
+  std::memcpy(invalid_mb.wr_ptr(), valid, 4);
+  invalid_mb.wr_ptr(4);
+  invalid_mb.rd_ptr(invalid_mb.wr_ptr() + 1);
+  ASSERT_GT(invalid_mb.rd_ptr(), invalid_mb.wr_ptr());
+
+  rsh.pdu_remaining(4);
+  rsh = invalid_mb;
+  EXPECT_FALSE(rsh.valid());
+  EXPECT_EQ(0u, rsh.get_serialized_size());
+}


### PR DESCRIPTION
Problem:
 - RtpsSampleHeader was not consistently checking whether input message block's rd_ptr() was valid before reading bytes.

Solution:
 - Improve validity checking for deserialization