### PR TITLE
Broaden Reader Mutex Protection In RtpsUdpReceiveStrategy

### DIFF
--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -535,9 +535,10 @@ RtpsUdpReceiveStrategy::deliver_sample(ReceivedDataSample& sample,
 #if OPENDDS_CONFIG_SECURITY
   const SubmessageKind kind = rsh.submessage_._d();
 
+  ACE_Guard<ACE_Recursive_Thread_Mutex> guard(readers_mutex_);
+
   if (secure_prefix_.smHeader.submessageId == SEC_PREFIX && kind != SEC_POSTFIX) {
     // secure envelope in progress, defer processing
-    ACE_Guard<ACE_Recursive_Thread_Mutex> guard(readers_mutex_);
     secure_submessages_.push_back(rsh.submessage_);
     if (kind == DATA) {
       secure_sample_ = sample;


### PR DESCRIPTION
Problem:
 - Elsewhere, `secure_prefix_` is protected by `readers_mutex_`

Solution:
 - We probably ought to protect it within `deliver_sample` as well as what we're currently protecting.
 - And since `readers_mutex_` is recursive, it shouldn't hurt to hold it during our call to `deliver_sample_i` which also locks it.