### PR TITLE
RtpsRelay early admission check

### DIFF
--- a/tools/dds/rtpsrelaylib/Relay.idl
+++ b/tools/dds/rtpsrelaylib/Relay.idl
@@ -191,7 +191,7 @@ module RtpsRelay {
     unsigned long relay_partitions_pub_count;
     unsigned long relay_address_pub_count;
     unsigned long admission_deferral_count;
-    unsigned long ghost_entry_skipped_count;
+    unsigned long unadmitted_entry_count;
     unsigned long remote_map_size;
     unsigned long max_ips_per_client;
     unsigned long total_client_ips;

--- a/tools/dds/rtpsrelaylib/Relay.idl
+++ b/tools/dds/rtpsrelaylib/Relay.idl
@@ -191,6 +191,7 @@ module RtpsRelay {
     unsigned long relay_partitions_pub_count;
     unsigned long relay_address_pub_count;
     unsigned long admission_deferral_count;
+    unsigned long ghost_entry_skipped_count;
     unsigned long remote_map_size;
     unsigned long max_ips_per_client;
     unsigned long total_client_ips;

--- a/tools/rtpsrelay/GuidAddrSet.cpp
+++ b/tools/rtpsrelay/GuidAddrSet.cpp
@@ -222,6 +222,16 @@ GuidAddrSet::record_activity(const AddrPort& remote_address,
     schedule_expiration();
   }
 
+  apply_drain_state(addr_set_stats, from_application_participant);
+
+  if (allow_stun_responses) {
+    *allow_stun_responses = addr_set_stats.allow_stun_responses;
+  }
+}
+
+void
+GuidAddrSet::apply_drain_state(AddrSetStats& addr_set_stats, bool from_application_participant)
+{
   switch (drain_state_) {
   case DrainState::DS_NORMAL:
     if (!addr_set_stats.allow_stun_responses && !addr_set_stats.in_denied_partition) {
@@ -237,10 +247,26 @@ GuidAddrSet::record_activity(const AddrPort& remote_address,
     }
     break;
   }
+}
 
-  if (allow_stun_responses) {
-    *allow_stun_responses = addr_set_stats.allow_stun_responses;
+bool
+GuidAddrSet::compute_allow_stun_responses(const AddrSetStats& addr_set_stats,
+                                          bool from_application_participant) const
+{
+  switch (drain_state_) {
+  case DrainState::DS_NORMAL:
+    // Mirrors apply_drain_state DS_NORMAL: an entry is un-marked when it is
+    // not in a denied partition, so the effective value is true in that case.
+    return addr_set_stats.allow_stun_responses || !addr_set_stats.in_denied_partition;
+  case DrainState::DS_DRAINING:
+    // Mirrors apply_drain_state DS_DRAINING: the entry would be marked false
+    // when there is budget available, without consuming mark_budget_.
+    if (!from_application_participant && addr_set_stats.allow_stun_responses && mark_budget_) {
+      return false;
+    }
+    break;
   }
+  return addr_set_stats.allow_stun_responses;
 }
 
 void GuidAddrSet::schedule_rejected_address_expiration()

--- a/tools/rtpsrelay/GuidAddrSet.cpp
+++ b/tools/rtpsrelay/GuidAddrSet.cpp
@@ -249,26 +249,6 @@ GuidAddrSet::apply_drain_state(AddrSetStats& addr_set_stats, bool from_applicati
   }
 }
 
-bool
-GuidAddrSet::compute_allow_stun_responses(const AddrSetStats& addr_set_stats,
-                                          bool from_application_participant) const
-{
-  switch (drain_state_) {
-  case DrainState::DS_NORMAL:
-    // Mirrors apply_drain_state DS_NORMAL: an entry is un-marked when it is
-    // not in a denied partition, so the effective value is true in that case.
-    return addr_set_stats.allow_stun_responses || !addr_set_stats.in_denied_partition;
-  case DrainState::DS_DRAINING:
-    // Mirrors apply_drain_state DS_DRAINING: the entry would be marked false
-    // when there is budget available, without consuming mark_budget_.
-    if (!from_application_participant && addr_set_stats.allow_stun_responses && mark_budget_) {
-      return false;
-    }
-    break;
-  }
-  return addr_set_stats.allow_stun_responses;
-}
-
 void GuidAddrSet::schedule_rejected_address_expiration()
 {
   if (rejected_address_expiration_queue_.empty()) {

--- a/tools/rtpsrelay/GuidAddrSet.cpp
+++ b/tools/rtpsrelay/GuidAddrSet.cpp
@@ -446,6 +446,9 @@ bool GuidAddrSet::ignore_rtps(bool from_application_participant,
   if (!already_checked_admit && !admitting()) {
     // Too many new clients to admit another.
     relay_stats_reporter_.admission_deferral_count(now);
+
+    // Increase the cumulative count of unadmitted entries
+    relay_stats_reporter_.unadmitted_entry_count(now);
     return true;
   }
 

--- a/tools/rtpsrelay/GuidAddrSet.cpp
+++ b/tools/rtpsrelay/GuidAddrSet.cpp
@@ -413,6 +413,7 @@ void GuidAddrSet::maintain_admission_queue(const OpenDDS::DCPS::MonotonicTimePoi
 bool GuidAddrSet::ignore_rtps(bool from_application_participant,
                               const OpenDDS::DCPS::GUID_t& guid,
                               const OpenDDS::DCPS::MonotonicTimePoint& now,
+                              bool already_checked_admit,
                               bool& admitted)
 {
   const auto pos = guid_addr_set_map_.find(guid);
@@ -442,7 +443,7 @@ bool GuidAddrSet::ignore_rtps(bool from_application_participant,
     return true;
   }
 
-  if (!admitting()) {
+  if (!already_checked_admit && !admitting()) {
     // Too many new clients to admit another.
     relay_stats_reporter_.admission_deferral_count(now);
     return true;

--- a/tools/rtpsrelay/GuidAddrSet.h
+++ b/tools/rtpsrelay/GuidAddrSet.h
@@ -286,6 +286,24 @@ public:
       gas_.deny(guid);
     }
 
+    // Read-only evaluation of allow_stun_responses for the admission-control
+    // skip path.  Reflects current drain state and denied-partition flag
+    // without modifying any drain counters.
+    bool compute_allow_stun_responses(GuidAddrSetMap::iterator pos,
+                                      bool from_application_participant)
+    {
+      return gas_.compute_allow_stun_responses(pos->second, from_application_participant);
+    }
+
+    // Increment the ghost entry skipped counter.  Called when an RTPS message
+    // from an unadmitted participant is dropped early (before record_activity)
+    // to prevent ghost entries in guid_addr_set_map_.  Kept separate from
+    // admission_deferral_count so the two paths can be monitored independently.
+    void admission_skipped(const OpenDDS::DCPS::MonotonicTimePoint& now)
+    {
+      gas_.relay_stats_reporter_.ghost_entry_skipped_count(now);
+    }
+
   private:
     GuidAddrSet& gas_;
 
@@ -306,6 +324,15 @@ private:
                   bool from_application_participant,
                   bool* allow_stun_responses,
                   const RelayHandler& handler);
+
+  void apply_drain_state(AddrSetStats& addr_set_stats, bool from_application_participant);
+
+  // Read-only equivalent of the allow_stun_responses evaluation in
+  // apply_drain_state.  Used by the admission-control skip path so it
+  // can report the correct value without touching drain counters
+  // (mark_count_ / mark_budget_), keeping the two features independent.
+  bool compute_allow_stun_responses(const AddrSetStats& addr_set_stats,
+                                    bool from_application_participant) const;
 
   void schedule_rejected_address_expiration();
   void process_rejected_address_expiration(const OpenDDS::DCPS::MonotonicTimePoint& now);

--- a/tools/rtpsrelay/GuidAddrSet.h
+++ b/tools/rtpsrelay/GuidAddrSet.h
@@ -217,9 +217,10 @@ public:
     bool ignore_rtps(bool from_application_participant,
                      const OpenDDS::DCPS::GUID_t& guid,
                      const OpenDDS::DCPS::MonotonicTimePoint& now,
+                     bool already_checked_admit,
                      bool& admitted)
     {
-      return gas_.ignore_rtps(from_application_participant, guid, now, admitted);
+      return gas_.ignore_rtps(from_application_participant, guid, now, already_checked_admit, admitted);
     }
 
     OpenDDS::DCPS::TimeDuration get_session_time(const OpenDDS::DCPS::GUID_t& guid,
@@ -286,6 +287,11 @@ public:
       gas_.deny(guid);
     }
 
+    void admission_deferral_count(const OpenDDS::DCPS::MonotonicTimePoint& now)
+    {
+      gas_.admission_deferral_count(now);
+    }
+
     void apply_drain_state(AddrSetStats& addr_set_stats, bool from_application_participant)
     {
       gas_.apply_drain_state(addr_set_stats, from_application_participant);
@@ -346,6 +352,7 @@ private:
   bool ignore_rtps(bool from_application_participant,
                    const OpenDDS::DCPS::GUID_t& guid,
                    const OpenDDS::DCPS::MonotonicTimePoint& now,
+                   bool already_checked_admit,
                    bool& admitted);
 
   void remove(const OpenDDS::DCPS::GUID_t& guid,
@@ -381,6 +388,11 @@ private:
   void populate_relay_status(RelayStatus& relay_status);
 
   void deny(const OpenDDS::DCPS::GUID_t& guid);
+
+  void admission_deferral_count(const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    relay_stats_reporter_.admission_deferral_count(now);
+  }
 
   void apply_drain_state(AddrSetStats& addr_set_stats, bool from_application_participant);
 

--- a/tools/rtpsrelay/GuidAddrSet.h
+++ b/tools/rtpsrelay/GuidAddrSet.h
@@ -289,21 +289,12 @@ public:
 
     void admission_deferral_count(const OpenDDS::DCPS::MonotonicTimePoint& now)
     {
-      gas_.admission_deferral_count(now);
+      gas_.relay_stats_reporter_.admission_deferral_count(now);
     }
 
     void apply_drain_state(AddrSetStats& addr_set_stats, bool from_application_participant)
     {
       gas_.apply_drain_state(addr_set_stats, from_application_participant);
-    }
-
-    // Increment the ghost entry skipped counter.  Called when an RTPS message
-    // from an unadmitted participant is dropped early (before record_activity)
-    // to prevent ghost entries in guid_addr_set_map_.  Kept separate from
-    // admission_deferral_count so the two paths can be monitored independently.
-    void admission_skipped(const OpenDDS::DCPS::MonotonicTimePoint& now)
-    {
-      gas_.relay_stats_reporter_.ghost_entry_skipped_count(now);
     }
 
   private:
@@ -388,11 +379,6 @@ private:
   void populate_relay_status(RelayStatus& relay_status);
 
   void deny(const OpenDDS::DCPS::GUID_t& guid);
-
-  void admission_deferral_count(const OpenDDS::DCPS::MonotonicTimePoint& now)
-  {
-    relay_stats_reporter_.admission_deferral_count(now);
-  }
 
   void apply_drain_state(AddrSetStats& addr_set_stats, bool from_application_participant);
 

--- a/tools/rtpsrelay/GuidAddrSet.h
+++ b/tools/rtpsrelay/GuidAddrSet.h
@@ -286,13 +286,9 @@ public:
       gas_.deny(guid);
     }
 
-    // Read-only evaluation of allow_stun_responses for the admission-control
-    // skip path.  Reflects current drain state and denied-partition flag
-    // without modifying any drain counters.
-    bool compute_allow_stun_responses(GuidAddrSetMap::iterator pos,
-                                      bool from_application_participant)
+    void apply_drain_state(AddrSetStats& addr_set_stats, bool from_application_participant)
     {
-      return gas_.compute_allow_stun_responses(pos->second, from_application_participant);
+      gas_.apply_drain_state(addr_set_stats, from_application_participant);
     }
 
     // Increment the ghost entry skipped counter.  Called when an RTPS message
@@ -324,15 +320,6 @@ private:
                   bool from_application_participant,
                   bool* allow_stun_responses,
                   const RelayHandler& handler);
-
-  void apply_drain_state(AddrSetStats& addr_set_stats, bool from_application_participant);
-
-  // Read-only equivalent of the allow_stun_responses evaluation in
-  // apply_drain_state.  Used by the admission-control skip path so it
-  // can report the correct value without touching drain counters
-  // (mark_count_ / mark_budget_), keeping the two features independent.
-  bool compute_allow_stun_responses(const AddrSetStats& addr_set_stats,
-                                    bool from_application_participant) const;
 
   void schedule_rejected_address_expiration();
   void process_rejected_address_expiration(const OpenDDS::DCPS::MonotonicTimePoint& now);
@@ -394,6 +381,8 @@ private:
   void populate_relay_status(RelayStatus& relay_status);
 
   void deny(const OpenDDS::DCPS::GUID_t& guid);
+
+  void apply_drain_state(AddrSetStats& addr_set_stats, bool from_application_participant);
 
   struct AdmissionControlInfo {
     AdmissionControlInfo(const OpenDDS::DCPS::GuidPrefix_t& prefix, const OpenDDS::DCPS::MonotonicTimePoint& admitted)

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -444,14 +444,14 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
         (src_guid == config_.application_participant_guid());
 
       bool allow_stun_responses = true;
-      const bool recorded = record_activity(proxy, addr_port, now, src_guid, from_application_participant, &allow_stun_responses);
+      const bool proceed = record_activity(proxy, addr_port, now, src_guid, from_application_participant, &allow_stun_responses);
 
       if (allow_stun_responses && response_needed) {
         send(remote_address, std::move(response), now);
         ++messages_sent;
       }
 
-      if (!recorded) {
+      if (!proceed) {
         return messages_sent;
       }
 
@@ -477,20 +477,26 @@ VerticalHandler::record_activity(GuidAddrSet::Proxy& proxy,
                                  bool from_application_participant,
                                  bool* allow_stun_responses)
 {
+  // A GuidAddrSet entry for src_guid is created even if it is not admitted.
+  // To avoid the same entry getting refreshed by subsequent messages from the same src_guid,
+  // this returns early if it keeps getting deferred.
+  // TODO: admitting() is supposed to be called once. It's currently called in ignore_rtps as well.
   if (!from_application_participant && !proxy.admitting()) {
     const auto pos = proxy.find(src_guid);
     if (pos != proxy.end() && !pos->second.allow_rtps) {
+      proxy.apply_drain_state(pos->second, from_application_participant);
+      if (allow_stun_responses) {
+        *allow_stun_responses = pos->second.allow_stun_responses;
+      }
       if (config_.log_activity()) {
-        ACE_DEBUG((LM_INFO, "(%P|%t) INFO: VerticalHandler::process_message %C skipped unadmitted participant %C from %C - relay not admitting\n",
+        ACE_DEBUG((LM_INFO, "(%P|%t) INFO: VerticalHandler::record_activity %C skipped unadmitted participant %C from %C - relay not admitting\n",
                    name_.c_str(), guid_to_string(src_guid).c_str(),
                    OpenDDS::DCPS::LogAddr(remote_address.addr).c_str()));
-      }
-      if (allow_stun_responses) {
-        *allow_stun_responses = proxy.compute_allow_stun_responses(pos, from_application_participant);
       }
       return false;
     }
   }
+
   proxy.record_activity(remote_address, now, src_guid, from_application_participant, allow_stun_responses, *this);
   return true;
 }

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -333,7 +333,12 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
 
     GuidAddrSet::Proxy proxy(guid_addr_set_);
     OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, READ_MASK | SIGNAL_MASK, handle_as_int);
-    record_activity(proxy, addr_port, now, src_guid, from_application_participant);
+
+    if (!record_activity(proxy, addr_port, now, src_guid, from_application_participant)) {
+      proxy.admission_skipped(now);
+      stats_reporter_.ignored_message(msg_len, now, type);
+      return 0;
+    }
 
     cache_message(proxy, src_guid, to, msg, now);
 
@@ -437,13 +442,17 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
       const bool from_application_participant =
         (remote_address == application_participant_addr_) &&
         (src_guid == config_.application_participant_guid());
-      bool allow_stun_responses = true;
 
-      record_activity(proxy, addr_port, now, src_guid, from_application_participant, &allow_stun_responses);
+      bool allow_stun_responses = true;
+      const bool recorded = record_activity(proxy, addr_port, now, src_guid, from_application_participant, &allow_stun_responses);
 
       if (allow_stun_responses && response_needed) {
         send(remote_address, std::move(response), now);
         ++messages_sent;
+      }
+
+      if (!recorded) {
+        return messages_sent;
       }
 
       bool admitted = false;
@@ -460,7 +469,7 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
   }
 }
 
-void
+bool
 VerticalHandler::record_activity(GuidAddrSet::Proxy& proxy,
                                  const AddrPort& remote_address,
                                  const OpenDDS::DCPS::MonotonicTimePoint& now,
@@ -468,7 +477,22 @@ VerticalHandler::record_activity(GuidAddrSet::Proxy& proxy,
                                  bool from_application_participant,
                                  bool* allow_stun_responses)
 {
+  if (!from_application_participant && !proxy.admitting()) {
+    const auto pos = proxy.find(src_guid);
+    if (pos != proxy.end() && !pos->second.allow_rtps) {
+      if (config_.log_activity()) {
+        ACE_DEBUG((LM_INFO, "(%P|%t) INFO: VerticalHandler::process_message %C skipped unadmitted participant %C from %C - relay not admitting\n",
+                   name_.c_str(), guid_to_string(src_guid).c_str(),
+                   OpenDDS::DCPS::LogAddr(remote_address.addr).c_str()));
+      }
+      if (allow_stun_responses) {
+        *allow_stun_responses = proxy.compute_allow_stun_responses(pos, from_application_participant);
+      }
+      return false;
+    }
+  }
   proxy.record_activity(remote_address, now, src_guid, from_application_participant, allow_stun_responses, *this);
+  return true;
 }
 
 bool VerticalHandler::parse_message(OpenDDS::RTPS::MessageParser& message_parser,

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -336,7 +336,6 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
 
     bool already_checked_admit = false;
     if (!record_activity(proxy, addr_port, now, src_guid, from_application_participant, already_checked_admit)) {
-      proxy.admission_skipped(now);
       stats_reporter_.ignored_message(msg_len, now, type);
       return 0;
     }

--- a/tools/rtpsrelay/RelayHandler.cpp
+++ b/tools/rtpsrelay/RelayHandler.cpp
@@ -334,7 +334,8 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
     GuidAddrSet::Proxy proxy(guid_addr_set_);
     OpenDDS::DCPS::ThreadStatusManager::Event evLocked(statusManager, READ_MASK | SIGNAL_MASK, handle_as_int);
 
-    if (!record_activity(proxy, addr_port, now, src_guid, from_application_participant)) {
+    bool already_checked_admit = false;
+    if (!record_activity(proxy, addr_port, now, src_guid, from_application_participant, already_checked_admit)) {
       proxy.admission_skipped(now);
       stats_reporter_.ignored_message(msg_len, now, type);
       return 0;
@@ -343,7 +344,7 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
     cache_message(proxy, src_guid, to, msg, now);
 
     bool admitted = false;
-    if (proxy.ignore_rtps(from_application_participant, src_guid, now, admitted)) {
+    if (proxy.ignore_rtps(from_application_participant, src_guid, now, already_checked_admit, admitted)) {
       stats_reporter_.ignored_message(msg_len, now, type);
       return 0;
     }
@@ -443,8 +444,10 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
         (remote_address == application_participant_addr_) &&
         (src_guid == config_.application_participant_guid());
 
+      bool already_checked_admit = false;
       bool allow_stun_responses = true;
-      const bool proceed = record_activity(proxy, addr_port, now, src_guid, from_application_participant, &allow_stun_responses);
+      const bool proceed = record_activity(proxy, addr_port, now, src_guid, from_application_participant,
+        already_checked_admit, &allow_stun_responses);
 
       if (allow_stun_responses && response_needed) {
         send(remote_address, std::move(response), now);
@@ -456,7 +459,7 @@ CORBA::ULong VerticalHandler::process_message(const ACE_INET_Addr& remote_addres
       }
 
       bool admitted = false;
-      proxy.ignore_rtps(from_application_participant, src_guid, now, admitted);
+      proxy.ignore_rtps(from_application_participant, src_guid, now, already_checked_admit, admitted);
       if (admitted && spdp_handler_) {
         messages_sent += spdp_handler_->send_to_application_participant(proxy, src_guid, now);
       }
@@ -475,25 +478,34 @@ VerticalHandler::record_activity(GuidAddrSet::Proxy& proxy,
                                  const OpenDDS::DCPS::MonotonicTimePoint& now,
                                  const OpenDDS::DCPS::GUID_t& src_guid,
                                  bool from_application_participant,
+                                 bool& already_checked_admit,
                                  bool* allow_stun_responses)
 {
-  // A GuidAddrSet entry for src_guid is created even if it is not admitted.
+  // A GuidAddrSet entry for src_guid is always created even if it isn't admitted initially.
   // To avoid the same entry getting refreshed by subsequent messages from the same src_guid,
-  // this returns early if it keeps getting deferred.
-  // TODO: admitting() is supposed to be called once. It's currently called in ignore_rtps as well.
-  if (!from_application_participant && !proxy.admitting()) {
+  // returns early if it keeps getting deferred.
+  already_checked_admit = false;
+  if (!from_application_participant) {
     const auto pos = proxy.find(src_guid);
-    if (pos != proxy.end() && !pos->second.allow_rtps) {
-      proxy.apply_drain_state(pos->second, from_application_participant);
-      if (allow_stun_responses) {
-        *allow_stun_responses = pos->second.allow_stun_responses;
+    if (pos != proxy.end()) {
+      if (!pos->second.allow_rtps) {
+        const auto admitting = proxy.admitting();
+        // Don't call admitting again in ignore_rtps if it is admitted here.
+        already_checked_admit = true;
+        if (!admitting) {
+          proxy.admission_deferral_count(now);
+          proxy.apply_drain_state(pos->second, from_application_participant);
+          if (allow_stun_responses) {
+            *allow_stun_responses = pos->second.allow_stun_responses;
+          }
+          if (config_.log_activity()) {
+            ACE_DEBUG((LM_INFO, "(%P|%t) INFO: VerticalHandler::record_activity %C skipped unadmitted participant %C from %C - relay not admitting\n",
+                       name_.c_str(), guid_to_string(src_guid).c_str(),
+                       OpenDDS::DCPS::LogAddr(remote_address.addr).c_str()));
+          }
+          return false;
+        }
       }
-      if (config_.log_activity()) {
-        ACE_DEBUG((LM_INFO, "(%P|%t) INFO: VerticalHandler::record_activity %C skipped unadmitted participant %C from %C - relay not admitting\n",
-                   name_.c_str(), guid_to_string(src_guid).c_str(),
-                   OpenDDS::DCPS::LogAddr(remote_address.addr).c_str()));
-      }
-      return false;
     }
   }
 

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -148,6 +148,7 @@ protected:
                        const OpenDDS::DCPS::MonotonicTimePoint& now,
                        const OpenDDS::DCPS::GUID_t& src_guid,
                        bool from_application_participant,
+                       bool& already_checked_admit,
                        bool* allow_stun_responses = 0);
 
   CORBA::ULong send(GuidAddrSet::Proxy& proxy,

--- a/tools/rtpsrelay/RelayHandler.h
+++ b/tools/rtpsrelay/RelayHandler.h
@@ -143,12 +143,12 @@ protected:
                                const OpenDDS::DCPS::Lockable_Message_Block_Ptr& msg,
                                MessageType& type) override;
 
-void record_activity(GuidAddrSet::Proxy& proxy,
-                     const AddrPort& remote_address,
-                     const OpenDDS::DCPS::MonotonicTimePoint& now,
-                     const OpenDDS::DCPS::GUID_t& src_guid,
-                     bool from_application_participant,
-                     bool* allow_stun_responses = 0);
+  bool record_activity(GuidAddrSet::Proxy& proxy,
+                       const AddrPort& remote_address,
+                       const OpenDDS::DCPS::MonotonicTimePoint& now,
+                       const OpenDDS::DCPS::GUID_t& src_guid,
+                       bool from_application_participant,
+                       bool* allow_stun_responses = 0);
 
   CORBA::ULong send(GuidAddrSet::Proxy& proxy,
                     const OpenDDS::DCPS::GUID_t& src_guid,

--- a/tools/rtpsrelay/RelayStatisticsReporter.cpp
+++ b/tools/rtpsrelay/RelayStatisticsReporter.cpp
@@ -122,7 +122,7 @@ void RelayStatisticsReporter::log_report(const OpenDDS::DCPS::MonotonicTimePoint
   log_relay_statistics_.new_address_count(0);
   log_relay_statistics_.expired_address_count(0);
   log_relay_statistics_.admission_deferral_count(0);
-  log_relay_statistics_.ghost_entry_skipped_count(0);
+  log_relay_statistics_.unadmitted_entry_count(0);
   log_relay_statistics_.max_ips_per_client(0);
   log_relay_statistics_.transitions_to_admitting(0);
   log_relay_statistics_.transitions_to_nonadmitting(0);
@@ -176,7 +176,7 @@ void RelayStatisticsReporter::publish_report(ACE_Guard<ACE_Thread_Mutex>& guard,
   publish_relay_statistics_.new_address_count(0);
   publish_relay_statistics_.expired_address_count(0);
   publish_relay_statistics_.admission_deferral_count(0);
-  publish_relay_statistics_.ghost_entry_skipped_count(0);
+  publish_relay_statistics_.unadmitted_entry_count(0);
   publish_relay_statistics_.max_ips_per_client(0);
   publish_relay_statistics_.transitions_to_admitting(0);
   publish_relay_statistics_.transitions_to_nonadmitting(0);

--- a/tools/rtpsrelay/RelayStatisticsReporter.cpp
+++ b/tools/rtpsrelay/RelayStatisticsReporter.cpp
@@ -122,6 +122,7 @@ void RelayStatisticsReporter::log_report(const OpenDDS::DCPS::MonotonicTimePoint
   log_relay_statistics_.new_address_count(0);
   log_relay_statistics_.expired_address_count(0);
   log_relay_statistics_.admission_deferral_count(0);
+  log_relay_statistics_.ghost_entry_skipped_count(0);
   log_relay_statistics_.max_ips_per_client(0);
   log_relay_statistics_.transitions_to_admitting(0);
   log_relay_statistics_.transitions_to_nonadmitting(0);
@@ -175,6 +176,7 @@ void RelayStatisticsReporter::publish_report(ACE_Guard<ACE_Thread_Mutex>& guard,
   publish_relay_statistics_.new_address_count(0);
   publish_relay_statistics_.expired_address_count(0);
   publish_relay_statistics_.admission_deferral_count(0);
+  publish_relay_statistics_.ghost_entry_skipped_count(0);
   publish_relay_statistics_.max_ips_per_client(0);
   publish_relay_statistics_.transitions_to_admitting(0);
   publish_relay_statistics_.transitions_to_nonadmitting(0);

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -219,6 +219,14 @@ public:
     report(guard, now);
   }
 
+  void ghost_entry_skipped_count(const OpenDDS::DCPS::MonotonicTimePoint& now)
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    ++log_relay_statistics_.ghost_entry_skipped_count();
+    ++publish_relay_statistics_.ghost_entry_skipped_count();
+    report(guard, now);
+  }
+
   void remote_map_size(uint32_t size, const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);

--- a/tools/rtpsrelay/RelayStatisticsReporter.h
+++ b/tools/rtpsrelay/RelayStatisticsReporter.h
@@ -219,11 +219,11 @@ public:
     report(guard, now);
   }
 
-  void ghost_entry_skipped_count(const OpenDDS::DCPS::MonotonicTimePoint& now)
+  void unadmitted_entry_count(const OpenDDS::DCPS::MonotonicTimePoint& now)
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
-    ++log_relay_statistics_.ghost_entry_skipped_count();
-    ++publish_relay_statistics_.ghost_entry_skipped_count();
+    ++log_relay_statistics_.unadmitted_entry_count();
+    ++publish_relay_statistics_.unadmitted_entry_count();
     report(guard, now);
   }
 


### PR DESCRIPTION
**Problem**
New client participant is added to the `GuidAddrSet` map even if it is not admitted. Subsequent messages from the same client participant keep its entry refreshed in the map. For an unlucky client, it may not get admitted for a prolonged period of time. However, the server still has to allocate resources, e.g., memory, timers, etc., for it unnecessarily.

**Solution**
Still create a `GuidAddrSet` map entry for the new client, but don't refresh its entry unless the client is admitted. Its entry, hence, will eventually expire and be removed from the map.