### PR TITLE
Fix for Coverity 1565993, Attempt 2

### DIFF
--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -1268,28 +1268,25 @@ Service_Participant::set_repo_domain(const DDS::DomainId_t domain,
 void
 Service_Participant::repository_lost(Discovery::RepoKey key)
 {
-  if (this->discoveryMap_.empty()) {
-    ACE_DEBUG((LM_WARNING,
-               ACE_TEXT("(%P|%t) WARNING: Service_Participant::repository_lost: ")
-               ACE_TEXT("no repositories are available to replace %C.\n"),
-               key.c_str()));
-    return;
-  }
+  bool reported_missing = false;
+  {
+    ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->maps_lock_);
+    if (this->discoveryMap_.empty()) {
+      ACE_DEBUG((LM_WARNING,
+                 ACE_TEXT("(%P|%t) WARNING: Service_Participant::repository_lost: ")
+                 ACE_TEXT("no repositories are available to replace %C.\n"),
+                 key.c_str()));
+      return;
+    }
 
-  // Find the lost repository.
-  RepoKeyDiscoveryMap::iterator initialLocation = this->discoveryMap_.find(key);
-  RepoKeyDiscoveryMap::iterator current         = initialLocation;
-
-  if (current == this->discoveryMap_.end()) {
-    ACE_DEBUG((LM_WARNING,
-               ACE_TEXT("(%P|%t) WARNING: Service_Participant::repository_lost: ")
-               ACE_TEXT("lost repository %C was not present, ")
-               ACE_TEXT("finding another anyway.\n"),
-               key.c_str()));
-
-  } else {
-    // Start with the repository *after* the lost one.
-    ++current;
+    if (this->discoveryMap_.find(key) == this->discoveryMap_.end()) {
+      ACE_DEBUG((LM_WARNING,
+                 ACE_TEXT("(%P|%t) WARNING: Service_Participant::repository_lost: ")
+                 ACE_TEXT("lost repository %C was not present, ")
+                 ACE_TEXT("finding another anyway.\n"),
+                 key.c_str()));
+      reported_missing = true;
+    }
   }
 
   // Calculate the bounding end time for attempts.
@@ -1301,75 +1298,120 @@ Service_Participant::repository_lost(Discovery::RepoKey key)
 
   // Keep trying until the total recovery time specified is exceeded.
   while (recoveryFailedTime > MonotonicTimePoint::now()) {
+    typedef OPENDDS_VECTOR(Discovery::RepoKey) RepoKeyList;
+    RepoKeyList candidates;
 
-    // Wrap to the beginning at the end of the list.
-    if (current == this->discoveryMap_.end()) {
-      // Continue to traverse the list.
-      current = this->discoveryMap_.begin();
-    }
+    {
+      ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->maps_lock_);
 
-    // Handle reaching the lost repository by waiting before trying
-    // again.
-    if (current == initialLocation) {
-      if (DCPS_debug_level > 0) {
-        ACE_DEBUG((LM_DEBUG,
-                   ACE_TEXT("(%P|%t) Service_Participant::repository_lost: ")
-                   ACE_TEXT("waiting %d seconds to traverse the ")
-                   ACE_TEXT("repository list another time ")
-                   ACE_TEXT("for lost key %C.\n"),
-                   backoff,
+      if (this->discoveryMap_.empty()) {
+        ACE_DEBUG((LM_WARNING,
+                   ACE_TEXT("(%P|%t) WARNING: Service_Participant::repository_lost: ")
+                   ACE_TEXT("no repositories are available to replace %C.\n"),
                    key.c_str()));
+        return;
       }
 
-      // Wait to traverse the list and try again.
-      ACE_OS::sleep(static_cast<unsigned int>(backoff));
+      // Find the lost repository.
+      const RepoKeyDiscoveryMap::const_iterator initialLocation = this->discoveryMap_.find(key);
 
-      // Exponentially backoff delay.
-      backoff *= this->federation_backoff_multiplier();
+      if (initialLocation == this->discoveryMap_.end()) {
+        if (!reported_missing) {
+          ACE_DEBUG((LM_WARNING,
+                     ACE_TEXT("(%P|%t) WARNING: Service_Participant::repository_lost: ")
+                     ACE_TEXT("lost repository %C was not present, ")
+                     ACE_TEXT("finding another anyway.\n"),
+                     key.c_str()));
+          reported_missing = true;
+        }
 
-      // Don't increment current to allow us to reattach to the
-      // original repository if it is restarted.
+        for (RepoKeyDiscoveryMap::const_iterator current = this->discoveryMap_.begin();
+             current != this->discoveryMap_.end(); ++current) {
+          candidates.push_back(current->first);
+        }
+
+      } else {
+        // Start with the repository *after* the lost one.
+        RepoKeyDiscoveryMap::const_iterator current = initialLocation;
+        ++current;
+
+        for (; current != this->discoveryMap_.end(); ++current) {
+          candidates.push_back(current->first);
+        }
+
+        for (current = this->discoveryMap_.begin(); current != initialLocation; ++current) {
+          candidates.push_back(current->first);
+        }
+
+        candidates.push_back(initialLocation->first);
+      }
     }
 
-    // Check the availability of the current repository.
-    if (current != this->discoveryMap_.end() && current->second->active()) {
-
-      if (DCPS_debug_level > 0) {
-        ACE_DEBUG((LM_DEBUG,
-                   ACE_TEXT("(%P|%t) Service_Participant::repository_lost: ")
-                   ACE_TEXT("replacing repository %C with %C.\n"),
-                   key.c_str(),
-                   current->first.c_str()));
+    for (RepoKeyList::const_iterator candidate = candidates.begin();
+         candidate != candidates.end(); ++candidate) {
+      if (recoveryFailedTime <= MonotonicTimePoint::now()) {
+        break;
       }
 
-      // If we reach here, the validate_connection() call succeeded
-      // and the repository is reachable.
-      this->remap_domains(key, current->first);
+      // Handle reaching the lost repository by waiting before trying
+      // again.
+      if (*candidate == key) {
+        if (DCPS_debug_level > 0) {
+          ACE_DEBUG((LM_DEBUG,
+                     ACE_TEXT("(%P|%t) Service_Participant::repository_lost: ")
+                     ACE_TEXT("waiting %d seconds to traverse the ")
+                     ACE_TEXT("repository list another time ")
+                     ACE_TEXT("for lost key %C.\n"),
+                     backoff,
+                     key.c_str()));
+        }
 
-      // Now we are done.  This is the only non-failure exit from
-      // this method.
-      return;
+        // Wait to traverse the list and try again.
+        ACE_OS::sleep(static_cast<unsigned int>(backoff));
 
-    } else {
-      if (current != this->discoveryMap_.end()) {
+        // Exponentially backoff delay.
+        backoff *= this->federation_backoff_multiplier();
+
+        // Don't increment current to allow us to reattach to the
+        // original repository if it is restarted.
+      }
+
+      Discovery_rch discovery;
+      {
+        ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->maps_lock_);
+        RepoKeyDiscoveryMap::const_iterator current = this->discoveryMap_.find(*candidate);
+        if (current != this->discoveryMap_.end()) {
+          discovery = current->second;
+        }
+      }
+
+      // Check the availability of the current repository.
+      if (discovery && discovery->active()) {
+
+        if (DCPS_debug_level > 0) {
+          ACE_DEBUG((LM_DEBUG,
+                     ACE_TEXT("(%P|%t) Service_Participant::repository_lost: ")
+                     ACE_TEXT("replacing repository %C with %C.\n"),
+                     key.c_str(),
+                     candidate->c_str()));
+        }
+
+        // If we reach here, the validate_connection() call succeeded
+        // and the repository is reachable.
+        this->remap_domains(key, *candidate);
+
+        // Now we are done.  This is the only non-failure exit from
+        // this method.
+        return;
+
+      } else {
         ACE_DEBUG((LM_WARNING,
                    ACE_TEXT("(%P|%t) WARNING: Service_Participant::repository_lost: ")
                    ACE_TEXT("repository %C was not available to replace %C, ")
                    ACE_TEXT("looking for another.\n"),
-                   current->first.c_str(),
-                   key.c_str()));
-      } else {
-        ACE_DEBUG((LM_WARNING,
-                   ACE_TEXT("(%P|%t) WARNING: Service_Participant::repository_lost: ")
-                   ACE_TEXT("no repositories are currently available to replace %C, ")
-                   ACE_TEXT("looking for another.\n"),
+                   candidate->c_str(),
                    key.c_str()));
       }
-    }
-
-    // Move to the next candidate repository.
-    if (current != this->discoveryMap_.end()) {
-      ++current;
     }
   }
 

--- a/dds/DCPS/Service_Participant.cpp
+++ b/dds/DCPS/Service_Participant.cpp
@@ -1300,6 +1300,7 @@ Service_Participant::repository_lost(Discovery::RepoKey key)
   while (recoveryFailedTime > MonotonicTimePoint::now()) {
     typedef OPENDDS_VECTOR(Discovery::RepoKey) RepoKeyList;
     RepoKeyList candidates;
+    bool missing_key = false;
 
     {
       ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, this->maps_lock_);
@@ -1316,6 +1317,7 @@ Service_Participant::repository_lost(Discovery::RepoKey key)
       const RepoKeyDiscoveryMap::const_iterator initialLocation = this->discoveryMap_.find(key);
 
       if (initialLocation == this->discoveryMap_.end()) {
+        missing_key = true;
         if (!reported_missing) {
           ACE_DEBUG((LM_WARNING,
                      ACE_TEXT("(%P|%t) WARNING: Service_Participant::repository_lost: ")
@@ -1412,6 +1414,24 @@ Service_Participant::repository_lost(Discovery::RepoKey key)
                    candidate->c_str(),
                    key.c_str()));
       }
+    }
+
+    if (missing_key && recoveryFailedTime > MonotonicTimePoint::now()) {
+      if (DCPS_debug_level > 0) {
+        ACE_DEBUG((LM_DEBUG,
+                   ACE_TEXT("(%P|%t) Service_Participant::repository_lost: ")
+                   ACE_TEXT("waiting %d seconds to traverse the ")
+                   ACE_TEXT("repository list another time ")
+                   ACE_TEXT("for lost key %C.\n"),
+                   backoff,
+                   key.c_str()));
+      }
+
+      // Wait to traverse the list and try again.
+      ACE_OS::sleep(static_cast<unsigned int>(backoff));
+
+      // Exponentially backoff delay.
+      backoff *= this->federation_backoff_multiplier();
     }
   }
 

--- a/tests/unit-tests/dds/DCPS/Service_Participant.cpp
+++ b/tests/unit-tests/dds/DCPS/Service_Participant.cpp
@@ -1,5 +1,6 @@
 #include <dds/DCPS/Service_Participant.h>
 #include <dds/DCPS/StaticDiscovery.h>
+#include <dds/DCPS/TimeTypes.h>
 
 #include <gtestWrapper.h>
 
@@ -9,18 +10,31 @@ namespace {
 
 class TestDiscovery : public StaticDiscovery {
 public:
-  TestDiscovery(const RepoKey& key, bool active)
+  TestDiscovery(const RepoKey& key, bool active, int active_after_calls = 0)
     : StaticDiscovery(key)
     , active_(active)
+    , active_after_calls_(active_after_calls)
+    , active_calls_(0)
   {}
 
   bool active()
   {
+    ++active_calls_;
+    if (active_after_calls_ && active_calls_ >= active_after_calls_) {
+      return true;
+    }
     return active_;
+  }
+
+  int active_calls() const
+  {
+    return active_calls_;
   }
 
 private:
   bool active_;
+  int active_after_calls_;
+  int active_calls_;
 };
 
 }
@@ -68,4 +82,25 @@ TEST(dds_DCPS_Service_Participant, repository_lost_remaps_to_next_active_discove
   sp.repository_lost(lost);
 
   EXPECT_EQ(replacement, sp.domain_to_repo(domain));
+}
+
+TEST(dds_DCPS_Service_Participant, repository_lost_backs_off_when_lost_key_is_missing)
+{
+  Service_Participant sp;
+
+  const Discovery::RepoKey lost("missing-repo");
+  const Discovery::RepoKey replacement("repo-2");
+
+  RcHandle<TestDiscovery> replacement_discovery = make_rch<TestDiscovery>(replacement, false, 2);
+  sp.add_discovery(replacement_discovery);
+  sp.federation_recovery_duration(5);
+  sp.federation_initial_backoff_seconds(1);
+  sp.federation_backoff_multiplier(1);
+
+  const MonotonicTimePoint start = MonotonicTimePoint::now();
+  sp.repository_lost(lost);
+  const TimeDuration elapsed = MonotonicTimePoint::now() - start;
+
+  EXPECT_EQ(2, replacement_discovery->active_calls());
+  EXPECT_GE(elapsed, TimeDuration(1));
 }

--- a/tests/unit-tests/dds/DCPS/Service_Participant.cpp
+++ b/tests/unit-tests/dds/DCPS/Service_Participant.cpp
@@ -1,8 +1,29 @@
 #include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/StaticDiscovery.h>
 
 #include <gtestWrapper.h>
 
 using namespace OpenDDS::DCPS;
+
+namespace {
+
+class TestDiscovery : public StaticDiscovery {
+public:
+  TestDiscovery(const RepoKey& key, bool active)
+    : StaticDiscovery(key)
+    , active_(active)
+  {}
+
+  bool active()
+  {
+    return active_;
+  }
+
+private:
+  bool active_;
+};
+
+}
 
 TEST(dds_DCPS_Service_Participant, type_object_encoding) {
   Service_Participant sp;
@@ -28,4 +49,23 @@ TEST(dds_DCPS_Service_Participant, event_dispatcher_thread_count)
 
   sp.config_store()->set_uint32(COMMON_DCPS_EVENT_DISPATCHER_THREADS, 0);
   EXPECT_EQ(sp.event_dispatcher_thread_count(), COMMON_DCPS_EVENT_DISPATCHER_THREADS_default);
+}
+
+TEST(dds_DCPS_Service_Participant, repository_lost_remaps_to_next_active_discovery)
+{
+  Service_Participant sp;
+
+  const Discovery::RepoKey lost("repo-1");
+  const Discovery::RepoKey unavailable("repo-2");
+  const Discovery::RepoKey replacement("repo-3");
+  const DDS::DomainId_t domain = 42;
+
+  sp.add_discovery(make_rch<TestDiscovery>(lost, false));
+  sp.add_discovery(make_rch<TestDiscovery>(unavailable, false));
+  sp.add_discovery(make_rch<TestDiscovery>(replacement, true));
+  sp.set_repo_domain(domain, lost, false);
+
+  sp.repository_lost(lost);
+
+  EXPECT_EQ(replacement, sp.domain_to_repo(domain));
 }


### PR DESCRIPTION
Problem:
 - Service_Participant::repository_lost() walks discoveryMap_ using iterators without holding maps_lock_. If another thread changes the discovery map during recovery, those iterators will be invalidated.
 - There is also a potential busy-spin issue: when the lost repo key is already missing from discoveryMap_ and no candidate repo is active, the retry loop can rebuild the same candidate list repeatedly without ever hitting the “lost key” backoff/sleep point.

Solution:
 - repository_lost() now snapshots repo keys under maps_lock_, releases the lock while iterating, and reacquires it only to look up each candidate’s current Discovery_rch. This avoids retaining bogus map iterators.
- For the spin case, track when the lost key is missing and explicitly sleep/apply backoff after a failed pass through candidates.