### PR TITLE
Misc Coverity Cleanup

### DIFF
--- a/dds/DCPS/DataSampleHeader.cpp
+++ b/dds/DCPS/DataSampleHeader.cpp
@@ -287,20 +287,40 @@ operator<<(ACE_Message_Block& buffer, const DataSampleHeader& value)
   writer << value.submessage_id_;
 
   // Write the flags as a single byte.
-  ACE_CDR::Octet flags = (value.byte_order_           << BYTE_ORDER_FLAG)
-                         | (value.coherent_change_    << COHERENT_CHANGE_FLAG)
-                         | (value.historic_sample_    << HISTORIC_SAMPLE_FLAG)
-                         | (value.lifespan_duration_  << LIFESPAN_DURATION_FLAG)
-                         | (value.group_coherent_     << GROUP_COHERENT_FLAG)
-                         | (value.content_filter_     << CONTENT_FILTER_FLAG)
-                         | (value.sequence_repair_    << SEQUENCE_REPAIR_FLAG)
-                         | (value.more_fragments_     << MORE_FRAGMENTS_FLAG)
-                         ;
+  ACE_CDR::Octet flags = 0;
+  if (value.byte_order_) {
+    flags |= DataSampleHeader::mask_flag(BYTE_ORDER_FLAG);
+  }
+  if (value.coherent_change_) {
+    flags |= DataSampleHeader::mask_flag(COHERENT_CHANGE_FLAG);
+  }
+  if (value.historic_sample_) {
+    flags |= DataSampleHeader::mask_flag(HISTORIC_SAMPLE_FLAG);
+  }
+  if (value.lifespan_duration_) {
+    flags |= DataSampleHeader::mask_flag(LIFESPAN_DURATION_FLAG);
+  }
+  if (value.group_coherent_) {
+    flags |= DataSampleHeader::mask_flag(GROUP_COHERENT_FLAG);
+  }
+  if (value.content_filter_) {
+    flags |= DataSampleHeader::mask_flag(CONTENT_FILTER_FLAG);
+  }
+  if (value.sequence_repair_) {
+    flags |= DataSampleHeader::mask_flag(SEQUENCE_REPAIR_FLAG);
+  }
+  if (value.more_fragments_) {
+    flags |= DataSampleHeader::mask_flag(MORE_FRAGMENTS_FLAG);
+  }
   writer << ACE_OutputCDR::from_octet(flags);
 
-  flags = (value.cdr_encapsulation_ << CDR_ENCAP_FLAG)
-        | (value.key_fields_only_   << KEY_ONLY_FLAG)
-        ;
+  flags = 0;
+  if (value.cdr_encapsulation_) {
+    flags |= DataSampleHeader::mask_flag(CDR_ENCAP_FLAG);
+  }
+  if (value.key_fields_only_) {
+    flags |= DataSampleHeader::mask_flag(KEY_ONLY_FLAG);
+  }
   writer << ACE_OutputCDR::from_octet(flags);
 
   writer << value.message_length_;

--- a/dds/DCPS/JsonValueWriter.h
+++ b/dds/DCPS/JsonValueWriter.h
@@ -437,7 +437,9 @@ std::string to_json(const T& sample)
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   JsonValueWriter<rapidjson::Writer<rapidjson::StringBuffer> > jvw(writer);
-  vwrite(jvw, sample);
+  if (!vwrite(jvw, sample)) {
+    return std::string();
+  }
   writer.Flush();
   return buffer.GetString();
 }
@@ -456,26 +458,33 @@ std::string to_json(const DDS::TopicDescription_ptr topic,
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   JsonValueWriter<rapidjson::Writer<rapidjson::StringBuffer> > jvw(writer);
-  jvw.begin_struct();
-  jvw.begin_struct_member("topic");
-  jvw.begin_struct();
-  jvw.begin_struct_member("name");
+  if (!jvw.begin_struct() ||
+      !jvw.begin_struct_member("topic") ||
+      !jvw.begin_struct() ||
+      !jvw.begin_struct_member("name")) {
+    return std::string();
+  }
   CORBA::String_var topic_name = topic->get_name();
-  static_cast<ValueWriter&>(jvw).write_string(topic_name);
-  jvw.end_struct_member();
-  jvw.begin_struct_member("type_name");
+  ValueWriter& vw = jvw;
+  if (!vw.write_string(topic_name) ||
+      !jvw.end_struct_member() ||
+      !jvw.begin_struct_member("type_name")) {
+    return std::string();
+  }
   CORBA::String_var type_name = topic->get_type_name();
-  static_cast<ValueWriter&>(jvw).write_string(type_name);
-  jvw.end_struct_member();
-  jvw.end_struct();
-  jvw.end_struct_member();
-  jvw.begin_struct_member("sample");
-  vwrite(jvw, sample);
-  jvw.end_struct_member();
-  jvw.begin_struct_member("sample_info");
-  vwrite(jvw, sample_info);
-  jvw.end_struct_member();
-  jvw.end_struct();
+  if (!vw.write_string(type_name) ||
+      !jvw.end_struct_member() ||
+      !jvw.end_struct() ||
+      !jvw.end_struct_member() ||
+      !jvw.begin_struct_member("sample") ||
+      !vwrite(jvw, sample) ||
+      !jvw.end_struct_member() ||
+      !jvw.begin_struct_member("sample_info") ||
+      !vwrite(jvw, sample_info) ||
+      !jvw.end_struct_member() ||
+      !jvw.end_struct()) {
+    return std::string();
+  }
   writer.Flush();
   return buffer.GetString();
 }

--- a/dds/DCPS/TypeSupportImpl.h
+++ b/dds/DCPS/TypeSupportImpl.h
@@ -169,17 +169,21 @@ template <typename T>
 struct TypeSupportInitializer {
   TypeSupportInitializer()
     : ts_(new T)
+    , registered_(ts_->register_type(0, "") == DDS::RETCODE_OK)
   {
-    ts_->register_type(0, "");
+    OPENDDS_ASSERT(registered_);
   }
 
   ~TypeSupportInitializer()
   {
-    T* const t = dynamic_cast<T*>(ts_.in());
-    ts_->unregister_type(0, t ? t->name() : 0);
+    if (registered_) {
+      T* const t = dynamic_cast<T*>(ts_.in());
+      ts_->unregister_type(0, t ? t->name() : 0);
+    }
   }
 
   typename T::_var_type ts_;
+  const bool registered_;
 };
 
 } // namespace DCPS

--- a/dds/DCPS/XTypes/IdlScanner.h
+++ b/dds/DCPS/XTypes/IdlScanner.h
@@ -74,10 +74,7 @@ public:
   IdlToken()
   : kind_(Error)
   {
-    numeric_value_.signed_ = false;
-    numeric_value_.integer_value_ = 0;
-    numeric_value_.exponent_signed_ = false;
-    numeric_value_.exponent_value_ = 0;
+    numeric_value_ = Numeric();
   }
 
   static IdlToken make_error()

--- a/dds/DCPS/XTypes/IdlScanner.h
+++ b/dds/DCPS/XTypes/IdlScanner.h
@@ -73,7 +73,12 @@ public:
 
   IdlToken()
   : kind_(Error)
-  {}
+  {
+    numeric_value_.signed_ = false;
+    numeric_value_.integer_value_ = 0;
+    numeric_value_.exponent_signed_ = false;
+    numeric_value_.exponent_value_ = 0;
+  }
 
   static IdlToken make_error()
   {

--- a/dds/DCPS/XTypes/Utils.cpp
+++ b/dds/DCPS/XTypes/Utils.cpp
@@ -155,7 +155,7 @@ bool MemberPathParser::get_next_subpath()
   size_t got = 0; // Char count to use for the result
   char c = '\0';
   bool scan = true;
-  for (; i < left && scan; ++i) {
+  while (i < left && scan) {
     c = path[i];
     switch (c) {
     case '.':
@@ -168,14 +168,16 @@ bool MemberPathParser::get_next_subpath()
         error = true;
         return false;
       }
-      --i; // Don't consume, leave for next iteration
-      // fallthrough
+      scan = false; // Don't consume, leave for next iteration
+      break;
     case ']':
       scan = false;
+      ++i;
       break;
 
     default:
       ++got;
+      ++i;
     }
   }
 

--- a/dds/DCPS/transport/multicast/ReliableSession.cpp
+++ b/dds/DCPS/transport/multicast/ReliableSession.cpp
@@ -28,6 +28,13 @@ namespace DCPS {
 namespace {
   const Encoding::Kind reliable_session_encoding_kind = Encoding::KIND_UNALIGNED_CDR;
   const Encoding encoding_unaligned_native(reliable_session_encoding_kind);
+
+  bool nak_max_reached(size_t request_index, size_t nak_delay_interval, size_t nak_max)
+  {
+    const size_t completed_intervals = request_index / nak_delay_interval;
+    return completed_intervals > nak_max ||
+      (completed_intervals == nak_max && request_index % nak_delay_interval != 0);
+  }
 }
 
 ReliableSession::ReliableSession(RcHandle<EventDispatcher> event_dispatcher,
@@ -352,8 +359,10 @@ ReliableSession::send_naks()
     //  if nak_delay_intervals=4, nak_max=3, any sequence between 5 - 1, 10 - 6, 15 - 11
     //  are skipped for naking due to nak_delay_intervals and 20 - 16 are skipped for
     //  naking due to nak_max.
+    const size_t nak_delay_interval = nak_delay_intervals_ == static_cast<size_t>(-1)
+      ? nak_delay_intervals_ : nak_delay_intervals_ + 1;
     for (size_t i = 1; i < sz; ++i) {
-      if ((i * 1.0) / (nak_delay_intervals_ + 1) > nak_max_) {
+      if (nak_max_reached(i, nak_delay_interval, nak_max_)) {
         if (first != SequenceNumber()) {
           first = this->nak_requests_.begin()->second;
         }
@@ -363,14 +372,14 @@ ReliableSession::send_naks()
         break;
       }
 
-      if (i % (nak_delay_intervals_ + 1) == 1) {
+      if (i % nak_delay_interval == 1) {
         second = itr->second;
       }
       if (second != SequenceNumber()) {
         first = itr->second;
       }
 
-      if (i % (nak_delay_intervals_ + 1) == 0) {
+      if (i % nak_delay_interval == 0) {
         first = itr->second;
 
         if (first != SequenceNumber() && second != SequenceNumber()) {

--- a/dds/idl/typeobject_generator.cpp
+++ b/dds/idl/typeobject_generator.cpp
@@ -21,6 +21,16 @@ using namespace AstTypeClassification;
 
 namespace {
 
+template <typename To, typename From>
+To* ast_cast(From* from)
+{
+  To* const to = dynamic_cast<To*>(from);
+  if (!to) {
+    be_util::misc_error_and_abort("Unexpected AST type", from);
+  }
+  return to;
+}
+
 OpenDDS::XTypes::TypeFlag
 extensibility_to_type_flag(ExtensibilityKind exten)
 {
@@ -761,13 +771,13 @@ typeobject_generator::consider(Element& v, AST_Type* type, const std::string& an
   switch (type->node_type()) {
   case AST_ConcreteType::NT_union_fwd:
     {
-      AST_UnionFwd* const n = dynamic_cast<AST_UnionFwd*>(type);
+      AST_UnionFwd* const n = ast_cast<AST_UnionFwd>(type);
       type = n->full_definition();
       break;
     }
   case AST_ConcreteType::NT_struct_fwd:
     {
-      AST_StructureFwd* const n = dynamic_cast<AST_StructureFwd*>(type);
+      AST_StructureFwd* const n = ast_cast<AST_StructureFwd>(type);
       type = n->full_definition();
       break;
     }
@@ -789,13 +799,13 @@ typeobject_generator::strong_connect(AST_Type* type, const std::string& anonymou
   switch (type->node_type()) {
   case AST_ConcreteType::NT_union_fwd:
     {
-      AST_UnionFwd* const n = dynamic_cast<AST_UnionFwd*>(type);
+      AST_UnionFwd* const n = ast_cast<AST_UnionFwd>(type);
       type = n->full_definition();
       break;
     }
   case AST_ConcreteType::NT_struct_fwd:
     {
-      AST_StructureFwd* const n = dynamic_cast<AST_StructureFwd*>(type);
+      AST_StructureFwd* const n = ast_cast<AST_StructureFwd>(type);
       type = n->full_definition();
       break;
     }
@@ -812,12 +822,11 @@ typeobject_generator::strong_connect(AST_Type* type, const std::string& anonymou
   v.on_stack = true;
 
   using OpenDDS::XTypes::MemberId;
-  AST_Structure* const stru = dynamic_cast<AST_Structure*>(type);
   switch (type->node_type()) {
 
   case AST_ConcreteType::NT_union:
     {
-      AST_Union* const n = dynamic_cast<AST_Union*>(type);
+      AST_Union* const n = ast_cast<AST_Union>(type);
       v.name = canonical_name(n->name());
 
       AST_Type* discriminator = n->disc_type();
@@ -829,8 +838,8 @@ typeobject_generator::strong_connect(AST_Type* type, const std::string& anonymou
       MemberId member_id = 0;
 
       for (Fields::Iterator i = fields.begin(); i != fields.end(); ++i) {
-        AST_UnionBranch* ub = dynamic_cast<AST_UnionBranch*>(*i);
-        const MemberId id = be_global->compute_id(stru, ub, auto_id, member_id);
+        AST_UnionBranch* ub = ast_cast<AST_UnionBranch>(*i);
+        const MemberId id = be_global->compute_id(n, ub, auto_id, member_id);
         consider(v, ub->field_type(), v.name + "." + OpenDDS::DCPS::to_dds_string(id));
       }
 
@@ -839,7 +848,7 @@ typeobject_generator::strong_connect(AST_Type* type, const std::string& anonymou
 
   case AST_ConcreteType::NT_struct:
     {
-      AST_Structure* const n = dynamic_cast<AST_Structure*>(type);
+      AST_Structure* const n = ast_cast<AST_Structure>(type);
       v.name = canonical_name(n->name());
 
       // TODO: Struct inheritance.
@@ -850,7 +859,7 @@ typeobject_generator::strong_connect(AST_Type* type, const std::string& anonymou
 
       for (Fields::Iterator i = fields.begin(); i != fields.end(); ++i) {
         AST_Field* field = *i;
-        const MemberId id = be_global->compute_id(stru, field, auto_id, member_id);
+        const MemberId id = be_global->compute_id(n, field, auto_id, member_id);
         consider(v, field->field_type(), v.name + "." + OpenDDS::DCPS::to_dds_string(id));
       }
 
@@ -859,14 +868,14 @@ typeobject_generator::strong_connect(AST_Type* type, const std::string& anonymou
 
   case AST_ConcreteType::NT_array:
     {
-      AST_Array* const n = dynamic_cast<AST_Array*>(type);
+      AST_Array* const n = ast_cast<AST_Array>(type);
       v.name = anonymous_name + ".a";
       consider(v, n->base_type(), v.name);
       break;
     }
   case AST_ConcreteType::NT_map:
     {
-      AST_Map* const n = dynamic_cast<AST_Map*>(type);
+      AST_Map* const n = ast_cast<AST_Map>(type);
       v.name = anonymous_name + ".m";
       consider(v, n->key_type(), v.name);
       consider(v, n->value_type(), v.name);
@@ -874,7 +883,7 @@ typeobject_generator::strong_connect(AST_Type* type, const std::string& anonymou
     }
   case AST_ConcreteType::NT_sequence:
     {
-      AST_Sequence* const n = dynamic_cast<AST_Sequence*>(type);
+      AST_Sequence* const n = ast_cast<AST_Sequence>(type);
       v.name = anonymous_name + ".s";
       consider(v, n->base_type(), v.name);
       break;
@@ -882,7 +891,7 @@ typeobject_generator::strong_connect(AST_Type* type, const std::string& anonymou
 
   case AST_ConcreteType::NT_typedef:
     {
-      AST_Typedef* const n = dynamic_cast<AST_Typedef*>(type);
+      AST_Typedef* const n = ast_cast<AST_Typedef>(type);
       v.name = canonical_name(n->name());
       // TODO: What is the member name for an anonymous type in a typedef?
       // 7.3.4.9.2
@@ -892,7 +901,7 @@ typeobject_generator::strong_connect(AST_Type* type, const std::string& anonymou
 
   case AST_ConcreteType::NT_enum:
     {
-      AST_Enum* const n = dynamic_cast<AST_Enum*>(type);
+      AST_Enum* const n = ast_cast<AST_Enum>(type);
       v.name = canonical_name(n->name());
       break;
     }
@@ -1064,9 +1073,8 @@ void typeobject_generator::set_builtin_member_annotations(AST_Decl* member,
   OPENDDS_OPTIONAL_NS::optional<OpenDDS::XTypes::AppliedBuiltinMemberAnnotations>& annotations)
 {
   // Support only @hashid annotation for member at this time.
-  const HashidAnnotation* hashid_ann = dynamic_cast<const HashidAnnotation*>(be_global->builtin_annotations_["::@hashid"]);
   std::string hash_name;
-  if (hashid_ann->node_value_exists(member, hash_name)) {
+  if (be_global->hashid(member, hash_name)) {
     OPENDDS_OPTIONAL_NS::optional<std::string> hash_id(hash_name);
     if (!annotations) {
       OpenDDS::XTypes::AppliedBuiltinMemberAnnotations value;
@@ -1079,7 +1087,7 @@ void typeobject_generator::set_builtin_member_annotations(AST_Decl* member,
 void
 typeobject_generator::generate_struct_type_identifier(AST_Type* type)
 {
-  AST_Structure* const n = dynamic_cast<AST_Structure*>(type);
+  AST_Structure* const n = ast_cast<AST_Structure>(type);
   const Fields fields(n);
 
   const ExtensibilityKind exten = be_global->extensibility(n);
@@ -1114,38 +1122,39 @@ typeobject_generator::generate_struct_type_identifier(AST_Type* type)
     AST_Field* field = *i;
     const TryConstructFailAction trycon = be_global->try_construct(field);
 
-    OpenDDS::XTypes::MinimalStructMember minimal_member;
-    minimal_member.common.member_id = be_global->get_id(field);
-    minimal_member.common.member_flags = try_construct_to_member_flag(trycon);
+    OpenDDS::XTypes::StructMemberFlag member_flags = try_construct_to_member_flag(trycon);
 
     if (be_global->is_optional(field)) {
-      minimal_member.common.member_flags |= OpenDDS::XTypes::IS_OPTIONAL;
+      member_flags |= OpenDDS::XTypes::IS_OPTIONAL;
     }
 
     if (be_global->is_must_understand(field)) {
-      minimal_member.common.member_flags |= OpenDDS::XTypes::IS_MUST_UNDERSTAND;
+      member_flags |= OpenDDS::XTypes::IS_MUST_UNDERSTAND;
     }
 
     if (be_global->is_key(field)) {
-      minimal_member.common.member_flags |= OpenDDS::XTypes::IS_KEY;
+      member_flags |= OpenDDS::XTypes::IS_KEY;
     }
 
     if (be_global->is_external(field)) {
-      minimal_member.common.member_flags |= OpenDDS::XTypes::IS_EXTERNAL;
+      member_flags |= OpenDDS::XTypes::IS_EXTERNAL;
     }
 
-    minimal_member.common.member_type_id = get_minimal_type_identifier(field->field_type());
+    const OpenDDS::XTypes::MemberId member_id = be_global->get_id(field);
     const std::string name = canonical_name(field->local_name());
-    OpenDDS::XTypes::hash_member_name(minimal_member.detail.name_hash, name);
+    const OpenDDS::XTypes::MinimalStructMember minimal_member(
+      OpenDDS::XTypes::CommonStructMember(member_id, member_flags,
+                                          get_minimal_type_identifier(field->field_type())),
+      OpenDDS::XTypes::MinimalMemberDetail(name));
     minimal_to.minimal.struct_type.member_seq.append(minimal_member);
 
-    OpenDDS::XTypes::CompleteStructMember complete_member;
-    complete_member.common.member_id = minimal_member.common.member_id;
-    complete_member.common.member_flags = minimal_member.common.member_flags;
-    complete_member.common.member_type_id = get_complete_type_identifier(field->field_type());
-
-    complete_member.detail.name = name;
-    set_builtin_member_annotations(field, complete_member.detail.ann_builtin);
+    OpenDDS::XTypes::CompleteMemberDetail complete_detail;
+    complete_detail.name = name;
+    set_builtin_member_annotations(field, complete_detail.ann_builtin);
+    const OpenDDS::XTypes::CompleteStructMember complete_member(
+      OpenDDS::XTypes::CommonStructMember(member_id, member_flags,
+                                          get_complete_type_identifier(field->field_type())),
+      complete_detail);
 
     complete_to.complete.struct_type.member_seq.append(complete_member);
   }
@@ -1161,7 +1170,7 @@ typeobject_generator::generate_struct_type_identifier(AST_Type* type)
 void
 typeobject_generator::generate_union_type_identifier(AST_Type* type)
 {
-  AST_Union* const n = dynamic_cast<AST_Union*>(type);
+  AST_Union* const n = ast_cast<AST_Union>(type);
 
   AST_Type* const discriminator = n->disc_type();
   AST_Type* const discriminatorActual = resolveActualType(discriminator);
@@ -1187,11 +1196,12 @@ typeobject_generator::generate_union_type_identifier(AST_Type* type)
   }
 
   const TryConstructFailAction trycon = be_global->union_discriminator_try_construct(n);
-  minimal_to.minimal.union_type.discriminator.common.member_flags = try_construct_to_member_flag(trycon);
+  OpenDDS::XTypes::UnionDiscriminatorFlag discriminator_flags = try_construct_to_member_flag(trycon);
   if (be_global->union_discriminator_is_key(n)) {
-    minimal_to.minimal.union_type.discriminator.common.member_flags |= OpenDDS::XTypes::IS_KEY;
+    discriminator_flags |= OpenDDS::XTypes::IS_KEY;
   }
-  minimal_to.minimal.union_type.discriminator.common.type_id = get_minimal_type_identifier(discriminator);
+  minimal_to.minimal.union_type.discriminator.common =
+    OpenDDS::XTypes::CommonDiscriminatorMember(discriminator_flags, get_minimal_type_identifier(discriminator));
 
   complete_to.kind = OpenDDS::XTypes::EK_COMPLETE;
   complete_to.complete.kind = OpenDDS::XTypes::TK_UNION;
@@ -1199,12 +1209,11 @@ typeobject_generator::generate_union_type_identifier(AST_Type* type)
 
   complete_to.complete.union_type.header.detail.type_name = canonical_name(type->name());
 
-  complete_to.complete.union_type.discriminator.common.member_flags =
-    minimal_to.minimal.union_type.discriminator.common.member_flags;
-  complete_to.complete.union_type.discriminator.common.type_id = get_complete_type_identifier(discriminator);
+  complete_to.complete.union_type.discriminator.common =
+    OpenDDS::XTypes::CommonDiscriminatorMember(discriminator_flags, get_complete_type_identifier(discriminator));
 
   for (Fields::Iterator i = fields.begin(); i != fields.end(); ++i) {
-    AST_UnionBranch* branch = dynamic_cast<AST_UnionBranch*>(*i);
+    AST_UnionBranch* branch = ast_cast<AST_UnionBranch>(*i);
     const TryConstructFailAction try_con = be_global->try_construct(branch);
 
     bool is_default = false;
@@ -1216,20 +1225,17 @@ typeobject_generator::generate_union_type_identifier(AST_Type* type)
       }
     }
 
-    OpenDDS::XTypes::MinimalUnionMember minimal_member;
-    minimal_member.common.member_id = be_global->get_id(branch);
-    minimal_member.common.member_flags = try_construct_to_member_flag(try_con);
+    OpenDDS::XTypes::UnionMemberFlag member_flags = try_construct_to_member_flag(try_con);
 
     if (is_default) {
-      minimal_member.common.member_flags |= OpenDDS::XTypes::IS_DEFAULT;
+      member_flags |= OpenDDS::XTypes::IS_DEFAULT;
     }
 
     if (be_global->is_external(branch)) {
-      minimal_member.common.member_flags |= OpenDDS::XTypes::IS_EXTERNAL;
+      member_flags |= OpenDDS::XTypes::IS_EXTERNAL;
     }
 
-    minimal_member.common.type_id = get_minimal_type_identifier(branch->field_type());
-
+    OpenDDS::XTypes::UnionCaseLabelSeq label_seq;
     for (unsigned long j = 0; j < branch->label_list_length(); ++j) {
       AST_UnionLabel* label = branch->label(j);
       if (label->label_kind() != AST_UnionLabel::UL_default) {
@@ -1239,26 +1245,31 @@ typeobject_generator::generate_union_type_identifier(AST_Type* type)
           if (iter == enumValues->second.end()) {
             be_util::misc_error_and_abort("Unknown union label value", branch);
           }
-          minimal_member.common.label_seq.append(iter->second);
+          label_seq.append(iter->second);
         } else {
-          minimal_member.common.label_seq.append(to_long(*label->label_val()->ev()));
+          label_seq.append(to_long(*label->label_val()->ev()));
         }
       }
     }
-    minimal_member.common.label_seq.sort();
+    label_seq.sort();
 
+    const OpenDDS::XTypes::MemberId member_id = be_global->get_id(branch);
     const std::string name = canonical_name(branch->local_name());
-    OpenDDS::XTypes::hash_member_name(minimal_member.detail.name_hash, name);
+    const OpenDDS::XTypes::MinimalUnionMember minimal_member(
+      OpenDDS::XTypes::CommonUnionMember(member_id, member_flags,
+                                         get_minimal_type_identifier(branch->field_type()),
+                                         label_seq),
+      OpenDDS::XTypes::MinimalMemberDetail(name));
     minimal_to.minimal.union_type.member_seq.append(minimal_member);
 
-    OpenDDS::XTypes::CompleteUnionMember complete_member;
-    complete_member.common.member_id = minimal_member.common.member_id;
-    complete_member.common.member_flags = minimal_member.common.member_flags;
-    complete_member.common.type_id = get_complete_type_identifier(branch->field_type());
-    complete_member.common.label_seq = minimal_member.common.label_seq;
-
-    complete_member.detail.name = name;
-    set_builtin_member_annotations(branch, complete_member.detail.ann_builtin);
+    OpenDDS::XTypes::CompleteMemberDetail complete_detail;
+    complete_detail.name = name;
+    set_builtin_member_annotations(branch, complete_detail.ann_builtin);
+    const OpenDDS::XTypes::CompleteUnionMember complete_member(
+      OpenDDS::XTypes::CommonUnionMember(member_id, member_flags,
+                                         get_complete_type_identifier(branch->field_type()),
+                                         label_seq),
+      complete_detail);
 
     complete_to.complete.union_type.member_seq.append(complete_member);
   }
@@ -1274,7 +1285,7 @@ typeobject_generator::generate_union_type_identifier(AST_Type* type)
 void
 typeobject_generator::generate_enum_type_identifier(AST_Type* type)
 {
-  AST_Enum* const n = dynamic_cast<AST_Enum*>(type);
+  AST_Enum* const n = ast_cast<AST_Enum>(type);
   std::vector<AST_EnumVal*> contents;
   scope2vector(contents, n, AST_Decl::NT_enum_val);
   bool has_extensibility_annotation = false;
@@ -1295,6 +1306,7 @@ typeobject_generator::generate_enum_type_identifier(AST_Type* type)
   OpenDDS::XTypes::TypeObject minimal_to, complete_to;
   minimal_to.kind = OpenDDS::XTypes::EK_MINIMAL;
   minimal_to.minimal.kind = OpenDDS::XTypes::TK_ENUM;
+  minimal_to.minimal.enumerated_type.enum_flags = 0;
   if (has_extensibility_annotation || !be_global->default_enum_extensibility_zero()) {
     minimal_to.minimal.enumerated_type.enum_flags = extensibility_to_type_flag(ek);
   }
@@ -1303,6 +1315,7 @@ typeobject_generator::generate_enum_type_identifier(AST_Type* type)
 
   complete_to.kind = OpenDDS::XTypes::EK_COMPLETE;
   complete_to.complete.kind = OpenDDS::XTypes::TK_ENUM;
+  complete_to.complete.enumerated_type.enum_flags = 0;
   if (has_extensibility_annotation || !be_global->default_enum_extensibility_zero()) {
     complete_to.complete.enumerated_type.enum_flags = extensibility_to_type_flag(ek);
   }
@@ -1315,20 +1328,23 @@ typeobject_generator::generate_enum_type_identifier(AST_Type* type)
   for (size_t i = 0; i != contents.size(); ++i) {
     const std::string name = canonical_name(contents[i]->local_name());
 
-    OpenDDS::XTypes::MinimalEnumeratedLiteral minimal_lit;
-    if (!be_global->value(contents[i], minimal_lit.common.value)) {
-      minimal_lit.common.value = last_value + 1;
+    ACE_CDR::Long value = 0;
+    if (!be_global->value(contents[i], value)) {
+      value = last_value + 1;
     }
-    cached[name] = last_value = minimal_lit.common.value;
+    cached[name] = last_value = value;
 
-    minimal_lit.common.flags = (i == default_literal_idx ? OpenDDS::XTypes::IS_DEFAULT : 0);
+    const OpenDDS::XTypes::EnumeratedLiteralFlag literal_flags =
+      (i == default_literal_idx ? OpenDDS::XTypes::IS_DEFAULT : 0);
 
-    OpenDDS::XTypes::hash_member_name(minimal_lit.detail.name_hash, name);
+    const OpenDDS::XTypes::CommonEnumeratedLiteral common_literal(value, literal_flags);
+    const OpenDDS::XTypes::MinimalEnumeratedLiteral minimal_lit(
+      common_literal, OpenDDS::XTypes::MinimalMemberDetail(name));
     minimal_to.minimal.enumerated_type.literal_seq.append(minimal_lit);
 
-    OpenDDS::XTypes::CompleteEnumeratedLiteral complete_lit;
-    complete_lit.common = minimal_lit.common;
-    complete_lit.detail.name = name;
+    OpenDDS::XTypes::CompleteMemberDetail complete_detail;
+    complete_detail.name = name;
+    const OpenDDS::XTypes::CompleteEnumeratedLiteral complete_lit(common_literal, complete_detail);
 
     complete_to.complete.enumerated_type.literal_seq.append(complete_lit);
   }
@@ -1341,7 +1357,7 @@ typeobject_generator::generate_enum_type_identifier(AST_Type* type)
 void
 typeobject_generator::generate_array_type_identifier(AST_Type* type, bool force_type_object)
 {
-  AST_Array* const n = dynamic_cast<AST_Array*>(type);
+  AST_Array* const n = ast_cast<AST_Array>(type);
 
   const TryConstructFailAction trycon = be_global->try_construct(n->base_type());
   OpenDDS::XTypes::CollectionElementFlag cef = try_construct_to_member_flag(trycon);
@@ -1410,6 +1426,7 @@ typeobject_generator::generate_array_type_identifier(AST_Type* type, bool force_
     OpenDDS::XTypes::TypeObject minimal_to, complete_to;
     minimal_to.kind = OpenDDS::XTypes::EK_MINIMAL;
     minimal_to.minimal.kind = OpenDDS::XTypes::TK_ARRAY;
+    minimal_to.minimal.array_type.collection_flag = 0;
     for (ACE_CDR::ULong dim = 0; dim != n->n_dims(); ++dim) {
       minimal_to.minimal.array_type.header.common.bound_seq.append(n->dims()[dim]->ev()->u.ulval);
     }
@@ -1418,6 +1435,7 @@ typeobject_generator::generate_array_type_identifier(AST_Type* type, bool force_
 
     complete_to.kind = OpenDDS::XTypes::EK_COMPLETE;
     complete_to.complete.kind = OpenDDS::XTypes::TK_ARRAY;
+    complete_to.complete.array_type.collection_flag = 0;
     complete_to.complete.array_type.header.common.bound_seq = minimal_to.minimal.array_type.header.common.bound_seq;
     complete_to.complete.array_type.header.detail.type_name = canonical_name(type->name());
 
@@ -1432,7 +1450,7 @@ void
 typeobject_generator::generate_map_type_identifier(AST_Type* type, bool force_type_object)
 {
   using namespace OpenDDS::XTypes;
-  AST_Map* const n = dynamic_cast<AST_Map*>(type);
+  AST_Map* const n = ast_cast<AST_Map>(type);
   const ACE_CDR::ULong bound = n->unbounded() ? INVALID_LBOUND : n->max_size()->ev()->u.ulval;
 
   const TryConstructFailAction trykey = be_global->try_construct(n->key_type());
@@ -1481,6 +1499,7 @@ typeobject_generator::generate_map_type_identifier(AST_Type* type, bool force_ty
     TypeObject minimal_to;
     minimal_to.kind = EK_MINIMAL;
     minimal_to.minimal.kind = TK_MAP;
+    minimal_to.minimal.map_type.collection_flag = 0;
     minimal_to.minimal.map_type.header.common.bound = bound;
     minimal_to.minimal.map_type.key.common.element_flags = cef_key;
     minimal_to.minimal.map_type.key.common.type = minimal_key_ti;
@@ -1490,6 +1509,7 @@ typeobject_generator::generate_map_type_identifier(AST_Type* type, bool force_ty
     TypeObject complete_to;
     complete_to.kind = EK_COMPLETE;
     complete_to.complete.kind = TK_MAP;
+    complete_to.complete.map_type.collection_flag = 0;
     complete_to.complete.map_type.header.common = minimal_to.minimal.map_type.header.common;
     complete_to.complete.map_type.key.common.element_flags = cef_key;
     complete_to.complete.map_type.key.common.type = get_complete_type_identifier(n->key_type());
@@ -1503,7 +1523,7 @@ typeobject_generator::generate_map_type_identifier(AST_Type* type, bool force_ty
 void
 typeobject_generator::generate_sequence_type_identifier(AST_Type* type, bool force_type_object)
 {
-  AST_Sequence* const n = dynamic_cast<AST_Sequence*>(type);
+  AST_Sequence* const n = ast_cast<AST_Sequence>(type);
 
   ACE_CDR::ULong bound = 0;
   if (!n->unbounded()) {
@@ -1566,12 +1586,14 @@ typeobject_generator::generate_sequence_type_identifier(AST_Type* type, bool for
     OpenDDS::XTypes::TypeObject minimal_to, complete_to;
     minimal_to.kind = OpenDDS::XTypes::EK_MINIMAL;
     minimal_to.minimal.kind = OpenDDS::XTypes::TK_SEQUENCE;
+    minimal_to.minimal.sequence_type.collection_flag = 0;
     minimal_to.minimal.sequence_type.header.common.bound = bound;
     minimal_to.minimal.sequence_type.element.common.element_flags = cef;
     minimal_to.minimal.sequence_type.element.common.type = minimal_elem_ti;
 
     complete_to.kind = OpenDDS::XTypes::EK_COMPLETE;
     complete_to.complete.kind = OpenDDS::XTypes::TK_SEQUENCE;
+    complete_to.complete.sequence_type.collection_flag = 0;
     complete_to.complete.sequence_type.header.common.bound = bound;
     complete_to.complete.sequence_type.element.common.element_flags = cef;
     complete_to.complete.sequence_type.element.common.type = complete_elem_ti;
@@ -1583,16 +1605,20 @@ typeobject_generator::generate_sequence_type_identifier(AST_Type* type, bool for
 void
 typeobject_generator::generate_alias_type_identifier(AST_Type* type)
 {
-  AST_Typedef* const n = dynamic_cast<AST_Typedef*>(type);
+  AST_Typedef* const n = ast_cast<AST_Typedef>(type);
 
   OpenDDS::XTypes::TypeObject minimal_to, complete_to;
   minimal_to.kind = OpenDDS::XTypes::EK_MINIMAL;
   minimal_to.minimal.kind = OpenDDS::XTypes::TK_ALIAS;
+  minimal_to.minimal.alias_type.alias_flags = 0;
+  minimal_to.minimal.alias_type.body.common.related_flags = 0;
   minimal_to.minimal.alias_type.body.common.related_type = get_minimal_type_identifier(n->base_type());
 
   complete_to.kind = OpenDDS::XTypes::EK_COMPLETE;
   complete_to.complete.kind = OpenDDS::XTypes::TK_ALIAS;
+  complete_to.complete.alias_type.alias_flags = 0;
   complete_to.complete.alias_type.header.detail.type_name = canonical_name(type->name());
+  complete_to.complete.alias_type.body.common.related_flags = 0;
   complete_to.complete.alias_type.body.common.related_type = get_complete_type_identifier(n->base_type());
 
   update_maps(type, minimal_to, complete_to);
@@ -1601,7 +1627,7 @@ typeobject_generator::generate_alias_type_identifier(AST_Type* type)
 void
 typeobject_generator::generate_primitive_type_identifier(AST_Type* type)
 {
-  AST_PredefinedType* const n = dynamic_cast<AST_PredefinedType*>(type);
+  AST_PredefinedType* const n = ast_cast<AST_PredefinedType>(type);
   switch (n->pt()) {
   case AST_PredefinedType::PT_long:
     fully_desc_type_identifier_map_[type] = OpenDDS::XTypes::TypeIdentifier(OpenDDS::XTypes::TK_INT32);
@@ -1686,7 +1712,7 @@ typeobject_generator::generate_type_identifier(AST_Type* type, bool force_type_o
 
   case AST_ConcreteType::NT_string:
     {
-      AST_String* const n = dynamic_cast<AST_String*>(type);
+      AST_String* const n = ast_cast<AST_String>(type);
       ACE_CDR::ULong bound = n->max_size()->ev()->u.ulval;
       if (bound < 256) {
         OpenDDS::XTypes::TypeIdentifier ti(OpenDDS::XTypes::TI_STRING8_SMALL);
@@ -1702,7 +1728,7 @@ typeobject_generator::generate_type_identifier(AST_Type* type, bool force_type_o
 
   case AST_ConcreteType::NT_wstring:
     {
-      AST_String* const n = dynamic_cast<AST_String*>(type);
+      AST_String* const n = ast_cast<AST_String>(type);
       ACE_CDR::ULong bound = n->max_size()->ev()->u.ulval;
       if (bound < 256) {
         OpenDDS::XTypes::TypeIdentifier ti(OpenDDS::XTypes::TI_STRING16_SMALL);
@@ -1807,12 +1833,12 @@ typeobject_generator::get_minimal_type_identifier(AST_Type* type)
   switch(type->node_type()) {
   case AST_Decl::NT_union_fwd:
     {
-      AST_UnionFwd* const td = dynamic_cast<AST_UnionFwd*>(type);
+      AST_UnionFwd* const td = ast_cast<AST_UnionFwd>(type);
       return get_minimal_type_identifier(td->full_definition());
     }
   case AST_Decl::NT_struct_fwd:
     {
-      AST_StructureFwd* const td = dynamic_cast<AST_StructureFwd*>(type);
+      AST_StructureFwd* const td = ast_cast<AST_StructureFwd>(type);
       return get_minimal_type_identifier(td->full_definition());
     }
   default:
@@ -1834,12 +1860,12 @@ typeobject_generator::get_complete_type_identifier(AST_Type* type)
   switch(type->node_type()) {
   case AST_Decl::NT_union_fwd:
     {
-      AST_UnionFwd* const td = dynamic_cast<AST_UnionFwd*>(type);
+      AST_UnionFwd* const td = ast_cast<AST_UnionFwd>(type);
       return get_complete_type_identifier(td->full_definition());
     }
   case AST_Decl::NT_struct_fwd:
     {
-      AST_StructureFwd* const td = dynamic_cast<AST_StructureFwd*>(type);
+      AST_StructureFwd* const td = ast_cast<AST_StructureFwd>(type);
       return get_complete_type_identifier(td->full_definition());
     }
   default:

--- a/tests/unit-tests/dds/DCPS/DataSampleHeader.cpp
+++ b/tests/unit-tests/dds/DCPS/DataSampleHeader.cpp
@@ -16,3 +16,40 @@ TEST(dds_DCPS_DataSampleHeader, valid_data)
       << "msg_id is " << to_string(msg_id);
   }
 }
+
+TEST(dds_DCPS_DataSampleHeader, serialize_flags)
+{
+  DataSampleHeader header;
+  header.message_id_ = static_cast<char>(SAMPLE_DATA);
+  header.submessage_id_ = static_cast<char>(SUBMESSAGE_NONE);
+  header.coherent_change_ = true;
+  header.historic_sample_ = true;
+  header.lifespan_duration_ = true;
+  header.group_coherent_ = true;
+  header.sequence_repair_ = true;
+  header.more_fragments_ = true;
+  header.cdr_encapsulation_ = true;
+  header.key_fields_only_ = true;
+
+  ACE_Message_Block mb(DataSampleHeader::get_max_serialized_size());
+  ASSERT_TRUE(mb << header);
+
+  DataSampleHeader parsed(mb);
+  EXPECT_EQ(ACE_CDR_BYTE_ORDER != 0, parsed.byte_order_);
+  EXPECT_TRUE(parsed.coherent_change_);
+  EXPECT_TRUE(parsed.historic_sample_);
+  EXPECT_TRUE(parsed.lifespan_duration_);
+  EXPECT_TRUE(parsed.group_coherent_);
+  EXPECT_TRUE(parsed.sequence_repair_);
+  EXPECT_TRUE(parsed.more_fragments_);
+  EXPECT_TRUE(parsed.cdr_encapsulation_);
+  EXPECT_TRUE(parsed.key_fields_only_);
+
+  DataSampleHeader content_filter_header;
+  content_filter_header.message_id_ = static_cast<char>(SAMPLE_DATA);
+  content_filter_header.submessage_id_ = static_cast<char>(SUBMESSAGE_NONE);
+  content_filter_header.content_filter_ = true;
+  ACE_Message_Block content_filter_mb(DataSampleHeader::get_max_serialized_size());
+  ASSERT_TRUE(content_filter_mb << content_filter_header);
+  EXPECT_TRUE(DataSampleHeader::test_flag(CONTENT_FILTER_FLAG, &content_filter_mb));
+}

--- a/tests/unit-tests/dds/DCPS/JsonValueWriter.cpp
+++ b/tests/unit-tests/dds/DCPS/JsonValueWriter.cpp
@@ -29,6 +29,26 @@ public:
   size_t elements_;
 };
 
+struct ToJsonFail {};
+
+bool vwrite(ValueWriter&, const ToJsonFail&)
+{
+  return false;
+}
+
+struct ToJsonSuccess {};
+
+bool vwrite(ValueWriter& value_writer, const ToJsonSuccess&)
+{
+  return value_writer.begin_struct(FINAL) && value_writer.end_struct();
+}
+
+TEST(dds_DCPS_JsonValueWriter, to_json)
+{
+  EXPECT_STREQ("{}", to_json(ToJsonSuccess()).c_str());
+  EXPECT_TRUE(to_json(ToJsonFail()).empty());
+}
+
 TEST(dds_DCPS_JsonValueWriter, begin_struct)
 {
   Buffer buffer;


### PR DESCRIPTION
This PR is intended to address a number of small Coverity issues, namely:
- 1648943 - JsonValueWriter.h::to_json - Check vwrite() / writer return values in the string-returning to_json() overloads; return empty string on serialization failure. 
- 1527474 - TypeSupportImpl.h::TypeSupportInitializer - Check register_type() result, assert in debug if it fails, and only unregister during destruction if registration succeeded. 
- 1573405, 1573403, 1573398, 1573396 - XTypes/IdlScanner.h - Initialize IdlToken::numeric_value_ fields in the default constructor so token factory paths do not leave scalar members
 indeterminate. 
- 1594377 - XTypes/Utils.cpp::MemberPathParser::get_next_subpath - Remove the size_t decrement / underflow-prone loop logic and make consumption explicit. 
- 1594403 - DataSampleHeader.cpp::operator<< - Replace boolean left-shifts with DataSampleHeader::mask_flag() accumulation for serialized flag bytes. 
- 1594437, 1594418 - ReliableSession.cpp::send_naks - Avoid overflow around nak_delay_intervals_ + 1, and replace the floating-point threshold test with integer helper logic. 
- 1644788, 1644783 - typeobject_generator.cpp::generate_map_type_identifier - Initialize map collection_flag fields. 
- 1515269, 1515232 - typeobject_generator.cpp::generate_array_type_identifier - Initialize array collection_flag fields. 
- 1515195, 1515173 - typeobject_generator.cpp::generate_sequence_type_identifier - Initialize sequence collection_flag fields. 
- 1515285, 1515220 - typeobject_generator.cpp::generate_alias_type_identifier - Initialize alias flags and related-type flags. 
- 1515319, 1515260, 1515240 - typeobject_generator.cpp::generate_struct_type_identifier  - Build struct members via initialized XTypes constructors instead of partially filling default-constructed members.
- 1515230, 1515197, 1515149 - typeobject_generator.cpp::generate_union_type_identifier - Same idea for union discriminator/members: use initialized constructor paths and explicit flag variables. 
- 1515206, 1515193, 1515152 - typeobject_generator.cpp::generate_enum_type_identifier - Build enum literals from initialized common/detail objects. 
- 1644767, 1510264, 1510260, 1510258, 1510256, 1510253, 1510251, 1510250, 1510248, 1510245, 1510243, 1500892, 1500891, 1500884, 1500867 - typeobject_generator.cpp unchecked dynamic_cast sites - Add ast_cast() helper that checks the cast and aborts with an IDL generator error if the AST type is unexpected.
- 1643839 - typeobject_generator.cpp::set_builtin_member_annotations - Avoid direct unchecked cast to HashidAnnotation; use be_global->hashid() instead.
