### PR TITLE
Minor Fix For Bench ReadAction WaitSet Use

### DIFF
--- a/performance-tests/bench/worker/ReadAction.cpp
+++ b/performance-tests/bench/worker/ReadAction.cpp
@@ -132,12 +132,12 @@ void ReadAction::do_read()
   if (started_ && !stopped_) {
     DDS::ConditionSeq active;
     const DDS::Duration_t duration = read_period_.to_dds_duration();
-    DDS::WaitSet_var ws_copy= ws_;
+    DDS::WaitSet_var ws_copy = ws_;
     DDS::ReturnCode_t ret;
 
     {
       reverse_guard rg(lock);
-      ret = ws_->wait(active, duration);
+      ret = ws_copy->wait(active, duration);
     }
 
     if (stopped_) {


### PR DESCRIPTION
Problem:
 - In ReadAction, a copy of a waitset is made under a lock, in order to use outside the lock.
 - But then the original is used outside the lock instead of the copy.

Solution:
 - Use the copy.