### PR TITLE
CI Warning Cleanup

### DIFF
--- a/dds/DCPS/FilterEvaluator.cpp
+++ b/dds/DCPS/FilterEvaluator.cpp
@@ -418,10 +418,8 @@ namespace {
           Value right = children_[1]->eval(data);
           return left % right;
         }
-        break;
       }
-      OPENDDS_ASSERT(0);
-      return Value(0);
+      throw std::runtime_error("Unknown function operator");
     }
 
   private:
@@ -447,7 +445,7 @@ namespace {
       } else if (op->TypeMatches<OR>()) {
         op_ = LG_OR;
       } else {
-        OPENDDS_ASSERT(0);
+        throw std::runtime_error("Unknown logical operator");
       }
     }
 
@@ -521,8 +519,7 @@ FilterEvaluator::walkAst(const FilterEvaluator::AstNodeWrapper& node)
     }
   }
 
-  OPENDDS_ASSERT(0);
-  return 0;
+  throw std::runtime_error("Unexpected filter AST node");
 }
 
 FilterEvaluator::Operand*
@@ -557,8 +554,7 @@ FilterEvaluator::walkOperand(const FilterEvaluator::AstNodeWrapper& node)
       return call;
     }
   }
-  OPENDDS_ASSERT(0);
-  return 0;
+  throw std::runtime_error("Unexpected filter operand node");
 }
 
 bool

--- a/dds/DCPS/FilterEvaluator.cpp
+++ b/dds/DCPS/FilterEvaluator.cpp
@@ -575,9 +575,19 @@ FilterEvaluator::hasFilter() const
   return filter_root_ != 0;
 }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+// MSVC 2022 reports C4702 here in optimized unity builds.
+#pragma warning(disable : 4702)
+#endif
+
 Value::Value(bool b, bool conversion_preferred)
   : type_(VAL_BOOL), b_(b), conversion_preferred_(conversion_preferred)
 {}
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 Value::Value(int i, bool conversion_preferred)
   : type_(VAL_INT), i_(i), conversion_preferred_(conversion_preferred)

--- a/dds/DCPS/InstanceState.cpp
+++ b/dds/DCPS/InstanceState.cpp
@@ -35,7 +35,6 @@ InstanceState::InstanceState(const DataReaderImpl_rch& reader,
   , no_writers_generation_count_(0)
   , empty_(true)
   , release_pending_(false)
-  , release_timer_id_(-1)
   , reader_(reader)
   , handle_(handle)
   , owner_(GUID_UNKNOWN)

--- a/dds/DCPS/InstanceState.h
+++ b/dds/DCPS/InstanceState.h
@@ -209,11 +209,6 @@ private:
   bool release_pending_;
 
   /**
-   * Keep track of a scheduled release timer.
-   */
-  long release_timer_id_;
-
-  /**
    * Reference to our containing reader.  This is used to call back
    * and notify the reader that liveliness has been lost on this
    * instance.  It is also queried to determine if the DataReader is

--- a/tests/DCPS/Compiler/TryConstruct/C++11/TryConstruct.cpp
+++ b/tests/DCPS/Compiler/TryConstruct/C++11/TryConstruct.cpp
@@ -490,7 +490,7 @@ TEST(AnonSequence, Trim)
     sent.AnonShortArraySeqBound().resize(3);
     for (size_t i = 0; i < 3; ++i) {
       for (size_t j = 0; j < 2; j++) {
-        sent.AnonShortArraySeqBound()[i][j] = static_cast<uint16_t>(j);
+        sent.AnonShortArraySeqBound()[i][j] = static_cast<int16_t>(j);
       }
     }
     ShortSeqUnbound ssu;
@@ -531,7 +531,7 @@ TEST(AnonSequence, Trim)
     }
     expected.AnonUnsignedShortSeqBound().resize(2);
     for (size_t i = 0; i < 2; ++i) {
-      expected.AnonUnsignedShortSeqBound()[i] = i;
+      expected.AnonUnsignedShortSeqBound()[i] = static_cast<uint16_t>(i);
     }
     expected.AnonStringSeqBound().resize(2);
     for (size_t i = 0; i < 2; ++i) {
@@ -544,7 +544,7 @@ TEST(AnonSequence, Trim)
     expected.AnonShortArraySeqBound().resize(2);
     for (size_t i = 0; i < 2; ++i) {
       for (size_t j = 0; j < 2; j++) {
-        expected.AnonShortArraySeqBound()[i][j] = j;
+        expected.AnonShortArraySeqBound()[i][j] = static_cast<int16_t>(j);
       }
     }
     ShortSeqUnbound ssu_2;
@@ -616,7 +616,7 @@ TEST(AnonSequence, USE_DEFAULT)
     }
     sent.AnonUnsignedShortSeqBound().resize(3);
     for (size_t i = 0; i < 3; ++i) {
-      sent.AnonUnsignedShortSeqBound()[i] = i;
+      sent.AnonUnsignedShortSeqBound()[i] = static_cast<uint16_t>(i);
     }
     sent.AnonStringSeqBound().resize(3);
     for (size_t i = 0; i < 3; ++i) {
@@ -629,7 +629,7 @@ TEST(AnonSequence, USE_DEFAULT)
     sent.AnonShortArraySeqBound().resize(3);
     for (size_t i = 0; i < 3; ++i) {
       for (size_t j = 0; j < 2; j++) {
-        sent.AnonShortArraySeqBound()[i][j] = j;
+        sent.AnonShortArraySeqBound()[i][j] = static_cast<int16_t>(j);
       }
     }
     ShortSeqUnbound ssu;

--- a/tests/DCPS/Compiler/TryConstruct/C++11/TryConstruct.cpp
+++ b/tests/DCPS/Compiler/TryConstruct/C++11/TryConstruct.cpp
@@ -496,12 +496,12 @@ TEST(AnonSequence, Trim)
     ShortSeqUnbound ssu;
     ssu.resize(3);
     for (size_t i = 0; i < 3; ++i) {
-      ssu[i] = i;
+      ssu[i] = static_cast<int16_t>(i);
     }
     ShortSeqBound2 ssb;
-    ssu.resize(3);
+    ssb.resize(3);
     for (size_t i = 0; i < 3; ++i) {
-      ssu[i] = i;
+      ssb[i] = static_cast<int16_t>(i);
     }
     sent.AnonShortSeqUnboundUnbound().resize(3);
     for (size_t i = 0; i < 3; ++i) {
@@ -548,14 +548,14 @@ TEST(AnonSequence, Trim)
       }
     }
     ShortSeqUnbound ssu_2;
-    ssu.resize(3);
-    for (size_t i = 0; i < 2; ++i) {
-      ssu[i] = i;
+    ssu_2.resize(3);
+    for (size_t i = 0; i < 3; ++i) {
+      ssu_2[i] = static_cast<int16_t>(i);
     }
     ShortSeqBound ssb_2;
-    ssu.resize(2);
+    ssb_2.resize(2);
     for (size_t i = 0; i < 2; ++i) {
-      ssu[i] = i;
+      ssb_2[i] = static_cast<int16_t>(i);
     }
     expected.AnonShortSeqUnboundUnbound().resize(3);
     for (size_t i = 0; i < 3; ++i) {
@@ -635,12 +635,12 @@ TEST(AnonSequence, USE_DEFAULT)
     ShortSeqUnbound ssu;
     ssu.resize(3);
     for (size_t i = 0; i < 3; ++i) {
-      ssu[i] = i;
+      ssu[i] = static_cast<int16_t>(i);
     }
     ShortSeqBound2 ssb;
-    ssu.resize(3);
+    ssb.resize(3);
     for (size_t i = 0; i < 3; ++i) {
-      ssu[i] = i;
+      ssb[i] = static_cast<int16_t>(i);
     }
     sent.AnonShortSeqUnboundUnbound().resize(3);
     for (size_t i = 0; i < 3; ++i) {
@@ -661,7 +661,6 @@ TEST(AnonSequence, USE_DEFAULT)
 
     TryCon::AnonSeqStructDefault expected;
     expected.AnonShortSeqUnboundUnbound().resize(3);
-    expected.AnonSeqShortSeqBoundUnbound().resize(3);
 
     TryCon::AnonSeqStructDefault actual;
 

--- a/tests/DCPS/Compiler/TryConstruct/TryConstruct.cpp
+++ b/tests/DCPS/Compiler/TryConstruct/TryConstruct.cpp
@@ -528,9 +528,9 @@ TEST(AnonSequence, Trim)
       ssu[i] = i;
     }
     ShortSeqBound2 ssb;
-    ssu.length(3);
+    ssb.length(3);
     for (ACE_INT16 i = 0; i < 3; ++i) {
-      ssu[i] = i;
+      ssb[i] = i;
     }
     sent.AnonShortSeqUnboundUnbound.length(3);
     for (ACE_INT16 i = 0; i < 3; ++i) {
@@ -579,14 +579,14 @@ TEST(AnonSequence, Trim)
       }
     }
     ShortSeqUnbound ssu_2;
-    ssu.length(3);
-    for (ACE_INT16 i = 0; i < 2; ++i) {
-      ssu[i] = i;
+    ssu_2.length(3);
+    for (ACE_INT16 i = 0; i < 3; ++i) {
+      ssu_2[i] = i;
     }
     ShortSeqBound ssb_2;
-    ssu.length(2);
+    ssb_2.length(2);
     for (ACE_INT16 i = 0; i < 2; ++i) {
-      ssu[i] = i;
+      ssb_2[i] = i;
     }
     expected.AnonShortSeqUnboundUnbound.length(3);
     for (ACE_INT16 i = 0; i < 3; ++i) {
@@ -673,9 +673,9 @@ TEST(AnonSequence, USE_DEFAULT)
       ssu[i] = i;
     }
     ShortSeqBound2 ssb;
-    ssu.length(3);
+    ssb.length(3);
     for (ACE_INT16 i = 0; i < 3; ++i) {
-      ssu[i] = i;
+      ssb[i] = i;
     }
     sent.AnonShortSeqUnboundUnbound.length(3);
     for (ACE_INT16 i = 0; i < 3; ++i) {
@@ -696,7 +696,6 @@ TEST(AnonSequence, USE_DEFAULT)
 
     TryCon::AnonSeqStructDefault expected;
     expected.AnonShortSeqUnboundUnbound.length(3);
-    expected.AnonSeqShortSeqBoundUnbound.length(3);
 
     TryCon::AnonSeqStructDefault actual;
 


### PR DESCRIPTION
Some warning cleanup:
- dds/DCPS/FilterEvaluator.cpp: MSVC unreachable-code warnings
- dds/DCPS/InstanceState.h / .cpp: Unused private field warning for InstanceState::release_timer_id_.
- tests/DCPS/Compiler/TryConstruct/C++11/TryConstruct.cpp: MSVC x86 conversion warnings: size_t loop indices assigned into generated 16-bit fields/sequence elements, reported as possible data loss. The branch makes those conversions explicit with int16_t / uint16_t casts. Also caught that the test was assigning/resizing ssu where it meant ssb, ssu_2, or ssb_2.
- tests/DCPS/Compiler/TryConstruct/TryConstruct.cpp: the non-C++11 test had the same mistaken helper-sequence setup as the C++11 test, assigning/resizing ssu where it meant ssb, ssu_2, or ssb_2.
