### PR TITLE
Fix for Coverity Issue 1571442

### DIFF
--- a/dds/DCPS/DataSampleHeader.cpp
+++ b/dds/DCPS/DataSampleHeader.cpp
@@ -398,8 +398,13 @@ DataSampleHeader::split(const ACE_Message_Block& orig, size_t size,
   for (; payload->length() == 0; payload = payload->cont()) {
     prev = payload;
   }
-  prev->cont(0);
-  Message_Block_Ptr payload_head(payload);
+  Message_Block_Ptr payload_head;
+  if (prev) {
+    prev->cont(0);
+    payload_head.reset(payload);
+  } else {
+    payload_head.reset(payload->duplicate());
+  }
 
   if (size < hdr_len) { // need to fragment the content_filter_entries_
     head.reset(alloc_msgblock(*dup, this_max_serialized_size, true));

--- a/tests/unit-tests/dds/DCPS/DataSampleHeader.cpp
+++ b/tests/unit-tests/dds/DCPS/DataSampleHeader.cpp
@@ -8,7 +8,7 @@ using namespace OpenDDS::DCPS;
 
 namespace {
 
-Message_Block_Ptr serialized_sample(const std::string& payload, size_t& header_len)
+void serialized_sample(const std::string& payload, size_t& header_len, Message_Block_Ptr& mb)
 {
   DataSampleHeader header;
   header.message_id_ = SAMPLE_DATA;
@@ -16,12 +16,10 @@ Message_Block_Ptr serialized_sample(const std::string& payload, size_t& header_l
   header.message_length_ = static_cast<ACE_UINT32>(payload.size());
   header.sequence_ = SequenceNumber(7);
 
-  Message_Block_Ptr mb(new ACE_Message_Block(
-    DataSampleHeader::get_max_serialized_size() + payload.size()));
+  mb.reset(new ACE_Message_Block(DataSampleHeader::get_max_serialized_size() + payload.size()));
   EXPECT_TRUE(*mb << header);
   header_len = mb->length();
   EXPECT_EQ(0, mb->copy(payload.data(), payload.size()));
-  return mb;
 }
 
 std::string message_block_data(const ACE_Message_Block* mb)
@@ -66,7 +64,8 @@ TEST(dds_DCPS_DataSampleHeader, split_header_and_payload_in_same_message_block)
 {
   const std::string payload = "abcdefghijklmnopqrstuvwxyz";
   size_t header_len = 0;
-  Message_Block_Ptr orig = serialized_sample(payload, header_len);
+  Message_Block_Ptr orig;
+  serialized_sample(payload, header_len, orig);
 
   Message_Block_Ptr head;
   Message_Block_Ptr tail;

--- a/tests/unit-tests/dds/DCPS/DataSampleHeader.cpp
+++ b/tests/unit-tests/dds/DCPS/DataSampleHeader.cpp
@@ -2,7 +2,52 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 using namespace OpenDDS::DCPS;
+
+namespace {
+
+Message_Block_Ptr serialized_sample(const std::string& payload, size_t& header_len)
+{
+  DataSampleHeader header;
+  header.message_id_ = SAMPLE_DATA;
+  header.submessage_id_ = SUBMESSAGE_NONE;
+  header.message_length_ = static_cast<ACE_UINT32>(payload.size());
+  header.sequence_ = SequenceNumber(7);
+
+  Message_Block_Ptr mb(new ACE_Message_Block(
+    DataSampleHeader::get_max_serialized_size() + payload.size()));
+  EXPECT_TRUE(*mb << header);
+  header_len = mb->length();
+  EXPECT_EQ(0, mb->copy(payload.data(), payload.size()));
+  return mb;
+}
+
+std::string message_block_data(const ACE_Message_Block* mb)
+{
+  std::string data;
+  for (const ACE_Message_Block* block = mb; block; block = block->cont()) {
+    data.append(block->rd_ptr(), block->length());
+  }
+  return data;
+}
+
+DataSampleHeader read_header(const Message_Block_Ptr& mb)
+{
+  Message_Block_Ptr dup(mb->duplicate());
+  return DataSampleHeader(*dup);
+}
+
+std::string payload_after_header(const Message_Block_Ptr& mb)
+{
+  Message_Block_Ptr dup(mb->duplicate());
+  const DataSampleHeader header(*dup);
+  ACE_UNUSED_ARG(header);
+  return message_block_data(dup.get());
+}
+
+}
 
 // Test DataSampleHeader::valid_data()
 TEST(dds_DCPS_DataSampleHeader, valid_data)
@@ -15,4 +60,29 @@ TEST(dds_DCPS_DataSampleHeader, valid_data)
     EXPECT_EQ(header.valid_data(), msg_id == SAMPLE_DATA)
       << "msg_id is " << to_string(msg_id);
   }
+}
+
+TEST(dds_DCPS_DataSampleHeader, split_header_and_payload_in_same_message_block)
+{
+  const std::string payload = "abcdefghijklmnopqrstuvwxyz";
+  size_t header_len = 0;
+  Message_Block_Ptr orig = serialized_sample(payload, header_len);
+
+  Message_Block_Ptr head;
+  Message_Block_Ptr tail;
+  const size_t head_payload_len = 10;
+  DataSampleHeader::split(*orig, header_len + head_payload_len, head, tail);
+
+  ASSERT_TRUE(head.get());
+  ASSERT_TRUE(tail.get());
+
+  const DataSampleHeader head_header = read_header(head);
+  EXPECT_TRUE(head_header.more_fragments_);
+  EXPECT_EQ(head_payload_len, head_header.message_length_);
+  EXPECT_EQ(payload.substr(0, head_payload_len), payload_after_header(head));
+
+  const DataSampleHeader tail_header = read_header(tail);
+  EXPECT_FALSE(tail_header.more_fragments_);
+  EXPECT_EQ(payload.size() - head_payload_len, tail_header.message_length_);
+  EXPECT_EQ(payload.substr(head_payload_len), payload_after_header(tail));
 }


### PR DESCRIPTION
Problem:
 - In `DataSampleHeader::split()`, the code could inadvertently wrap a raw pointer taken from an existing Message_Block_Ptr and use it to initialize a second second Message_Block_Ptr, specifically when the header and payload were in the same ACE_Message_Block, meaning that the two smart pointers could manage the same raw message block, leading to a crash.

Solution:
 - Check to make sure the raw pointer has advanced to the next message block, otherwise duplicate the message block for the new Message_Block_Ptr.