### PR TITLE
Check for infinite interval before scheduling Liveliness timer

### DIFF
--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -2324,7 +2324,7 @@ DomainParticipantImpl::LivelinessTimer::~LivelinessTimer()
 void
 DomainParticipantImpl::LivelinessTimer::add_adjust(OpenDDS::DCPS::DataWriterImpl* writer)
 {
-  TimeDuration writer_interval = writer->liveliness_check_interval(kind_);
+  const TimeDuration writer_interval = writer->liveliness_check_interval(kind_);
   if (writer_interval.is_max()) {
     return;
   }

--- a/dds/DCPS/DomainParticipantImpl.cpp
+++ b/dds/DCPS/DomainParticipantImpl.cpp
@@ -2324,6 +2324,11 @@ DomainParticipantImpl::LivelinessTimer::~LivelinessTimer()
 void
 DomainParticipantImpl::LivelinessTimer::add_adjust(OpenDDS::DCPS::DataWriterImpl* writer)
 {
+  TimeDuration writer_interval = writer->liveliness_check_interval(kind_);
+  if (writer_interval.is_max()) {
+    return;
+  }
+
   ACE_GUARD(ACE_Thread_Mutex, guard, lock_);
 
   const MonotonicTimePoint now = MonotonicTimePoint::now();
@@ -2332,7 +2337,7 @@ DomainParticipantImpl::LivelinessTimer::add_adjust(OpenDDS::DCPS::DataWriterImpl
   const TimeDuration remaining = interval_ - (now - last_liveliness_check_);
 
   // Adopt a smaller interval.
-  interval_ = std::min(interval_, writer->liveliness_check_interval(kind_));
+  interval_ = std::min(interval_, writer_interval);
 
   // Reschedule or schedule a timer if necessary.
   if (scheduled_ && interval_ < remaining) {


### PR DESCRIPTION
- Problem
`LivelinessTimer::add_adjust` updates the liveliness interval of a `DomainParticipant` based on the input data writer's QoS policy. When the writer's liveliness kind does not match the kind of the specific `LivelinessTimer` object from `DomainParticipantImpl`, or when the writer's liveliness lease duration is infinite, the timer is scheduled with infinite duration, causing overflow when computing expiration time.

- Solution
Add a check and return when either of these conditions happens.