### PR TITLE
DelayedDurable Lifetime Fix

### DIFF
--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -2125,6 +2125,13 @@ void finish_store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_da
 
   instance_ptr->last_sequence_ = header.sequence_;
 
+#ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
+  const bool coherent_change = ptr->coherent_change_;
+#endif
+
+  // After this point ptr is visible to take/read paths that can remove and
+  // release it while status notifications temporarily release sample_lock_.
+  ptr->inc_ref();
   instance_ptr->rcvd_strategy_->add(ptr);
 
   if (! is_dispose_msg  && ! is_unregister_msg
@@ -2159,11 +2166,13 @@ void finish_store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_da
     }
 
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
-  if (! ptr->coherent_change_) {
+  if (!coherent_change) {
 #endif
     RcHandle<OpenDDS::DCPS::SubscriberImpl> sub = get_subscriber_servant();
-    if (!sub || get_deleted())
+    if (!sub || get_deleted()) {
+      ptr->dec_ref();
       return;
+    }
 
     sub->set_status_changed_flag(DDS::DATA_ON_READERS_STATUS, true);
 
@@ -2202,6 +2211,7 @@ void finish_store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_da
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
   }
 #endif
+  ptr->dec_ref();
 }
 
 /// Release sample_lock_ during status notifications in store_instance_data()


### PR DESCRIPTION
Problem:
 - `finish_store_instance_data()` makes a newly-created `ReceivedDataElement* ptr` visible by adding it to `rcvd_strategy_`, then later releases `sample_lock_` while sending status notifications. During that unlocked window, a read/take path, especially a WaitSet-driven reader like DelayedDurable, could remove the same sample and drop its last ref. When `finish_store_instance_data()` resumed, it could still read `ptr->coherent_change_` or otherwise continue assuming `ptr` was alive, producing an intermittent use-after-free.

Solution:
 - give `finish_store_instance_data()` its own temporary reference to `ptr` before publishing it to the received-sample list, snapshot `coherent_change_` before the unlocked notification window, and release the temporary reference before returning. That keeps the sample alive until the receive path is done with it even if user/read/take code removes it concurrently during notification.