### PR TITLE
Guard against cyclic type alias assignability checks

### DIFF
--- a/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -13,6 +13,10 @@ OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 namespace OpenDDS {
 namespace XTypes {
 
+namespace {
+  const size_t MAX_ALIAS_CHAIN_LENGTH = 64;
+}
+
 /**
  * @brief Both input type objects must be minimal
  */
@@ -95,6 +99,10 @@ bool TypeAssignability::assignable(const TypeObject& ta,
 bool TypeAssignability::assignable(const TypeIdentifier& ta,
                                    const TypeIdentifier& tb) const
 {
+  if (ta == TypeIdentifier::None || tb == TypeIdentifier::None) {
+    return false;
+  }
+
   if (ta == tb) {
     return true;
   }
@@ -210,7 +218,7 @@ bool TypeAssignability::assignable_alias(const MinimalTypeObject& ta,
                                          const MinimalTypeObject& tb) const
 {
   if (TK_ALIAS == ta.kind && TK_ALIAS != tb.kind) {
-    const TypeIdentifier& tia = ta.alias_type.body.common.related_type;
+    const TypeIdentifier& tia = get_base_type(ta);
     switch (tia.kind()) {
     case TK_BOOLEAN:
     case TK_BYTE:
@@ -256,7 +264,7 @@ bool TypeAssignability::assignable_alias(const MinimalTypeObject& ta,
       return false; // Future extensions
     }
   } else if (TK_ALIAS != ta.kind && TK_ALIAS == tb.kind) {
-    const TypeIdentifier& tib = tb.alias_type.body.common.related_type;
+    const TypeIdentifier& tib = get_base_type(tb);
     switch (ta.kind) {
     case TK_ANNOTATION:
       return assignable_annotation(ta, tib);
@@ -280,8 +288,8 @@ bool TypeAssignability::assignable_alias(const MinimalTypeObject& ta,
       return false; // Future extensions
     }
   } else if (TK_ALIAS == ta.kind && TK_ALIAS == tb.kind) {
-    const TypeIdentifier& tia = ta.alias_type.body.common.related_type;
-    const TypeIdentifier& tib = tb.alias_type.body.common.related_type;
+    const TypeIdentifier& tia = get_base_type(ta);
+    const TypeIdentifier& tib = get_base_type(tb);
     return assignable(tia, tib);
   }
 
@@ -1970,23 +1978,35 @@ bool TypeAssignability::hold_key(const TypeIdentifier& ti, MinimalTypeObject& to
 
 /**
  * @brief The input must be of type TK_ALIAS
- * Return the non-alias base type identifier of the input
+ * Return the non-alias base type identifier of the input, or
+ * TypeIdentifier::None if the alias chain is cyclic or too deep.
  */
 const TypeIdentifier& TypeAssignability::get_base_type(const MinimalTypeObject& type) const
 {
-  const TypeIdentifier& base = type.alias_type.body.common.related_type;
-  switch (base.kind()) {
-  case EK_COMPLETE:
-  case EK_MINIMAL: {
-    const MinimalTypeObject& type_obj = lookup_minimal(base);
-    if (TK_ALIAS == type_obj.kind) {
-      return get_base_type(type_obj);
+  TypeIdentifierSet visited;
+  const MinimalTypeObject* current = &type;
+
+  for (size_t i = 0; i < MAX_ALIAS_CHAIN_LENGTH; ++i) {
+    const TypeIdentifier& base = current->alias_type.body.common.related_type;
+    switch (base.kind()) {
+    case EK_COMPLETE:
+    case EK_MINIMAL: {
+      if (!visited.insert(base).second) {
+        return TypeIdentifier::None;
+      }
+      const MinimalTypeObject& type_obj = lookup_minimal(base);
+      if (TK_ALIAS == type_obj.kind) {
+        current = &type_obj;
+        continue;
+      }
+      return base;
     }
-    return base;
+    default:
+      return base;
+    }
   }
-  default:
-    return base;
-  }
+
+  return TypeIdentifier::None;
 }
 
 /**

--- a/tests/unit-tests/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -2845,6 +2845,67 @@ TEST(dds_DCPS_XTypes_TypeAssignability, AliasTypeTest_NotAssignable)
   expect_false_alias_to_alias();
 }
 
+TEST(dds_DCPS_XTypes_TypeAssignability, AliasTypeTest_NestedAliasChainAssignable)
+{
+  TypeAssignability test(make_rch<TypeLookupService>());
+  EquivalenceHash hash;
+  get_equivalence_hash(hash);
+  const TypeIdentifier alias_b_id = make(EK_MINIMAL, hash);
+
+  MinimalAliasType alias_a;
+  MinimalAliasType alias_b;
+  alias_a.body.common.related_type = alias_b_id;
+  alias_b.body.common.related_type = TypeIdentifier(TK_INT32);
+  test.insert_entry(alias_b_id, TypeObject(MinimalTypeObject(alias_b)));
+
+  EXPECT_TRUE(test.assignable(TypeObject(MinimalTypeObject(alias_a)), TypeIdentifier(TK_INT32)));
+  EXPECT_TRUE(test.assignable(TypeIdentifier(TK_INT32), TypeObject(MinimalTypeObject(alias_a))));
+  EXPECT_TRUE(test.assignable(TypeObject(MinimalTypeObject(alias_a)),
+                              TypeObject(MinimalTypeObject(alias_b))));
+}
+
+TEST(dds_DCPS_XTypes_TypeAssignability, AliasTypeTest_CyclicAliasesNotAssignable)
+{
+  TypeAssignability test(make_rch<TypeLookupService>());
+
+  EquivalenceHash hash;
+  get_equivalence_hash(hash);
+  const TypeIdentifier self_alias_id = make(EK_MINIMAL, hash);
+
+  MinimalAliasType self_alias;
+  self_alias.body.common.related_type = self_alias_id;
+  test.insert_entry(self_alias_id, TypeObject(MinimalTypeObject(self_alias)));
+
+  MinimalSequenceType sequence_type;
+  sequence_type.header.common.bound = 10;
+  sequence_type.element.common.type = TypeIdentifier(TK_INT32);
+
+  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(self_alias)), TypeIdentifier(TK_INT32)));
+  EXPECT_FALSE(test.assignable(TypeIdentifier(TK_INT32), TypeObject(MinimalTypeObject(self_alias))));
+  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(self_alias)),
+                               TypeObject(MinimalTypeObject(sequence_type))));
+  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(self_alias)),
+                               TypeObject(MinimalTypeObject(self_alias))));
+
+  EquivalenceHash hash_a;
+  EquivalenceHash hash_b;
+  get_equivalence_hash(hash_a);
+  get_equivalence_hash(hash_b);
+  const TypeIdentifier alias_a_id = make(EK_MINIMAL, hash_a);
+  const TypeIdentifier alias_b_id = make(EK_MINIMAL, hash_b);
+
+  MinimalAliasType alias_a;
+  MinimalAliasType alias_b;
+  alias_a.body.common.related_type = alias_b_id;
+  alias_b.body.common.related_type = alias_a_id;
+  test.insert_entry(alias_a_id, TypeObject(MinimalTypeObject(alias_a)));
+  test.insert_entry(alias_b_id, TypeObject(MinimalTypeObject(alias_b)));
+
+  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(alias_a)), TypeIdentifier(TK_INT32)));
+  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(alias_a)),
+                               TypeObject(MinimalTypeObject(alias_b))));
+}
+
 TEST(dds_DCPS_XTypes_TypeAssignability, StructTypeTest_Assignable)
 {
   TypeAssignability test(make_rch<TypeLookupService>());


### PR DESCRIPTION
Problem:
 - A malicious or malformed XTypes alias chain can be cyclic, causing TypeAssignability::get_base_type() to recurse indefinitely while resolving aliases. This can terminate the process with stack overflow during type assignability checks.

Solution:
 - Replace recursive alias unwrapping with a bounded iterative walk that tracks visited TypeIdentifiers. Cyclic or excessively deep alias chains now resolve to an invalid type and are treated as not assignable, while normal alias chains continue to work. Regression tests cover nested aliases, self-cycles, and mutual cycles.