### PR TITLE
XTypes fixes from self-interop testing

### DIFF
--- a/.github/workflows/dds-xtypes.yml
+++ b/.github/workflows/dds-xtypes.yml
@@ -1,4 +1,4 @@
-name: "omg-dds/dds-rtps"
+name: "omg-dds/dds-xtypes"
 
 on:
   workflow_dispatch:
@@ -17,11 +17,12 @@ jobs:
       with:
         path: OpenDDS
         submodules: true
-    - name: checkout dds-rtps
+    - name: checkout dds-xtypes
       uses: actions/checkout@v7
       with:
-        repository: omg-dds/dds-rtps
-        path: dds-rtps
+        repository: omg-dds/dds-xtypes
+        ref: feature/xml-driver-enhanced
+        path: dds-xtypes
     - name: checkout ACE_TAO
       uses: actions/checkout@v7
       with:
@@ -44,33 +45,42 @@ jobs:
       with:
         repository: DOCGroup/MPC
         path: OpenDDS/ACE_TAO/ACE/MPC
+    - name: install dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libxerces-c-dev zip
     - name: configure OpenDDS
       run: |
         cd OpenDDS
-        ./configure --optimize --no-debug --static --no-inline
+        ./configure --optimize --no-debug --static --no-inline --xerces3
         tools/scripts/show_build_config.pl
     - uses: ammaraskar/gcc-problem-matcher@0.3.0
     - name: build OpenDDS
       shell: bash
       run: |
         cd OpenDDS
-        make -j4 OpenDDS_Rtps_Udp
-    - name: build shape_main
+        make -j4 OpenDDS_Rtps_Udp OpenDDS_XTypes_Xml
+    - name: build test_main
       shell: bash
       run: |
         . OpenDDS/setenv.sh
-        cd dds-rtps/srcCxx/opendds-cmake
-        cmake -S . -B build
+        cd dds-xtypes/src/cxx/opendds-cmake
+        cmake -S . -B build -DOpenDDS_DIR="$GITHUB_WORKSPACE/OpenDDS/cmake"
         cmake --build build -- -j4
-    - name: rename shape_main artifact
+    - name: package test_main artifact
       shell: bash
       run: |
         OPENDDS_VERSION=$(sed -n 's/^#define OPENDDS_VERSION "\(.*\)"/\1/p' OpenDDS/dds/Version.h)
         echo "OPENDDS_VERSION=$OPENDDS_VERSION" >> $GITHUB_ENV
-        cp dds-rtps/srcCxx/opendds-cmake/build/shape_main \
-          dds-rtps/srcCxx/opendds-cmake/build/opendds-${OPENDDS_VERSION}_shape_main_linux
-    - name: upload shape_main artifact
+        EXECUTABLE=opendds-${OPENDDS_VERSION}_test_main_linux
+        ARTIFACT=${EXECUTABLE}.zip
+        cp dds-xtypes/src/cxx/opendds-cmake/build/shape_main \
+          dds-xtypes/src/cxx/opendds-cmake/build/${EXECUTABLE}
+        (cd dds-xtypes/src/cxx/opendds-cmake/build && zip "$GITHUB_WORKSPACE/$ARTIFACT" "$EXECUTABLE")
+        echo "ARTIFACT=$ARTIFACT" >> $GITHUB_ENV
+    - name: upload test_main artifact
       uses: actions/upload-artifact@v7
       with:
-        name: opendds-${{ env.OPENDDS_VERSION }}_shape_main_linux
-        path: dds-rtps/srcCxx/opendds-cmake/build/opendds-${{ env.OPENDDS_VERSION }}_shape_main_linux
+        name: ${{ env.ARTIFACT }}
+        path: ${{ env.ARTIFACT }}

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -51,6 +51,31 @@ namespace {
 
 const OpenDDS::DCPS::MonotonicTime_t MTZERO = { 0, 0 };
 
+bool has_complete_equivalence(const OpenDDS::XTypes::TypeIdentifier& ti)
+{
+  using namespace OpenDDS::XTypes;
+  switch (ti.kind()) {
+  case EK_COMPLETE:
+    return true;
+  case TI_STRONGLY_CONNECTED_COMPONENT:
+    return ti.sc_component_id().sc_component_id.kind == EK_COMPLETE;
+  case TI_PLAIN_SEQUENCE_SMALL:
+    return ti.seq_sdefn().header.equiv_kind == EK_COMPLETE;
+  case TI_PLAIN_SEQUENCE_LARGE:
+    return ti.seq_ldefn().header.equiv_kind == EK_COMPLETE;
+  case TI_PLAIN_ARRAY_SMALL:
+    return ti.array_sdefn().header.equiv_kind == EK_COMPLETE;
+  case TI_PLAIN_ARRAY_LARGE:
+    return ti.array_ldefn().header.equiv_kind == EK_COMPLETE;
+  case TI_PLAIN_MAP_SMALL:
+    return ti.map_sdefn().header.equiv_kind == EK_COMPLETE;
+  case TI_PLAIN_MAP_LARGE:
+    return ti.map_ldefn().header.equiv_kind == EK_COMPLETE;
+  default:
+    return false;
+  }
+}
+
 bool checkAndAssignQos(DDS::PublicationBuiltinTopicData& dest,
                        const DDS::PublicationBuiltinTopicData& src)
 {
@@ -3879,6 +3904,17 @@ bool Sedp::TypeLookupRequestReader::process_get_types_request(
     result.types);
   if (result.types.length() > 0) {
     result.complete_to_minimal.length(0);
+    for (CORBA::ULong i = 0; i != result.types.length(); ++i) {
+      const XTypes::TypeIdentifier& complete_ti = result.types[i].type_identifier;
+      XTypes::TypeIdentifier minimal_ti;
+      if (has_complete_equivalence(complete_ti) &&
+          sedp_.type_lookup_service_->get_minimal_type_identifier(complete_ti, minimal_ti)) {
+        const CORBA::ULong length = result.complete_to_minimal.length();
+        result.complete_to_minimal.length(length + 1);
+        result.complete_to_minimal[length] =
+          XTypes::TypeIdentifierPair(complete_ti, minimal_ti);
+      }
+    }
 
     XTypes::TypeLookup_getTypes_Result typeResult;
     typeResult.result(result);
@@ -7626,7 +7662,7 @@ void Sedp::match_continue(UsedEndpoints& ue,
       XTypes::TypeAssignability ta(type_lookup_service_, type_consistency);
 
       if (drQos->type_consistency.kind == DDS::ALLOW_TYPE_COERCION) {
-        consistent = ta.assignable(reader_type_id, writer_type_id);
+        consistent = ta.assignable(*reader_type_info, *writer_type_info);
       } else {
         // The two types must be equivalent for DISALLOW_TYPE_COERCION
         consistent = reader_type_id == writer_type_id;

--- a/dds/DCPS/StaticDiscovery.cpp
+++ b/dds/DCPS/StaticDiscovery.cpp
@@ -1272,7 +1272,7 @@ void StaticEndpointManager::match_continue(const GUID_t& writer, const GUID_t& r
       XTypes::TypeAssignability ta(type_lookup_service_, type_consistency);
 
       if (drQos->type_consistency.kind == DDS::ALLOW_TYPE_COERCION) {
-        consistent = ta.assignable(reader_type_id, writer_type_id);
+        consistent = ta.assignable(*reader_type_info, *writer_type_info);
       } else {
         // The two types must be equivalent for DISALLOW_TYPE_COERCION
         consistent = reader_type_id == writer_type_id;

--- a/dds/DCPS/TypeSupportImpl.cpp
+++ b/dds/DCPS/TypeSupportImpl.cpp
@@ -11,6 +11,8 @@
 #include "Service_Participant.h"
 #include "XTypes/TypeLookupService.h"
 
+#include <set>
+
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
@@ -64,6 +66,63 @@ namespace {
                  "TypeIdentifier \"%C\" of topic type \"%C\" not found in local type map.\n",
                  method_name, str.c_str(), name));
     }
+  }
+
+  void add_complete_to_minimal_type_identifier_map(
+    const XTypes::TypeLookupService_rch& tls,
+    const XTypes::TypeMap& complete_type_map)
+  {
+    if (complete_type_map.empty()) {
+      return;
+    }
+
+    XTypes::TypeLookupService converter;
+    converter.add(complete_type_map.begin(), complete_type_map.end());
+
+    std::set<XTypes::TypeIdentifier> pending;
+    for (XTypes::TypeMap::const_iterator pos = complete_type_map.begin();
+         pos != complete_type_map.end(); ++pos) {
+      pending.insert(pos->first);
+    }
+
+    XTypes::TypeIdentifierPairSeq pairs;
+    while (!pending.empty()) {
+      bool progress = false;
+
+      for (std::set<XTypes::TypeIdentifier>::iterator pos = pending.begin();
+           pos != pending.end(); ) {
+        const XTypes::TypeMap::const_iterator complete = complete_type_map.find(*pos);
+        if (complete == complete_type_map.end()) {
+          pending.erase(pos++);
+          continue;
+        }
+
+        XTypes::TypeObject minimal;
+        if (!converter.complete_to_minimal_type_object(complete->second, minimal)) {
+          ++pos;
+          continue;
+        }
+
+        const XTypes::TypeIdentifier minimal_ti = XTypes::makeTypeIdentifier(minimal);
+        XTypes::TypeIdentifierPairSeq pair;
+        pair.length(1);
+        pair[0] = XTypes::TypeIdentifierPair(complete->first, minimal_ti);
+        converter.update_type_identifier_map(pair);
+
+        const CORBA::ULong length = pairs.length();
+        pairs.length(length + 1);
+        pairs[length] = pair[0];
+
+        pending.erase(pos++);
+        progress = true;
+      }
+
+      if (!progress) {
+        return;
+      }
+    }
+
+    tls->update_type_identifier_map(pairs);
   }
 }
 
@@ -128,6 +187,7 @@ void TypeSupportImpl::add_types(const XTypes::TypeLookupService_rch& tls) const
   tls->add(minTypeMap.begin(), minTypeMap.end());
   const TypeMap& comTypeMap = getCompleteTypeMap();
   tls->add(comTypeMap.begin(), comTypeMap.end());
+  add_complete_to_minimal_type_identifier_map(tls, comTypeMap);
 
   if (TheServiceParticipant->type_object_encoding() != Service_Participant::Encoding_Normal) {
     // In this mode we need to be able to recognize TypeIdentifiers received over the network

--- a/dds/DCPS/XTypes/DynamicDataImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataImpl.cpp
@@ -18,6 +18,8 @@
 #  include <dds/DdsDynamicDataSeqTypeSupportImpl.h>
 #  include <dds/DdsDcpsCoreTypeSupportImpl.h>
 
+#  include <cfloat>
+
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
@@ -26,6 +28,22 @@ namespace XTypes {
 using DCPS::LogLevel;
 using DCPS::log_level;
 using DCPS::retcode_to_string;
+
+namespace {
+
+void canonicalize_float128_padding(CORBA::LongDouble& value)
+{
+#if ACE_SIZEOF_LONG_DOUBLE == 16 && LDBL_MANT_DIG == 64 && !defined(ACE_BIG_ENDIAN)
+  char* const bytes = reinterpret_cast<char*>(&value);
+  for (size_t i = 10; i != 16; ++i) {
+    bytes[i] = 0;
+  }
+#else
+  ACE_UNUSED_ARG(value);
+#endif
+}
+
+}
 
 DynamicDataImpl::DynamicDataImpl(DDS::DynamicType_ptr type,
                                  DDS::DynamicData_ptr backing_store)
@@ -956,7 +974,9 @@ DynamicDataImpl::SingleValue::SingleValue(CORBA::Double float64)
 
 DynamicDataImpl::SingleValue::SingleValue(CORBA::LongDouble float128)
   : kind_(TK_FLOAT128), active_(0), float128_(float128)
-{}
+{
+  canonicalize_float128_padding(float128_);
+}
 
 DynamicDataImpl::SingleValue::SingleValue(ACE_OutputCDR::from_char value)
   : kind_(TK_CHAR8), active_(new(char8_) ACE_OutputCDR::from_char(value.val_))

--- a/dds/DCPS/XTypes/DynamicDataImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataImpl.cpp
@@ -18,8 +18,6 @@
 #  include <dds/DdsDynamicDataSeqTypeSupportImpl.h>
 #  include <dds/DdsDcpsCoreTypeSupportImpl.h>
 
-#  include <cfloat>
-
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
@@ -28,22 +26,6 @@ namespace XTypes {
 using DCPS::LogLevel;
 using DCPS::log_level;
 using DCPS::retcode_to_string;
-
-namespace {
-
-void canonicalize_float128_padding(CORBA::LongDouble& value)
-{
-#if ACE_SIZEOF_LONG_DOUBLE == 16 && LDBL_MANT_DIG == 64 && !defined(ACE_BIG_ENDIAN)
-  char* const bytes = reinterpret_cast<char*>(&value);
-  for (size_t i = 10; i != 16; ++i) {
-    bytes[i] = 0;
-  }
-#else
-  ACE_UNUSED_ARG(value);
-#endif
-}
-
-}
 
 DynamicDataImpl::DynamicDataImpl(DDS::DynamicType_ptr type,
                                  DDS::DynamicData_ptr backing_store)

--- a/dds/DCPS/XTypes/DynamicDataJson.cpp
+++ b/dds/DCPS/XTypes/DynamicDataJson.cpp
@@ -23,7 +23,6 @@
 #include <ace/OS_NS_string.h>
 
 #include <cerrno>
-#include <cfloat>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -325,18 +324,6 @@ char* float128_bytes(ACE_CDR::LongDouble& value)
   return reinterpret_cast<char*>(&value);
 #else
   return value.ld;
-#endif
-}
-
-void canonicalize_float128_padding(ACE_CDR::LongDouble& value)
-{
-#if ACE_SIZEOF_LONG_DOUBLE == 16 && LDBL_MANT_DIG == 64 && !defined(ACE_BIG_ENDIAN)
-  char* const bytes = float128_bytes(value);
-  for (size_t i = 10; i != 16; ++i) {
-    bytes[i] = 0;
-  }
-#else
-  ACE_UNUSED_ARG(value);
 #endif
 }
 

--- a/dds/DCPS/XTypes/DynamicDataJson.cpp
+++ b/dds/DCPS/XTypes/DynamicDataJson.cpp
@@ -23,6 +23,7 @@
 #include <ace/OS_NS_string.h>
 
 #include <cerrno>
+#include <cfloat>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -327,18 +328,23 @@ char* float128_bytes(ACE_CDR::LongDouble& value)
 #endif
 }
 
-const char* float128_bytes(const ACE_CDR::LongDouble& value)
+void canonicalize_float128_padding(ACE_CDR::LongDouble& value)
 {
-#if ACE_SIZEOF_LONG_DOUBLE == 16
-  return reinterpret_cast<const char*>(&value);
+#if ACE_SIZEOF_LONG_DOUBLE == 16 && LDBL_MANT_DIG == 64 && !defined(ACE_BIG_ENDIAN)
+  char* const bytes = float128_bytes(value);
+  for (size_t i = 10; i != 16; ++i) {
+    bytes[i] = 0;
+  }
 #else
-  return value.ld;
+  ACE_UNUSED_ARG(value);
 #endif
 }
 
 void float128_big_endian_bytes(const ACE_CDR::LongDouble& value, char bytes[16])
 {
-  const char* const src = float128_bytes(value);
+  ACE_CDR::LongDouble canonical = value;
+  canonicalize_float128_padding(canonical);
+  const char* const src = float128_bytes(canonical);
 #if defined(ACE_BIG_ENDIAN)
   ACE_OS::memcpy(bytes, src, 16);
 #else

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -626,38 +626,11 @@ bool DynamicDataXcdrReadImpl::get_union_item_count()
   }
 
 #if OPENDDS_CONFIG_IDL_MAP
-  DDS::DynamicTypeMembersById members;
-  rc = type_->get_all_members(members);
-  if (rc != DDS::RETCODE_OK) {
-    if (log_level >= LogLevel::Warning) {
-      ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: DynamicDataXcdrReadImpl::get_item_count:"
-                 " get_all_members returned %C\n", retcode_to_string(rc)));
-    }
-    return false;
+  DDS::MemberDescriptor_var selected_md = get_union_selected_member(label, true);
+  if (!selected_md && apply_union_discriminator_try_construct(label)) {
+    selected_md = get_union_selected_member(label, false);
   }
-  for (DDS::DynamicTypeMembersById::const_iterator it = members.begin(); it != members.end(); ++it) {
-    DDS::MemberDescriptor_var md;
-    rc = it->second->get_descriptor(md);
-    if (rc != DDS::RETCODE_OK) {
-      if (log_level >= LogLevel::Warning) {
-        ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: DynamicDataXcdrReadImpl::get_item_count:"
-                   " get_descriptor returned %C\n", retcode_to_string(rc)));
-      }
-      return false;
-    }
-    if (md->is_default_label()) {
-      item_count_ = 2;
-      return true;
-    }
-    const DDS::UnionCaseLabelSeq& labels = md->label();
-    for (ACE_CDR::ULong i = 0; i < labels.length(); ++i) {
-      if (label == labels[i]) {
-        item_count_ = 2;
-        return true;
-      }
-    }
-  }
-  item_count_ = 1;
+  item_count_ = selected_md ? 2 : 1;
   return true;
 #else
   return false;
@@ -934,6 +907,15 @@ DDS::MemberDescriptor* DynamicDataXcdrReadImpl::get_union_selected_member()
     return 0;
   }
 
+  DDS::MemberDescriptor_var selected_md = get_union_selected_member(label, true);
+  if (!selected_md && apply_union_discriminator_try_construct(label)) {
+    selected_md = get_union_selected_member(label, false);
+  }
+  return selected_md._retn();
+}
+
+DDS::MemberDescriptor* DynamicDataXcdrReadImpl::get_union_selected_member(ACE_CDR::Long label, bool allow_default)
+{
 #if OPENDDS_CONFIG_IDL_MAP
   DDS::DynamicTypeMembersById members;
   if (type_->get_all_members(members) != DDS::RETCODE_OK) {
@@ -960,7 +942,7 @@ DDS::MemberDescriptor* DynamicDataXcdrReadImpl::get_union_selected_member()
     }
   }
 
-  if (has_default) {
+  if (has_default && allow_default) {
     return default_member._retn();
   }
 #endif
@@ -3126,6 +3108,20 @@ bool DynamicDataXcdrReadImpl::read_discriminator(const DDS::DynamicType_ptr disc
   }
 }
 
+bool DynamicDataXcdrReadImpl::apply_union_discriminator_try_construct(ACE_CDR::Long& label)
+{
+  DDS::DynamicTypeMember_var disc_dtm;
+  if (type_->get_member(disc_dtm, DISCRIMINATOR_ID) != DDS::RETCODE_OK) {
+    return false;
+  }
+  DDS::MemberDescriptor_var disc_md;
+  if (disc_dtm->get_descriptor(disc_md) != DDS::RETCODE_OK) {
+    return false;
+  }
+
+  return apply_value_try_construct(label, disc_md) == DDS::RETCODE_OK;
+}
+
 bool DynamicDataXcdrReadImpl::skip_all()
 {
   const TypeKind tk = type_->get_kind();
@@ -3164,36 +3160,13 @@ bool DynamicDataXcdrReadImpl::skip_all()
       }
 
 #if OPENDDS_CONFIG_IDL_MAP
-      DDS::DynamicTypeMembersById members;
-      if (type_->get_all_members(members) != DDS::RETCODE_OK) {
-        return false;
+      DDS::MemberDescriptor_var selected_md = get_union_selected_member(label, true);
+      if (!selected_md && apply_union_discriminator_try_construct(label)) {
+        selected_md = get_union_selected_member(label, false);
       }
-
-      bool has_default = false;
-      DDS::MemberDescriptor_var default_member;
-      for (DDS::DynamicTypeMembersById::const_iterator it = members.begin(); it != members.end(); ++it) {
-        DDS::MemberDescriptor_var md;
-        if (it->second->get_descriptor(md) != DDS::RETCODE_OK) {
-          return false;
-        }
-        const DDS::UnionCaseLabelSeq& labels = md->label();
-        for (ACE_CDR::ULong i = 0; i < labels.length(); ++i) {
-          if (label == labels[i]) {
-            const DDS::DynamicType_ptr selected_member = md->type();
-            bool good = selected_member && skip_member(selected_member);
-            return good;
-          }
-        }
-
-        if (md->is_default_label()) {
-          has_default = true;
-          default_member = md;
-        }
-      }
-
-      if (has_default) {
-        const DDS::DynamicType_ptr default_dt = default_member->type();
-        bool good = default_dt && skip_member(default_dt);
+      if (selected_md) {
+        const DDS::DynamicType_ptr selected_dt = selected_md->type();
+        bool good = selected_dt && skip_member(selected_dt);
         return good;
       }
       if (DCPS::DCPS_debug_level >= 1) {

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -626,9 +626,12 @@ bool DynamicDataXcdrReadImpl::get_union_item_count()
   }
 
 #if OPENDDS_CONFIG_IDL_MAP
-  DDS::MemberDescriptor_var selected_md = get_union_selected_member(label, true);
+  DDS::MemberDescriptor_var selected_md = get_union_selected_member(label, false);
   if (!selected_md && apply_union_discriminator_try_construct(label)) {
     selected_md = get_union_selected_member(label, false);
+  }
+  if (!selected_md) {
+    selected_md = get_union_selected_member(label, true);
   }
   item_count_ = selected_md ? 2 : 1;
   return true;
@@ -907,9 +910,12 @@ DDS::MemberDescriptor* DynamicDataXcdrReadImpl::get_union_selected_member()
     return 0;
   }
 
-  DDS::MemberDescriptor_var selected_md = get_union_selected_member(label, true);
+  DDS::MemberDescriptor_var selected_md = get_union_selected_member(label, false);
   if (!selected_md && apply_union_discriminator_try_construct(label)) {
     selected_md = get_union_selected_member(label, false);
+  }
+  if (!selected_md) {
+    selected_md = get_union_selected_member(label, true);
   }
   return selected_md._retn();
 }
@@ -3160,9 +3166,12 @@ bool DynamicDataXcdrReadImpl::skip_all()
       }
 
 #if OPENDDS_CONFIG_IDL_MAP
-      DDS::MemberDescriptor_var selected_md = get_union_selected_member(label, true);
+      DDS::MemberDescriptor_var selected_md = get_union_selected_member(label, false);
       if (!selected_md && apply_union_discriminator_try_construct(label)) {
         selected_md = get_union_selected_member(label, false);
+      }
+      if (!selected_md) {
+        selected_md = get_union_selected_member(label, true);
       }
       if (selected_md) {
         const DDS::DynamicType_ptr selected_dt = selected_md->type();

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -3078,6 +3078,45 @@ bool DynamicDataXcdrReadImpl::read_discriminator(const DDS::DynamicType_ptr disc
       }
       return true;
     }
+  case TK_BITMASK:
+    {
+      TypeKind bound_kind = TK_NONE;
+      if (bitmask_bound(disc_type, bound_kind) != DDS::RETCODE_OK) {
+        return false;
+      }
+      switch (bound_kind) {
+      case TK_UINT8:
+        {
+          ACE_CDR::UInt8 value;
+          if (!(strm_ >> ACE_InputCDR::to_uint8(value))) { return false; }
+          label = static_cast<ACE_CDR::Long>(value);
+          return true;
+        }
+      case TK_UINT16:
+        {
+          ACE_CDR::UShort value;
+          if (!(strm_ >> value)) { return false; }
+          label = static_cast<ACE_CDR::Long>(value);
+          return true;
+        }
+      case TK_UINT32:
+        {
+          ACE_CDR::ULong value;
+          if (!(strm_ >> value)) { return false; }
+          label = static_cast<ACE_CDR::Long>(value);
+          return true;
+        }
+      case TK_UINT64:
+        {
+          ACE_CDR::ULongLong value;
+          if (!(strm_ >> value)) { return false; }
+          label = static_cast<ACE_CDR::Long>(value);
+          return true;
+        }
+      default:
+        return false;
+      }
+    }
   default:
     if (DCPS::DCPS_debug_level >= 1) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) DynamicDataXcdrReadImpl::read_discriminator - Union has")

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -3060,11 +3060,6 @@ bool DynamicDataXcdrReadImpl::read_discriminator(const DDS::DynamicType_ptr disc
     }
   case TK_ENUM:
     {
-      DDS::MemberDescriptor_var disc_md;
-      DDS::DynamicTypeMember_var disc_dtm;
-      if (type_->get_member(disc_dtm, DISCRIMINATOR_ID) == DDS::RETCODE_OK) {
-        disc_dtm->get_descriptor(disc_md);
-      }
       DDS::TypeDescriptor_var disc_td;
       if (disc_type->get_descriptor(disc_td) != DDS::RETCODE_OK) {
         return false;
@@ -3081,7 +3076,7 @@ bool DynamicDataXcdrReadImpl::read_discriminator(const DDS::DynamicType_ptr disc
       } else {
         if (!(strm_ >> label)) { return false; }
       }
-      return apply_value_try_construct(label, disc_md) == DDS::RETCODE_OK;
+      return true;
     }
   default:
     if (DCPS::DCPS_debug_level >= 1) {

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -57,12 +57,14 @@ DynamicDataXcdrReadImpl::DynamicDataXcdrReadImpl()
   , reset_align_state_(false)
   , strm_(0, encoding_)
   , item_count_(ITEM_COUNT_INVALID)
+  , item_count_limit_(ACE_UINT32_MAX)
 {}
 
 DynamicDataXcdrReadImpl::DynamicDataXcdrReadImpl(ACE_Message_Block* chain,
                                                  const DCPS::Encoding& encoding,
                                                  DDS::DynamicType_ptr type,
-                                                 DCPS::Sample::Extent ext)
+                                                 DCPS::Sample::Extent ext,
+                                                 ACE_CDR::ULong item_count_limit)
   : DynamicDataBase(type)
   , chain_(chain->duplicate())
   , encoding_(encoding)
@@ -70,6 +72,7 @@ DynamicDataXcdrReadImpl::DynamicDataXcdrReadImpl(ACE_Message_Block* chain,
   , reset_align_state_(false)
   , strm_(chain_, encoding_)
   , item_count_(ITEM_COUNT_INVALID)
+  , item_count_limit_(item_count_limit)
 {
   if (encoding_.xcdr_version() != DCPS::Encoding::XCDR_VERSION_1 &&
       encoding_.xcdr_version() != DCPS::Encoding::XCDR_VERSION_2) {
@@ -78,7 +81,8 @@ DynamicDataXcdrReadImpl::DynamicDataXcdrReadImpl(ACE_Message_Block* chain,
 }
 
 DynamicDataXcdrReadImpl::DynamicDataXcdrReadImpl(DCPS::Serializer& ser, DDS::DynamicType_ptr type,
-                                                 DCPS::Sample::Extent ext)
+                                                 DCPS::Sample::Extent ext,
+                                                 ACE_CDR::ULong item_count_limit)
   : DynamicDataBase(type)
   , chain_(ser.current()->duplicate())
   , encoding_(ser.encoding())
@@ -87,6 +91,7 @@ DynamicDataXcdrReadImpl::DynamicDataXcdrReadImpl(DCPS::Serializer& ser, DDS::Dyn
   , align_state_(ser.rdstate())
   , strm_(chain_, encoding_)
   , item_count_(ITEM_COUNT_INVALID)
+  , item_count_limit_(item_count_limit)
 {
   if (encoding_.xcdr_version() != DCPS::Encoding::XCDR_VERSION_1 &&
       encoding_.xcdr_version() != DCPS::Encoding::XCDR_VERSION_2) {
@@ -154,6 +159,7 @@ void DynamicDataXcdrReadImpl::copy(const DynamicDataXcdrReadImpl& other)
   strm_ = other.strm_;
   type_ = other.type_;
   item_count_ = other.item_count_;
+  item_count_limit_ = other.item_count_limit_;
 }
 
 DDS::ReturnCode_t DynamicDataXcdrReadImpl::set_descriptor(MemberId, DDS::MemberDescriptor*)
@@ -781,6 +787,9 @@ DDS::UInt32 DynamicDataXcdrReadImpl::get_item_count()
     return 0;
   }
 
+  if (item_count_limit_ != ACE_UINT32_MAX && item_count_ > item_count_limit_) {
+    item_count_ = item_count_limit_;
+  }
   return item_count_;
 }
 
@@ -904,7 +913,10 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_value_from_struct(MemberType& val
   if (rc != DDS::RETCODE_OK) {
     return rc;
   }
-  return read_value(value, MemberTypeKind) ? DDS::RETCODE_OK : DDS::RETCODE_ERROR;
+  if (!read_value(value, MemberTypeKind)) {
+    return DDS::RETCODE_ERROR;
+  }
+  return apply_value_try_construct(value, md);
 }
 
 DDS::MemberDescriptor* DynamicDataXcdrReadImpl::get_union_selected_member()
@@ -1035,15 +1047,20 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_value_from_union(
 
   const DDS::ExtensibilityKind ek = type_desc_->extensibility_kind();
   DDS::DynamicType_var member_type;
+  DDS::MemberDescriptor_var md;
   if (id == DISCRIMINATOR_ID) {
     if (ek == DDS::APPENDABLE || ek == DDS::MUTABLE) {
       if (!strm_.skip_delimiter()) {
         return DDS::RETCODE_ERROR;
       }
     }
+    DDS::DynamicTypeMember_var disc_dtm;
+    if (type_->get_member(disc_dtm, DISCRIMINATOR_ID) == DDS::RETCODE_OK) {
+      disc_dtm->get_descriptor(md);
+    }
     member_type = get_base_type(type_desc_->discriminator_type());
   } else {
-    DDS::MemberDescriptor_var md = get_from_union_common_checks(id, "get_value_from_union");
+    md = get_from_union_common_checks(id, "get_value_from_union");
     if (!md) {
       return DDS::RETCODE_ERROR;
     }
@@ -1079,7 +1096,10 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_value_from_union(
   }
 
   if (member_tk == MemberTypeKind) {
-    return read_value(value, MemberTypeKind) ? DDS::RETCODE_OK : DDS::RETCODE_ERROR;
+    if (!read_value(value, MemberTypeKind)) {
+      return DDS::RETCODE_ERROR;
+    }
+    return apply_value_try_construct(value, md);
   }
 
   DDS::TypeDescriptor_var td;
@@ -1088,8 +1108,10 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_value_from_union(
     return rc;
   }
   const LBound bit_bound = td->bound()[0];
-  return bit_bound >= lower && bit_bound <= upper &&
-    read_value(value, MemberTypeKind) ? DDS::RETCODE_OK : DDS::RETCODE_ERROR;
+  if (bit_bound < lower || bit_bound > upper || !read_value(value, MemberTypeKind)) {
+    return DDS::RETCODE_ERROR;
+  }
+  return apply_value_try_construct(value, md);
 }
 
 bool DynamicDataXcdrReadImpl::skip_to_sequence_element(MemberId id, DDS::DynamicType_ptr coll_type)
@@ -1672,8 +1694,13 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_complex_value(DDS::DynamicData_pt
         if (!member_type) {
           good = false;
         } else {
+          ACE_CDR::ULong item_count_limit;
+          if (try_construct_item_count_limit(item_count_limit, md) != DDS::RETCODE_OK) {
+            good = false;
+            break;
+          }
           CORBA::release(value);
-          value = new DynamicDataXcdrReadImpl(strm_, member_type, nested(extent_));
+          value = new DynamicDataXcdrReadImpl(strm_, member_type, nested(extent_), item_count_limit);
         }
       } else {
         good = false;
@@ -1735,8 +1762,13 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_complex_value(DDS::DynamicData_pt
       if (!member_type) {
         good = false;
       } else {
+        ACE_CDR::ULong item_count_limit;
+        if (try_construct_item_count_limit(item_count_limit, md) != DDS::RETCODE_OK) {
+          good = false;
+          break;
+        }
         CORBA::release(value);
-        value = new DynamicDataXcdrReadImpl(strm_, member_type, nested(extent_));
+        value = new DynamicDataXcdrReadImpl(strm_, member_type, nested(extent_), item_count_limit);
       }
       break;
     }
@@ -1855,6 +1887,213 @@ bool DynamicDataXcdrReadImpl::read_values(SequenceType& value, TypeKind elem_tk)
   return false;
 }
 
+template<typename ValueType>
+DDS::ReturnCode_t DynamicDataXcdrReadImpl::apply_value_try_construct(ValueType&, DDS::MemberDescriptor*) const
+{
+  return DDS::RETCODE_OK;
+}
+
+DDS::ReturnCode_t DynamicDataXcdrReadImpl::apply_value_try_construct(
+  CORBA::Long& value, DDS::MemberDescriptor* md) const
+{
+  if (!md) {
+    return DDS::RETCODE_OK;
+  }
+  const DDS::DynamicType_var member_type = get_base_type(md->type());
+  if (!member_type || member_type->get_kind() != TK_ENUM) {
+    return DDS::RETCODE_OK;
+  }
+
+  DDS::String8_var name;
+  if (get_enumerator_name(name, value, member_type) == DDS::RETCODE_OK) {
+    return DDS::RETCODE_OK;
+  }
+
+  if (md->try_construct_kind() != DDS::USE_DEFAULT) {
+    return DDS::RETCODE_ERROR;
+  }
+
+  const ACE_CDR::ULong count = member_type->get_member_count();
+  DDS::MemberDescriptor_var first_md;
+  for (ACE_CDR::ULong i = 0; i < count; ++i) {
+    DDS::DynamicTypeMember_var dtm;
+    if (member_type->get_member_by_index(dtm, i) != DDS::RETCODE_OK) {
+      return DDS::RETCODE_ERROR;
+    }
+    DDS::MemberDescriptor_var literal_md;
+    if (dtm->get_descriptor(literal_md) != DDS::RETCODE_OK) {
+      return DDS::RETCODE_ERROR;
+    }
+    if (i == 0) {
+      first_md = literal_md;
+    }
+    if (literal_md->is_default_label()) {
+      value = static_cast<CORBA::Long>(literal_md->id());
+      return DDS::RETCODE_OK;
+    }
+  }
+
+  if (!first_md) {
+    return DDS::RETCODE_ERROR;
+  }
+  value = static_cast<CORBA::Long>(first_md->id());
+  return DDS::RETCODE_OK;
+}
+
+template<>
+DDS::ReturnCode_t DynamicDataXcdrReadImpl::apply_value_try_construct(char*& value, DDS::MemberDescriptor* md) const
+{
+  return apply_string_try_construct(value, md);
+}
+
+#ifdef DDS_HAS_WCHAR
+template<>
+DDS::ReturnCode_t DynamicDataXcdrReadImpl::apply_value_try_construct(
+  CORBA::WChar*& value, DDS::MemberDescriptor* md) const
+{
+  return apply_wstring_try_construct(value, md);
+}
+#endif
+
+template<typename SequenceType>
+DDS::ReturnCode_t DynamicDataXcdrReadImpl::apply_sequence_try_construct(
+  SequenceType& value, DDS::MemberDescriptor* md) const
+{
+  if (!md) {
+    return DDS::RETCODE_OK;
+  }
+  const DDS::DynamicType_var member_type = get_base_type(md->type());
+  if (!member_type || member_type->get_kind() != TK_SEQUENCE) {
+    return DDS::RETCODE_OK;
+  }
+  DDS::TypeDescriptor_var td;
+  if (member_type->get_descriptor(td) != DDS::RETCODE_OK) {
+    return DDS::RETCODE_ERROR;
+  }
+  const CORBA::ULong bound = bound_total(td);
+  if (bound == 0 || value.length() <= bound) {
+    return DDS::RETCODE_OK;
+  }
+
+  switch (md->try_construct_kind()) {
+  case DDS::TRIM:
+    value.length(bound);
+    return DDS::RETCODE_OK;
+  case DDS::USE_DEFAULT:
+    value.length(0);
+    return DDS::RETCODE_OK;
+  case DDS::DISCARD:
+    break;
+  }
+  return DDS::RETCODE_ERROR;
+}
+
+DDS::ReturnCode_t DynamicDataXcdrReadImpl::apply_string_try_construct(
+  char*& value, DDS::MemberDescriptor* md) const
+{
+  if (!md || !value) {
+    return DDS::RETCODE_OK;
+  }
+  const DDS::DynamicType_var member_type = get_base_type(md->type());
+  if (!member_type || member_type->get_kind() != TK_STRING8) {
+    return DDS::RETCODE_OK;
+  }
+  DDS::TypeDescriptor_var td;
+  if (member_type->get_descriptor(td) != DDS::RETCODE_OK) {
+    return DDS::RETCODE_ERROR;
+  }
+  const CORBA::ULong bound = bound_total(td);
+  if (bound == 0 || ACE_OS::strlen(value) <= bound) {
+    return DDS::RETCODE_OK;
+  }
+
+  switch (md->try_construct_kind()) {
+  case DDS::TRIM:
+    value[bound] = '\0';
+    return DDS::RETCODE_OK;
+  case DDS::USE_DEFAULT:
+    CORBA::string_free(value);
+    value = CORBA::string_dup("");
+    return DDS::RETCODE_OK;
+  case DDS::DISCARD:
+    break;
+  }
+  return DDS::RETCODE_ERROR;
+}
+
+#ifdef DDS_HAS_WCHAR
+DDS::ReturnCode_t DynamicDataXcdrReadImpl::apply_wstring_try_construct(
+  CORBA::WChar*& value, DDS::MemberDescriptor* md) const
+{
+  if (!md || !value) {
+    return DDS::RETCODE_OK;
+  }
+  const DDS::DynamicType_var member_type = get_base_type(md->type());
+  if (!member_type || member_type->get_kind() != TK_STRING16) {
+    return DDS::RETCODE_OK;
+  }
+  DDS::TypeDescriptor_var td;
+  if (member_type->get_descriptor(td) != DDS::RETCODE_OK) {
+    return DDS::RETCODE_ERROR;
+  }
+  const CORBA::ULong bound = bound_total(td);
+  if (bound == 0 || ACE_OS::strlen(value) <= bound) {
+    return DDS::RETCODE_OK;
+  }
+
+  switch (md->try_construct_kind()) {
+  case DDS::TRIM:
+    value[bound] = 0;
+    return DDS::RETCODE_OK;
+  case DDS::USE_DEFAULT:
+    CORBA::wstring_free(value);
+    value = CORBA::wstring_dup(L"");
+    return DDS::RETCODE_OK;
+  case DDS::DISCARD:
+    break;
+  }
+  return DDS::RETCODE_ERROR;
+}
+#endif
+
+DDS::ReturnCode_t DynamicDataXcdrReadImpl::try_construct_item_count_limit(
+  ACE_CDR::ULong& limit, DDS::MemberDescriptor* md)
+{
+  limit = ACE_UINT32_MAX;
+  if (!md) {
+    return DDS::RETCODE_OK;
+  }
+  const DDS::DynamicType_var member_type = get_base_type(md->type());
+  if (!member_type || member_type->get_kind() != TK_SEQUENCE) {
+    return DDS::RETCODE_OK;
+  }
+  DDS::TypeDescriptor_var td;
+  if (member_type->get_descriptor(td) != DDS::RETCODE_OK) {
+    return DDS::RETCODE_ERROR;
+  }
+  const ACE_CDR::ULong bound = bound_total(td);
+  if (bound == 0) {
+    return DDS::RETCODE_OK;
+  }
+
+  DynamicDataXcdrReadImpl member_data(strm_, member_type, nested(extent_));
+  if (member_data.get_item_count() <= bound) {
+    return DDS::RETCODE_OK;
+  }
+
+  switch (md->try_construct_kind()) {
+  case DDS::TRIM:
+    limit = bound;
+    return DDS::RETCODE_OK;
+  case DDS::USE_DEFAULT:
+    limit = 0;
+    return DDS::RETCODE_OK;
+  case DDS::DISCARD:
+    break;
+  }
+  return DDS::RETCODE_ERROR;
+}
+
 template<TypeKind ElementTypeKind, typename SequenceType>
 DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_values_from_struct(SequenceType& value, MemberId id,
   TypeKind enum_or_bitmask, LBound lower, LBound upper)
@@ -1874,7 +2113,10 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_values_from_struct(SequenceType& 
     if (rc != DDS::RETCODE_OK) {
       return rc;
     }
-    return read_values(value, ElementTypeKind) ? DDS::RETCODE_OK : DDS::RETCODE_ERROR;
+    if (!read_values(value, ElementTypeKind)) {
+      return DDS::RETCODE_ERROR;
+    }
+    return apply_sequence_try_construct(value, md);
   }
 
   if (get_from_struct_common_checks(md, id, enum_or_bitmask, true)) {
@@ -1897,7 +2139,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_values_from_struct(SequenceType& 
           return rc;
         }
         if (read_values(value, enum_or_bitmask)) {
-          return DDS::RETCODE_OK;
+          return apply_sequence_try_construct(value, md);
         }
       }
     }
@@ -1976,14 +2218,15 @@ bool DynamicDataXcdrReadImpl::get_values_from_union(SequenceType& value, MemberI
   }
 
   if (elem_tk == ElementTypeKind) {
-    return read_values(value, ElementTypeKind);
+    return read_values(value, ElementTypeKind) && apply_sequence_try_construct(value, md) == DDS::RETCODE_OK;
   }
 
   if (elem_type->get_descriptor(td) != DDS::RETCODE_OK) {
     return false;
   }
   const LBound bit_bound = td->bound()[0];
-  return bit_bound >= lower && bit_bound <= upper && read_values(value, enum_or_bitmask);
+  return bit_bound >= lower && bit_bound <= upper && read_values(value, enum_or_bitmask)
+    && apply_sequence_try_construct(value, md) == DDS::RETCODE_OK;
 }
 
 template<TypeKind ElementTypeKind, typename SequenceType>
@@ -2817,6 +3060,11 @@ bool DynamicDataXcdrReadImpl::read_discriminator(const DDS::DynamicType_ptr disc
     }
   case TK_ENUM:
     {
+      DDS::MemberDescriptor_var disc_md;
+      DDS::DynamicTypeMember_var disc_dtm;
+      if (type_->get_member(disc_dtm, DISCRIMINATOR_ID) == DDS::RETCODE_OK) {
+        disc_dtm->get_descriptor(disc_md);
+      }
       DDS::TypeDescriptor_var disc_td;
       if (disc_type->get_descriptor(disc_td) != DDS::RETCODE_OK) {
         return false;
@@ -2831,9 +3079,9 @@ bool DynamicDataXcdrReadImpl::read_discriminator(const DDS::DynamicType_ptr disc
         if (!(strm_ >> value)) { return false; }
         label = static_cast<ACE_CDR::Long>(value);
       } else {
-        return strm_ >> label;
+        if (!(strm_ >> label)) { return false; }
       }
-      return true;
+      return apply_value_try_construct(label, disc_md) == DDS::RETCODE_OK;
     }
   default:
     if (DCPS::DCPS_debug_level >= 1) {

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -3176,8 +3176,7 @@ bool DynamicDataXcdrReadImpl::skip_all()
       }
       if (selected_md) {
         const DDS::DynamicType_ptr selected_dt = selected_md->type();
-        bool good = selected_dt && skip_member(selected_dt);
-        return good;
+        return selected_dt && skip_member(selected_dt);
       }
       if (DCPS::DCPS_debug_level >= 1) {
         ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) DynamicDataXcdrReadImpl::skip_all - Skip a union with no")

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -105,7 +105,7 @@ DynamicDataXcdrReadImpl::DynamicDataXcdrReadImpl(DCPS::Serializer& ser, DDS::Dyn
 }
 
 DynamicDataXcdrReadImpl::DynamicDataXcdrReadImpl(DCPS::Serializer& ser, DDS::DynamicType_ptr type,
-                                                 DCPS::Sample::Extent ext, size_t limit)
+                                                 DCPS::Sample::Extent ext, ByteLimitTag, size_t limit)
   : DynamicDataBase(type)
   , chain_(ser.trim(limit))
   , encoding_(ser.encoding())
@@ -114,6 +114,7 @@ DynamicDataXcdrReadImpl::DynamicDataXcdrReadImpl(DCPS::Serializer& ser, DDS::Dyn
   , align_state_(ser.rdstate())
   , strm_(chain_, encoding_)
   , item_count_(ITEM_COUNT_INVALID)
+  , item_count_limit_(ACE_UINT32_MAX)
 {
   if (encoding_.xcdr_version() != DCPS::Encoding::XCDR_VERSION_1 &&
       encoding_.xcdr_version() != DCPS::Encoding::XCDR_VERSION_2) {
@@ -1801,7 +1802,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_map_key_i(DDS::DynamicData_ptr& k
   }
   CORBA::release(key);
   key = encoded_size ?
-    new DynamicDataXcdrReadImpl(strm_, type_desc_->key_element_type(), nested(extent_), encoded_size) :
+    new DynamicDataXcdrReadImpl(strm_, type_desc_->key_element_type(), nested(extent_), ByteLimitTag(), encoded_size) :
     new DynamicDataXcdrReadImpl(strm_, type_desc_->key_element_type(), nested(extent_));
   return DDS::RETCODE_OK;
 }
@@ -1822,7 +1823,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_map_value_i(DDS::DynamicData_ptr&
   }
   CORBA::release(value);
   value = encoded_size ?
-    new DynamicDataXcdrReadImpl(strm_, type_desc_->element_type(), nested(extent_), encoded_size) :
+    new DynamicDataXcdrReadImpl(strm_, type_desc_->element_type(), nested(extent_), ByteLimitTag(), encoded_size) :
     new DynamicDataXcdrReadImpl(strm_, type_desc_->element_type(), nested(extent_));
   return DDS::RETCODE_OK;
 }

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -1970,7 +1970,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::apply_sequence_try_construct(
   if (member_type->get_descriptor(td) != DDS::RETCODE_OK) {
     return DDS::RETCODE_ERROR;
   }
-  const CORBA::ULong bound = bound_total(td);
+  const CORBA::ULong bound = td->bound().length() ? bound_total(td) : 0;
   if (bound == 0 || value.length() <= bound) {
     return DDS::RETCODE_OK;
   }
@@ -2002,7 +2002,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::apply_string_try_construct(
   if (member_type->get_descriptor(td) != DDS::RETCODE_OK) {
     return DDS::RETCODE_ERROR;
   }
-  const CORBA::ULong bound = bound_total(td);
+  const CORBA::ULong bound = td->bound().length() ? bound_total(td) : 0;
   if (bound == 0 || ACE_OS::strlen(value) <= bound) {
     return DDS::RETCODE_OK;
   }
@@ -2036,7 +2036,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::apply_wstring_try_construct(
   if (member_type->get_descriptor(td) != DDS::RETCODE_OK) {
     return DDS::RETCODE_ERROR;
   }
-  const CORBA::ULong bound = bound_total(td);
+  const CORBA::ULong bound = td->bound().length() ? bound_total(td) : 0;
   if (bound == 0 || ACE_OS::strlen(value) <= bound) {
     return DDS::RETCODE_OK;
   }
@@ -2071,7 +2071,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::try_construct_item_count_limit(
   if (member_type->get_descriptor(td) != DDS::RETCODE_OK) {
     return DDS::RETCODE_ERROR;
   }
-  const ACE_CDR::ULong bound = bound_total(td);
+  const ACE_CDR::ULong bound = td->bound().length() ? bound_total(td) : 0;
   if (bound == 0) {
     return DDS::RETCODE_OK;
   }

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.h
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.h
@@ -455,6 +455,7 @@ private:
 
   /// Return the member descriptor for the selected member from a union data or null.
   DDS::MemberDescriptor* get_union_selected_member();
+  DDS::MemberDescriptor* get_union_selected_member(ACE_CDR::Long label, bool allow_default);
 
   DDS::MemberDescriptor* get_from_union_common_checks(MemberId id, const char* func_name);
 
@@ -526,6 +527,7 @@ private:
   bool skip(const char* func_name, const char* description, size_t n, int size = 1);
 
   bool read_discriminator(const DDS::DynamicType_ptr disc_type, DDS::ExtensibilityKind union_ek, ACE_CDR::Long& label);
+  bool apply_union_discriminator_try_construct(ACE_CDR::Long& label);
 
   /// Skip a member of a final or appendable struct at the given index.
   ///

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.h
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.h
@@ -30,14 +30,16 @@ public:
   DynamicDataXcdrReadImpl(ACE_Message_Block* chain,
                           const DCPS::Encoding& encoding,
                           DDS::DynamicType_ptr type,
-                          DCPS::Sample::Extent ext = DCPS::Sample::Full);
+                          DCPS::Sample::Extent ext = DCPS::Sample::Full,
+                          ACE_CDR::ULong item_count_limit = ACE_UINT32_MAX);
 
   /// Use this when you want to pass the alignment state of a given Serializer object over.
   /// A typical use case would be when a part of the data has already been consumed from
   /// @a ser and you want to give the remaining to DynamicData.
   /// The provided type is expected to be the type of the binary data.
   DynamicDataXcdrReadImpl(DCPS::Serializer& ser, DDS::DynamicType_ptr type,
-                          DCPS::Sample::Extent ext = DCPS::Sample::Full);
+                          DCPS::Sample::Extent ext = DCPS::Sample::Full,
+                          ACE_CDR::ULong item_count_limit = ACE_UINT32_MAX);
 
   DynamicDataXcdrReadImpl(const DynamicDataXcdrReadImpl& other);
   DynamicDataXcdrReadImpl& operator=(const DynamicDataXcdrReadImpl& other);
@@ -475,6 +477,19 @@ private:
   template<typename SequenceType>
   bool read_values(SequenceType& value, TypeKind elem_tk);
 
+  template<typename ValueType>
+  DDS::ReturnCode_t apply_value_try_construct(ValueType& value, DDS::MemberDescriptor* md) const;
+
+  DDS::ReturnCode_t apply_value_try_construct(CORBA::Long& value, DDS::MemberDescriptor* md) const;
+
+  template<typename SequenceType>
+  DDS::ReturnCode_t apply_sequence_try_construct(SequenceType& value, DDS::MemberDescriptor* md) const;
+
+  DDS::ReturnCode_t apply_string_try_construct(char*& value, DDS::MemberDescriptor* md) const;
+#ifdef DDS_HAS_WCHAR
+  DDS::ReturnCode_t apply_wstring_try_construct(CORBA::WChar*& value, DDS::MemberDescriptor* md) const;
+#endif
+
   ///@{
   /** Templates for reading a sequence of primitives, strings or wstrings
    *  as a member (or an element) of a given containing type. See get_value_from_struct
@@ -543,6 +558,8 @@ private:
 
   bool has_optional_member(bool& has_optional) const;
 
+  DDS::ReturnCode_t try_construct_item_count_limit(ACE_CDR::ULong& limit, DDS::MemberDescriptor* md);
+
   /// A set of strings used to prevent infinite recursion when checking for XCDR1 Mutable
   typedef OPENDDS_SET(DCPS::String) DynamicTypeNameSet;
   bool check_xcdr1_mutable_i(DDS::DynamicType_ptr dt, DynamicTypeNameSet& dtns);
@@ -579,6 +596,7 @@ private:
 
   /// Cache the number of items (i.e., members or elements) in the data it holds.
   ACE_CDR::ULong item_count_;
+  ACE_CDR::ULong item_count_limit_;
 };
 
 OpenDDS_Dcps_Export bool print_dynamic_data(DDS::DynamicData_ptr dd,

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.h
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.h
@@ -353,10 +353,12 @@ public:
   }
 
 private:
+  struct ByteLimitTag {};
+
   /// Like the Serializer constructor, but limits the duplicated chain to
   /// @a limit bytes from the serializer's current read position.
   DynamicDataXcdrReadImpl(DCPS::Serializer& ser, DDS::DynamicType_ptr type,
-                          DCPS::Sample::Extent ext, size_t limit);
+                          DCPS::Sample::Extent ext, ByteLimitTag, size_t limit);
 
   DDS::ReturnCode_t get_map_key_i(DDS::DynamicData_ptr& key, DDS::MemberId id);
   DDS::ReturnCode_t get_map_value_i(DDS::DynamicData_ptr& value, DDS::MemberId id);

--- a/dds/DCPS/XTypes/DynamicSample.cpp
+++ b/dds/DCPS/XTypes/DynamicSample.cpp
@@ -22,6 +22,182 @@ namespace XTypes {
 
 using namespace OpenDDS::DCPS;
 
+namespace {
+
+enum ValidationResult {
+  VALID,
+  ABSENT,
+  INVALID
+};
+
+ValidationResult validate_dynamic_data(DDS::DynamicData_ptr data, DDS::DynamicType_ptr type);
+
+ValidationResult result(DDS::ReturnCode_t rc)
+{
+  return rc == DDS::RETCODE_OK ? VALID : rc == DDS::RETCODE_NO_DATA ? ABSENT : INVALID;
+}
+
+ValidationResult validate_scalar(DDS::DynamicData_ptr data, DDS::MemberId id, DDS::DynamicType_ptr type)
+{
+  const DDS::DynamicType_var base = get_base_type(type);
+  if (!data || !base) {
+    return INVALID;
+  }
+
+  switch (base->get_kind()) {
+  case TK_BOOLEAN: {
+    DDS::Boolean value = false;
+    return result(data->get_boolean_value(value, id));
+  }
+  case TK_BYTE: {
+    DDS::Byte value = 0;
+    return result(data->get_byte_value(value, id));
+  }
+  case TK_UINT8:
+  case TK_UINT16:
+  case TK_UINT32:
+  case TK_UINT64: {
+    DDS::UInt64 value = 0;
+    return result(get_uint_value(value, data, id, base->get_kind()));
+  }
+  case TK_INT8:
+  case TK_INT16:
+  case TK_INT32:
+  case TK_INT64: {
+    DDS::Int64 value = 0;
+    return result(get_int_value(value, data, id, base->get_kind()));
+  }
+  case TK_FLOAT32: {
+    DDS::Float32 value = 0;
+    return result(data->get_float32_value(value, id));
+  }
+  case TK_FLOAT64: {
+    DDS::Float64 value = 0;
+    return result(data->get_float64_value(value, id));
+  }
+  case TK_FLOAT128: {
+    DDS::Float128 value = ACE_CDR_LONG_DOUBLE_INITIALIZER;
+    return result(data->get_float128_value(value, id));
+  }
+  case TK_CHAR8: {
+    CORBA::Char value = 0;
+    return result(data->get_char8_value(value, id));
+  }
+  case TK_CHAR16: {
+    CORBA::WChar value = 0;
+    return result(data->get_char16_value(value, id));
+  }
+  case TK_STRING8: {
+    CORBA::String_var value;
+    return result(data->get_string_value(value, id));
+  }
+  case TK_STRING16: {
+    CORBA::WString_var value;
+    return result(data->get_wstring_value(value, id));
+  }
+  case TK_ENUM: {
+    DDS::Int32 value = 0;
+    return result(get_enum_value(value, base, data, id));
+  }
+  case TK_BITMASK: {
+    DDS::UInt64 value = 0;
+    return result(get_bitmask_value(value, base, data, id));
+  }
+  default:
+    return INVALID;
+  }
+}
+
+ValidationResult validate_member(DDS::DynamicData_ptr data, DDS::MemberId id, DDS::DynamicType_ptr type)
+{
+  const DDS::DynamicType_var base = get_base_type(type);
+  if (!base) {
+    return INVALID;
+  }
+
+  if (is_complex(base->get_kind())) {
+    DDS::DynamicData_var nested;
+    const DDS::ReturnCode_t rc = data->get_complex_value(nested, id);
+    if (rc != DDS::RETCODE_OK) {
+      return result(rc);
+    }
+    return validate_dynamic_data(nested, base);
+  }
+
+  return validate_scalar(data, id, base);
+}
+
+ValidationResult validate_dynamic_data(DDS::DynamicData_ptr data, DDS::DynamicType_ptr type)
+{
+  const DDS::DynamicType_var base = get_base_type(type);
+  if (!data || !base) {
+    return INVALID;
+  }
+
+  switch (base->get_kind()) {
+  case TK_STRUCTURE: {
+    const DDS::UInt32 count = base->get_member_count();
+    for (DDS::UInt32 i = 0; i != count; ++i) {
+      DDS::DynamicTypeMember_var member;
+      if (base->get_member_by_index(member, i) != DDS::RETCODE_OK) {
+        return INVALID;
+      }
+      DDS::MemberDescriptor_var md;
+      if (member->get_descriptor(md) != DDS::RETCODE_OK) {
+        return INVALID;
+      }
+      if (validate_member(data, md->id(), md->type()) == INVALID) {
+        return INVALID;
+      }
+    }
+    return VALID;
+  }
+  case TK_UNION: {
+    DDS::TypeDescriptor_var td;
+    if (base->get_descriptor(td) != DDS::RETCODE_OK) {
+      return INVALID;
+    }
+    if (validate_scalar(data, DISCRIMINATOR_ID, td->discriminator_type()) != VALID) {
+      return INVALID;
+    }
+    if (data->get_item_count() <= 1) {
+      return VALID;
+    }
+    const DDS::MemberId branch_id = data->get_member_id_at_index(1);
+    DDS::DynamicTypeMember_var member;
+    if (base->get_member(member, branch_id) != DDS::RETCODE_OK) {
+      return INVALID;
+    }
+    DDS::MemberDescriptor_var md;
+    if (member->get_descriptor(md) != DDS::RETCODE_OK) {
+      return INVALID;
+    }
+    return validate_member(data, branch_id, md->type()) == INVALID ? INVALID : VALID;
+  }
+  case TK_ARRAY:
+  case TK_SEQUENCE: {
+    DDS::TypeDescriptor_var td;
+    if (base->get_descriptor(td) != DDS::RETCODE_OK) {
+      return INVALID;
+    }
+    const DDS::DynamicType_var element_type = get_base_type(td->element_type());
+    const DDS::UInt32 count = base->get_kind() == TK_ARRAY ? bound_total(td) : data->get_item_count();
+    for (DDS::UInt32 i = 0; i != count; ++i) {
+      if (validate_member(data, i, element_type) != VALID) {
+        return INVALID;
+      }
+    }
+    return VALID;
+  }
+  case TK_MAP:
+    return VALID;
+  default:
+    return validate_scalar(data, MEMBER_ID_INVALID, base);
+  }
+}
+
+}
+
 DynamicSample::DynamicSample()
 {}
 
@@ -101,6 +277,9 @@ bool DynamicSample::deserialize(Serializer& ser)
 
   const DDS::DynamicType_var type = data_->type();
   DDS::DynamicData_var back = new DynamicDataXcdrReadImpl(mb.get(), ser.encoding(), type, extent_);
+  if (validate_dynamic_data(back, type) != VALID) {
+    return false;
+  }
   data_ = new DynamicDataImpl(type, back);
   return true;
 }

--- a/dds/DCPS/XTypes/DynamicSample.cpp
+++ b/dds/DCPS/XTypes/DynamicSample.cpp
@@ -157,7 +157,7 @@ ValidationResult validate_dynamic_data(DDS::DynamicData_ptr data, DDS::DynamicTy
     if (base->get_descriptor(td) != DDS::RETCODE_OK) {
       return INVALID;
     }
-    if (validate_scalar(data, DISCRIMINATOR_ID, td->discriminator_type()) != VALID) {
+    if (validate_scalar(data, DISCRIMINATOR_ID, td->discriminator_type()) == INVALID) {
       return INVALID;
     }
     if (data->get_item_count() <= 1) {

--- a/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -415,7 +415,7 @@ bool TypeAssignability::assignable_struct(const MinimalTypeObject& ta,
 
   // If T1 is appendable, then members with the same member_index have the
   // same member ID, the same setting for the 'optional' attribute and the
-  // T1 member type is assignable from the T2 member type.
+  // T1 member type is strongly assignable from the T2 member type.
   // If T1 is final, then they meet the same condition as for T1 being
   // appendable and in addition T1 and T2 have the same set of member IDs.
   if (IS_FINAL == a_exten &&
@@ -430,8 +430,8 @@ bool TypeAssignability::assignable_struct(const MinimalTypeObject& ta,
           tb.struct_type.member_seq[i].common.member_id ||
           (ta.struct_type.member_seq[i].common.member_flags & IS_OPTIONAL) !=
           (tb.struct_type.member_seq[i].common.member_flags & IS_OPTIONAL) ||
-          !assignable(ta.struct_type.member_seq[i].common.member_type_id,
-                      tb.struct_type.member_seq[i].common.member_type_id)) {
+          !strongly_assignable(ta.struct_type.member_seq[i].common.member_type_id,
+                               tb.struct_type.member_seq[i].common.member_type_id)) {
         return false;
       }
     }
@@ -576,68 +576,46 @@ bool TypeAssignability::assignable_struct(const MinimalTypeObject& ta,
     }
   }
 
-  // For any string key member m2 in T2, the m1 member of T1 with the
-  // same member ID verifies m1.type.length >= m2.type.length
-  for (size_t i = 0; i < matched_members.size(); ++i) {
-    const CommonStructMember& member = matched_members[i].second->common;
-    MemberFlag flags = member.member_flags;
-    LBound bound_a, bound_b;
-    if ((flags & IS_KEY) == IS_KEY && get_string_bound(bound_b, member)) {
-      if (!get_string_bound(bound_a, matched_members[i].first->common)) {
-        return false;
-      }
-      if (bound_a < bound_b) {
-        return false;
+  if (!type_consistency_.ignore_string_bounds) {
+    // For any string key member m2 in T2, the m1 member of T1 with the
+    // same member ID verifies m1.type.length >= m2.type.length
+    for (size_t i = 0; i < matched_members.size(); ++i) {
+      const CommonStructMember& member = matched_members[i].second->common;
+      MemberFlag flags = member.member_flags;
+      LBound bound_a, bound_b;
+      if ((flags & IS_KEY) == IS_KEY && get_string_bound(bound_b, member)) {
+        if (!get_string_bound(bound_a, matched_members[i].first->common)) {
+          return false;
+        }
+        if (bound_a < bound_b) {
+          return false;
+        }
       }
     }
   }
 
-  // For any enumerated key member m2 in T2, the m1 member of T1 with
-  // the same member ID verifies that all literals in m2.type appear as
-  // literals in m1.type
-  for (size_t i = 0; i < matched_members.size(); ++i) {
-    const CommonStructMember& member = matched_members[i].second->common;
-    MemberFlag flags = member.member_flags;
-    if ((flags & IS_KEY) == IS_KEY &&
-        EK_MINIMAL == member.member_type_id.kind()) {
-      const MinimalTypeObject& tob = lookup_minimal(member.member_type_id);
-      if (TK_ENUM == tob.kind) {
-        if (!struct_rule_enum_key(tob, matched_members[i].first->common)) {
-          return false;
-        }
-      } else if (TK_ALIAS == tob.kind) {
-        const TypeIdentifier& base_b = get_base_type(tob);
-        if (EK_MINIMAL == base_b.kind()) {
-          const MinimalTypeObject& base_obj_b = lookup_minimal(base_b);
-          if (TK_ENUM == base_obj_b.kind &&
-              !struct_rule_enum_key(base_obj_b, matched_members[i].first->common)) {
+  if (!type_consistency_.ignore_sequence_bounds) {
+    // For any sequence or map key member m2 in T2, the m1 member of T1
+    // with the same member ID verifies m1.type.length >= m2.type.length
+    for (size_t i = 0; i < matched_members.size(); ++i) {
+      const CommonStructMember& member = matched_members[i].second->common;
+      MemberFlag flags = member.member_flags;
+      LBound bound_a, bound_b;
+      if ((flags & IS_KEY) == IS_KEY) {
+        if (get_sequence_bound(bound_b, member)) {
+          if (!get_sequence_bound(bound_a, matched_members[i].first->common)) {
             return false;
           }
-        }
-      }
-    }
-  }
-
-  // For any sequence or map key member m2 in T2, the m1 member of T1
-  // with the same member ID verifies m1.type.length >= m2.type.length
-  for (size_t i = 0; i < matched_members.size(); ++i) {
-    const CommonStructMember& member = matched_members[i].second->common;
-    MemberFlag flags = member.member_flags;
-    LBound bound_a, bound_b;
-    if ((flags & IS_KEY) == IS_KEY) {
-      if (get_sequence_bound(bound_b, member)) {
-        if (!get_sequence_bound(bound_a, matched_members[i].first->common)) {
-          return false;
-        }
-        if (bound_a < bound_b) {
-          return false;
-        }
-      } else if (get_map_bound(bound_b, member)) {
-        if (!get_map_bound(bound_a, matched_members[i].first->common)) {
-          return false;
-        }
-        if (bound_a < bound_b) {
-          return false;
+          if (bound_a < bound_b) {
+            return false;
+          }
+        } else if (get_map_bound(bound_b, member)) {
+          if (!get_map_bound(bound_a, matched_members[i].first->common)) {
+            return false;
+          }
+          if (bound_a < bound_b) {
+            return false;
+          }
         }
       }
     }

--- a/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -32,6 +32,32 @@ namespace {
     return ti.kind() == TI_PLAIN_SEQUENCE_SMALL ?
       ti.seq_sdefn().bound : ti.seq_ldefn().bound;
   }
+
+  bool has_default_label(const MinimalUnionMemberSeq& members)
+  {
+    for (unsigned i = 0; i < members.length(); ++i) {
+      if ((members[i].common.member_flags & IS_DEFAULT) == IS_DEFAULT) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool has_explicit_label(const MinimalUnionMemberSeq& members, ACE_CDR::Long label)
+  {
+    for (unsigned i = 0; i < members.length(); ++i) {
+      if ((members[i].common.member_flags & IS_DEFAULT) == IS_DEFAULT) {
+        continue;
+      }
+      const UnionCaseLabelSeq& labels = members[i].common.label_seq;
+      for (unsigned j = 0; j < labels.length(); ++j) {
+        if (labels[j] == label) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 }
 
 /**
@@ -752,6 +778,10 @@ bool TypeAssignability::assignable_union(const MinimalTypeObject& ta,
     if (labels_set_a.size() > 0) {
       return false;
     }
+    if (has_default_label(ta.union_type.member_seq) !=
+        has_default_label(tb.union_type.member_seq)) {
+      return false;
+    }
   } else { // Must have at least one common label other than the default
     // This implementation assumes that the default member has IS_DEFAULT
     // flag turned on, but the label "default" does not map into a numeric
@@ -839,6 +869,12 @@ bool TypeAssignability::assignable_union(const MinimalTypeObject& ta,
       for (unsigned k = 0; k < label_seq_b.length(); ++k) {
         for (unsigned t = 0; t < label_seq_a.length(); ++t) {
           if (label_seq_b.members[k] == label_seq_a.members[t]) {
+            if (name_hash_equal(ta.union_type.member_seq[j].detail.name_hash,
+                                tb.union_type.member_seq[i].detail.name_hash) &&
+                ta.union_type.member_seq[j].common.member_id !=
+                tb.union_type.member_seq[i].common.member_id) {
+              return false;
+            }
             const TypeIdentifier& ti_a = ta.union_type.member_seq[j].common.type_id;
             const TypeIdentifier& ti_b = tb.union_type.member_seq[i].common.type_id;
             if (!assignable(ti_a, ti_b)) {
@@ -853,29 +889,52 @@ bool TypeAssignability::assignable_union(const MinimalTypeObject& ta,
     }
   }
 
-  // If any non-default labels of T1 that select the default member of T2,
+  // If any non-default labels of T1 select the default member of T2,
   // the type of the member in T1 is assignable from the type of the default
-  // member in T2
+  // member in T2.
   for (unsigned i = 0; i < tb.union_type.member_seq.length(); ++i) {
     const UnionMemberFlag& mem_flags_b = tb.union_type.member_seq[i].common.member_flags;
     if ((mem_flags_b & IS_DEFAULT) == IS_DEFAULT) {
-      const UnionCaseLabelSeq& label_seq_b = tb.union_type.member_seq[i].common.label_seq;
       for (unsigned j = 0; j < ta.union_type.member_seq.length(); ++j) {
+        const UnionMemberFlag& mem_flags_a = ta.union_type.member_seq[j].common.member_flags;
+        if ((mem_flags_a & IS_DEFAULT) == IS_DEFAULT) {
+          continue;
+        }
         const UnionCaseLabelSeq& label_seq_a = ta.union_type.member_seq[j].common.label_seq;
-        bool matched = false;
         for (unsigned k = 0; k < label_seq_a.length(); ++k) {
-          for (unsigned t = 0; t < label_seq_b.length(); ++t) {
-            if (label_seq_a[k] == label_seq_b[t]) {
-              const TypeIdentifier& ti_a = ta.union_type.member_seq[j].common.type_id;
-              const TypeIdentifier& ti_b = tb.union_type.member_seq[i].common.type_id;
-              if (!assignable(ti_a, ti_b)) {
-                return false;
-              }
-              matched = true;
-              break;
+          if (!has_explicit_label(tb.union_type.member_seq, label_seq_a[k])) {
+            const TypeIdentifier& ti_a = ta.union_type.member_seq[j].common.type_id;
+            const TypeIdentifier& ti_b = tb.union_type.member_seq[i].common.type_id;
+            if (!assignable(ti_a, ti_b)) {
+              return false;
             }
           }
-          if (matched) break;
+        }
+      }
+      break;
+    }
+  }
+
+  // If any non-default labels of T2 select the default member of T1,
+  // the type of T1's default member is assignable from the type of the
+  // member in T2.
+  for (unsigned i = 0; i < ta.union_type.member_seq.length(); ++i) {
+    const UnionMemberFlag& mem_flags_a = ta.union_type.member_seq[i].common.member_flags;
+    if ((mem_flags_a & IS_DEFAULT) == IS_DEFAULT) {
+      for (unsigned j = 0; j < tb.union_type.member_seq.length(); ++j) {
+        const UnionMemberFlag& mem_flags_b = tb.union_type.member_seq[j].common.member_flags;
+        if ((mem_flags_b & IS_DEFAULT) == IS_DEFAULT) {
+          continue;
+        }
+        const UnionCaseLabelSeq& label_seq_b = tb.union_type.member_seq[j].common.label_seq;
+        for (unsigned k = 0; k < label_seq_b.length(); ++k) {
+          if (!has_explicit_label(ta.union_type.member_seq, label_seq_b[k])) {
+            const TypeIdentifier& ti_a = ta.union_type.member_seq[i].common.type_id;
+            const TypeIdentifier& ti_b = tb.union_type.member_seq[j].common.type_id;
+            if (!assignable(ti_a, ti_b)) {
+              return false;
+            }
+          }
         }
       }
       break;

--- a/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -1002,8 +1002,8 @@ bool TypeAssignability::assignable_sequence(const MinimalTypeObject& ta,
                         tb.sequence_type.header.common.bound)) {
     return false;
   }
-  return assignable(ta.sequence_type.element.common.type,
-                    tb.sequence_type.element.common.type);
+  return strongly_assignable(ta.sequence_type.element.common.type,
+                             tb.sequence_type.element.common.type);
 }
 
 /**
@@ -1018,15 +1018,15 @@ bool TypeAssignability::assignable_sequence(const MinimalTypeObject& ta,
         !bound_assignable(ta.sequence_type.header.common.bound, tb.seq_sdefn().bound)) {
       return false;
     }
-    return assignable(ta.sequence_type.element.common.type,
-                      *tb.seq_sdefn().element_identifier);
+    return strongly_assignable(ta.sequence_type.element.common.type,
+                               *tb.seq_sdefn().element_identifier);
   } else if (TI_PLAIN_SEQUENCE_LARGE == tb.kind()) {
     if (!type_consistency_.ignore_sequence_bounds &&
         !bound_assignable(ta.sequence_type.header.common.bound, tb.seq_ldefn().bound)) {
       return false;
     }
-    return assignable(ta.sequence_type.element.common.type,
-                      *tb.seq_ldefn().element_identifier);
+    return strongly_assignable(ta.sequence_type.element.common.type,
+                               *tb.seq_ldefn().element_identifier);
   } else if (EK_MINIMAL == tb.kind()) {
     const MinimalTypeObject& tob = lookup_minimal(tb);
     if (TK_SEQUENCE == tob.kind) {
@@ -1066,8 +1066,8 @@ bool TypeAssignability::assignable_array(const MinimalTypeObject& ta,
       return false;
     }
   }
-  return assignable(ta.array_type.element.common.type,
-                    tb.array_type.element.common.type);
+  return strongly_assignable(ta.array_type.element.common.type,
+                             tb.array_type.element.common.type);
 }
 
 /**
@@ -1090,8 +1090,8 @@ bool TypeAssignability::assignable_array(const MinimalTypeObject& ta,
       }
     }
 
-    return assignable(ta.array_type.element.common.type,
-                      *tb.array_sdefn().element_identifier);
+    return strongly_assignable(ta.array_type.element.common.type,
+                               *tb.array_sdefn().element_identifier);
   } else if (TI_PLAIN_ARRAY_LARGE == tb.kind()) {
     const LBoundSeq& bounds_b = tb.array_ldefn().array_bound_seq;
     if (bounds_a.members.size() != bounds_b.members.size()) {
@@ -1103,8 +1103,8 @@ bool TypeAssignability::assignable_array(const MinimalTypeObject& ta,
         return false;
       }
     }
-    return assignable(ta.array_type.element.common.type,
-                      *tb.array_ldefn().element_identifier);
+    return strongly_assignable(ta.array_type.element.common.type,
+                               *tb.array_ldefn().element_identifier);
   } else if (EK_MINIMAL == tb.kind()) {
     const MinimalTypeObject& tob = lookup_minimal(tb);
     if (TK_ARRAY == tob.kind) {
@@ -1446,11 +1446,11 @@ bool TypeAssignability::assignable_plain_sequence(const TypeIdentifier& ta,
       return false;
     }
     if (TI_PLAIN_SEQUENCE_SMALL == ta.kind()) {
-      return assignable(*ta.seq_sdefn().element_identifier,
-                        *tb.seq_sdefn().element_identifier);
+      return strongly_assignable(*ta.seq_sdefn().element_identifier,
+                                 *tb.seq_sdefn().element_identifier);
     } else { // TI_PLAIN_SEQUENCE_LARGE
-      return assignable(*ta.seq_ldefn().element_identifier,
-                        *tb.seq_sdefn().element_identifier);
+      return strongly_assignable(*ta.seq_ldefn().element_identifier,
+                                 *tb.seq_sdefn().element_identifier);
     }
   } else if (TI_PLAIN_SEQUENCE_LARGE == tb.kind()) {
     if (!type_consistency_.ignore_sequence_bounds &&
@@ -1458,11 +1458,11 @@ bool TypeAssignability::assignable_plain_sequence(const TypeIdentifier& ta,
       return false;
     }
     if (TI_PLAIN_SEQUENCE_SMALL == ta.kind()) {
-      return assignable(*ta.seq_sdefn().element_identifier,
-                        *tb.seq_ldefn().element_identifier);
+      return strongly_assignable(*ta.seq_sdefn().element_identifier,
+                                 *tb.seq_ldefn().element_identifier);
     } else { // TI_PLAIN_SEQUENCE_LARGE
-      return assignable(*ta.seq_ldefn().element_identifier,
-                        *tb.seq_ldefn().element_identifier);
+      return strongly_assignable(*ta.seq_ldefn().element_identifier,
+                                 *tb.seq_ldefn().element_identifier);
     }
   } else if (EK_MINIMAL == tb.kind()) {
     const MinimalTypeObject& tob = lookup_minimal(tb);
@@ -1496,11 +1496,11 @@ bool TypeAssignability::assignable_plain_sequence(const TypeIdentifier& ta,
       return false;
     }
     if (TI_PLAIN_SEQUENCE_SMALL == ta.kind()) {
-      return assignable(*ta.seq_sdefn().element_identifier,
-                        tb.sequence_type.element.common.type);
+      return strongly_assignable(*ta.seq_sdefn().element_identifier,
+                                 tb.sequence_type.element.common.type);
     } else { // TI_PLAIN_SEQUENCE_LARGE
-      return assignable(*ta.seq_ldefn().element_identifier,
-                        tb.sequence_type.element.common.type);
+      return strongly_assignable(*ta.seq_ldefn().element_identifier,
+                                 tb.sequence_type.element.common.type);
     }
   }
 
@@ -1528,8 +1528,8 @@ bool TypeAssignability::assignable_plain_array(const TypeIdentifier& ta,
         }
       }
 
-      return assignable(*ta.array_sdefn().element_identifier,
-                        *tb.array_sdefn().element_identifier);
+      return strongly_assignable(*ta.array_sdefn().element_identifier,
+                                 *tb.array_sdefn().element_identifier);
     } else { // TI_PLAIN_ARRAY_LARGE
       const Sequence<LBound>& bounds_a = ta.array_ldefn().array_bound_seq;
       if (bounds_a.members.size() != bounds_b.members.size()) {
@@ -1542,8 +1542,8 @@ bool TypeAssignability::assignable_plain_array(const TypeIdentifier& ta,
         }
       }
 
-      return assignable(*ta.array_ldefn().element_identifier,
-                        *tb.array_sdefn().element_identifier);
+      return strongly_assignable(*ta.array_ldefn().element_identifier,
+                                 *tb.array_sdefn().element_identifier);
     }
   } else if (TI_PLAIN_ARRAY_LARGE == tb.kind()) {
     const Sequence<LBound>& bounds_b = tb.array_ldefn().array_bound_seq;
@@ -1559,8 +1559,8 @@ bool TypeAssignability::assignable_plain_array(const TypeIdentifier& ta,
         }
       }
 
-      return assignable(*ta.array_sdefn().element_identifier,
-                        *tb.array_ldefn().element_identifier);
+      return strongly_assignable(*ta.array_sdefn().element_identifier,
+                                 *tb.array_ldefn().element_identifier);
     } else { // TI_PLAIN_ARRAY_LARGE
       const Sequence<LBound>& bounds_a = ta.array_ldefn().array_bound_seq;
       if (bounds_a.members.size() != bounds_b.members.size()) {
@@ -1573,8 +1573,8 @@ bool TypeAssignability::assignable_plain_array(const TypeIdentifier& ta,
         }
       }
 
-      return assignable(*ta.array_ldefn().element_identifier,
-                        *tb.array_ldefn().element_identifier);
+      return strongly_assignable(*ta.array_ldefn().element_identifier,
+                                 *tb.array_ldefn().element_identifier);
     }
   } else if (EK_MINIMAL == tb.kind()) {
     const MinimalTypeObject& tob = lookup_minimal(tb);
@@ -1614,8 +1614,8 @@ bool TypeAssignability::assignable_plain_array(const TypeIdentifier& ta,
         }
       }
 
-      return assignable(*ta.array_sdefn().element_identifier,
-                        tb.array_type.element.common.type);
+      return strongly_assignable(*ta.array_sdefn().element_identifier,
+                                 tb.array_type.element.common.type);
     } else { // TI_PLAIN_ARRAY_LARGE
       const Sequence<LBound>& bounds_a = ta.array_ldefn().array_bound_seq;
       if (bounds_a.members.size() != bounds_b.members.size()) {
@@ -1628,8 +1628,8 @@ bool TypeAssignability::assignable_plain_array(const TypeIdentifier& ta,
         }
       }
 
-      return assignable(*ta.array_ldefn().element_identifier,
-                        tb.array_type.element.common.type);
+      return strongly_assignable(*ta.array_ldefn().element_identifier,
+                                 tb.array_type.element.common.type);
     }
   }
 

--- a/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -415,7 +415,7 @@ bool TypeAssignability::assignable_struct(const MinimalTypeObject& ta,
 
   // If T1 is appendable, then members with the same member_index have the
   // same member ID, the same setting for the 'optional' attribute and the
-  // T1 member type is strongly assignable from the T2 member type.
+  // T1 member type is assignable from the T2 member type.
   // If T1 is final, then they meet the same condition as for T1 being
   // appendable and in addition T1 and T2 have the same set of member IDs.
   if (IS_FINAL == a_exten &&
@@ -430,8 +430,8 @@ bool TypeAssignability::assignable_struct(const MinimalTypeObject& ta,
           tb.struct_type.member_seq[i].common.member_id ||
           (ta.struct_type.member_seq[i].common.member_flags & IS_OPTIONAL) !=
           (tb.struct_type.member_seq[i].common.member_flags & IS_OPTIONAL) ||
-          !strongly_assignable(ta.struct_type.member_seq[i].common.member_type_id,
-                               tb.struct_type.member_seq[i].common.member_type_id)) {
+          !assignable(ta.struct_type.member_seq[i].common.member_type_id,
+                      tb.struct_type.member_seq[i].common.member_type_id)) {
         return false;
       }
     }
@@ -1024,8 +1024,8 @@ bool TypeAssignability::assignable_sequence(const MinimalTypeObject& ta,
                         tb.sequence_type.header.common.bound)) {
     return false;
   }
-  return strongly_assignable(ta.sequence_type.element.common.type,
-                             tb.sequence_type.element.common.type);
+  return assignable(ta.sequence_type.element.common.type,
+                    tb.sequence_type.element.common.type);
 }
 
 /**
@@ -1040,15 +1040,15 @@ bool TypeAssignability::assignable_sequence(const MinimalTypeObject& ta,
         !bound_assignable(ta.sequence_type.header.common.bound, tb.seq_sdefn().bound)) {
       return false;
     }
-    return strongly_assignable(ta.sequence_type.element.common.type,
-                               *tb.seq_sdefn().element_identifier);
+    return assignable(ta.sequence_type.element.common.type,
+                      *tb.seq_sdefn().element_identifier);
   } else if (TI_PLAIN_SEQUENCE_LARGE == tb.kind()) {
     if (!type_consistency_.ignore_sequence_bounds &&
         !bound_assignable(ta.sequence_type.header.common.bound, tb.seq_ldefn().bound)) {
       return false;
     }
-    return strongly_assignable(ta.sequence_type.element.common.type,
-                               *tb.seq_ldefn().element_identifier);
+    return assignable(ta.sequence_type.element.common.type,
+                      *tb.seq_ldefn().element_identifier);
   } else if (EK_MINIMAL == tb.kind()) {
     const MinimalTypeObject& tob = lookup_minimal(tb);
     if (TK_SEQUENCE == tob.kind) {
@@ -1088,8 +1088,8 @@ bool TypeAssignability::assignable_array(const MinimalTypeObject& ta,
       return false;
     }
   }
-  return strongly_assignable(ta.array_type.element.common.type,
-                             tb.array_type.element.common.type);
+  return assignable(ta.array_type.element.common.type,
+                    tb.array_type.element.common.type);
 }
 
 /**
@@ -1112,8 +1112,8 @@ bool TypeAssignability::assignable_array(const MinimalTypeObject& ta,
       }
     }
 
-    return strongly_assignable(ta.array_type.element.common.type,
-                               *tb.array_sdefn().element_identifier);
+    return assignable(ta.array_type.element.common.type,
+                      *tb.array_sdefn().element_identifier);
   } else if (TI_PLAIN_ARRAY_LARGE == tb.kind()) {
     const LBoundSeq& bounds_b = tb.array_ldefn().array_bound_seq;
     if (bounds_a.members.size() != bounds_b.members.size()) {
@@ -1125,8 +1125,8 @@ bool TypeAssignability::assignable_array(const MinimalTypeObject& ta,
         return false;
       }
     }
-    return strongly_assignable(ta.array_type.element.common.type,
-                               *tb.array_ldefn().element_identifier);
+    return assignable(ta.array_type.element.common.type,
+                      *tb.array_ldefn().element_identifier);
   } else if (EK_MINIMAL == tb.kind()) {
     const MinimalTypeObject& tob = lookup_minimal(tb);
     if (TK_ARRAY == tob.kind) {
@@ -1468,11 +1468,11 @@ bool TypeAssignability::assignable_plain_sequence(const TypeIdentifier& ta,
       return false;
     }
     if (TI_PLAIN_SEQUENCE_SMALL == ta.kind()) {
-      return strongly_assignable(*ta.seq_sdefn().element_identifier,
-                                 *tb.seq_sdefn().element_identifier);
+      return assignable(*ta.seq_sdefn().element_identifier,
+                        *tb.seq_sdefn().element_identifier);
     } else { // TI_PLAIN_SEQUENCE_LARGE
-      return strongly_assignable(*ta.seq_ldefn().element_identifier,
-                                 *tb.seq_sdefn().element_identifier);
+      return assignable(*ta.seq_ldefn().element_identifier,
+                        *tb.seq_sdefn().element_identifier);
     }
   } else if (TI_PLAIN_SEQUENCE_LARGE == tb.kind()) {
     if (!type_consistency_.ignore_sequence_bounds &&
@@ -1480,11 +1480,11 @@ bool TypeAssignability::assignable_plain_sequence(const TypeIdentifier& ta,
       return false;
     }
     if (TI_PLAIN_SEQUENCE_SMALL == ta.kind()) {
-      return strongly_assignable(*ta.seq_sdefn().element_identifier,
-                                 *tb.seq_ldefn().element_identifier);
+      return assignable(*ta.seq_sdefn().element_identifier,
+                        *tb.seq_ldefn().element_identifier);
     } else { // TI_PLAIN_SEQUENCE_LARGE
-      return strongly_assignable(*ta.seq_ldefn().element_identifier,
-                                 *tb.seq_ldefn().element_identifier);
+      return assignable(*ta.seq_ldefn().element_identifier,
+                        *tb.seq_ldefn().element_identifier);
     }
   } else if (EK_MINIMAL == tb.kind()) {
     const MinimalTypeObject& tob = lookup_minimal(tb);
@@ -1518,11 +1518,11 @@ bool TypeAssignability::assignable_plain_sequence(const TypeIdentifier& ta,
       return false;
     }
     if (TI_PLAIN_SEQUENCE_SMALL == ta.kind()) {
-      return strongly_assignable(*ta.seq_sdefn().element_identifier,
-                                 tb.sequence_type.element.common.type);
+      return assignable(*ta.seq_sdefn().element_identifier,
+                        tb.sequence_type.element.common.type);
     } else { // TI_PLAIN_SEQUENCE_LARGE
-      return strongly_assignable(*ta.seq_ldefn().element_identifier,
-                                 tb.sequence_type.element.common.type);
+      return assignable(*ta.seq_ldefn().element_identifier,
+                        tb.sequence_type.element.common.type);
     }
   }
 
@@ -1550,8 +1550,8 @@ bool TypeAssignability::assignable_plain_array(const TypeIdentifier& ta,
         }
       }
 
-      return strongly_assignable(*ta.array_sdefn().element_identifier,
-                                 *tb.array_sdefn().element_identifier);
+      return assignable(*ta.array_sdefn().element_identifier,
+                        *tb.array_sdefn().element_identifier);
     } else { // TI_PLAIN_ARRAY_LARGE
       const Sequence<LBound>& bounds_a = ta.array_ldefn().array_bound_seq;
       if (bounds_a.members.size() != bounds_b.members.size()) {
@@ -1564,8 +1564,8 @@ bool TypeAssignability::assignable_plain_array(const TypeIdentifier& ta,
         }
       }
 
-      return strongly_assignable(*ta.array_ldefn().element_identifier,
-                                 *tb.array_sdefn().element_identifier);
+      return assignable(*ta.array_ldefn().element_identifier,
+                        *tb.array_sdefn().element_identifier);
     }
   } else if (TI_PLAIN_ARRAY_LARGE == tb.kind()) {
     const Sequence<LBound>& bounds_b = tb.array_ldefn().array_bound_seq;
@@ -1581,8 +1581,8 @@ bool TypeAssignability::assignable_plain_array(const TypeIdentifier& ta,
         }
       }
 
-      return strongly_assignable(*ta.array_sdefn().element_identifier,
-                                 *tb.array_ldefn().element_identifier);
+      return assignable(*ta.array_sdefn().element_identifier,
+                        *tb.array_ldefn().element_identifier);
     } else { // TI_PLAIN_ARRAY_LARGE
       const Sequence<LBound>& bounds_a = ta.array_ldefn().array_bound_seq;
       if (bounds_a.members.size() != bounds_b.members.size()) {
@@ -1595,8 +1595,8 @@ bool TypeAssignability::assignable_plain_array(const TypeIdentifier& ta,
         }
       }
 
-      return strongly_assignable(*ta.array_ldefn().element_identifier,
-                                 *tb.array_ldefn().element_identifier);
+      return assignable(*ta.array_ldefn().element_identifier,
+                        *tb.array_ldefn().element_identifier);
     }
   } else if (EK_MINIMAL == tb.kind()) {
     const MinimalTypeObject& tob = lookup_minimal(tb);
@@ -1636,8 +1636,8 @@ bool TypeAssignability::assignable_plain_array(const TypeIdentifier& ta,
         }
       }
 
-      return strongly_assignable(*ta.array_sdefn().element_identifier,
-                                 tb.array_type.element.common.type);
+      return assignable(*ta.array_sdefn().element_identifier,
+                        tb.array_type.element.common.type);
     } else { // TI_PLAIN_ARRAY_LARGE
       const Sequence<LBound>& bounds_a = ta.array_ldefn().array_bound_seq;
       if (bounds_a.members.size() != bounds_b.members.size()) {
@@ -1650,8 +1650,8 @@ bool TypeAssignability::assignable_plain_array(const TypeIdentifier& ta,
         }
       }
 
-      return strongly_assignable(*ta.array_ldefn().element_identifier,
-                                 tb.array_type.element.common.type);
+      return assignable(*ta.array_ldefn().element_identifier,
+                        tb.array_type.element.common.type);
     }
   }
 

--- a/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -15,6 +15,23 @@ namespace XTypes {
 
 namespace {
   const size_t MAX_ALIAS_CHAIN_LENGTH = 64;
+
+  bool bound_assignable(LBound a, LBound b)
+  {
+    return a == 0 || (b != 0 && b <= a);
+  }
+
+  LBound string_bound(const TypeIdentifier& ti)
+  {
+    return ti.kind() == TI_STRING8_SMALL || ti.kind() == TI_STRING16_SMALL ?
+      ti.string_sdefn().bound : ti.string_ldefn().bound;
+  }
+
+  LBound sequence_bound(const TypeIdentifier& ti)
+  {
+    return ti.kind() == TI_PLAIN_SEQUENCE_SMALL ?
+      ti.seq_sdefn().bound : ti.seq_ldefn().bound;
+  }
 }
 
 /**
@@ -211,6 +228,30 @@ bool TypeAssignability::assignable(const TypeIdentifier& ta,
   return false;
 }
 
+bool TypeAssignability::assignable(const TypeInformation& ta,
+                                   const TypeInformation& tb) const
+{
+  if (use_complete_type_objects()) {
+    const TypeIdentifier& complete_ta = ta.complete.typeid_with_size.type_id;
+    const TypeIdentifier& complete_tb = tb.complete.typeid_with_size.type_id;
+    if (complete_ta.kind() != TK_NONE && complete_tb.kind() != TK_NONE) {
+      const TypeObject& complete_to_a = tl_service_->get_type_object(complete_ta);
+      const TypeObject& complete_to_b = tl_service_->get_type_object(complete_tb);
+      if (complete_to_a.kind == EK_COMPLETE && complete_to_b.kind == EK_COMPLETE) {
+        TypeObject minimal_to_a;
+        TypeObject minimal_to_b;
+        if (tl_service_->complete_to_minimal_type_object(complete_to_a, minimal_to_a) &&
+            tl_service_->complete_to_minimal_type_object(complete_to_b, minimal_to_b)) {
+          return assignable(minimal_to_a, minimal_to_b);
+        }
+      }
+    }
+  }
+
+  return assignable(ta.minimal.typeid_with_size.type_id,
+                    tb.minimal.typeid_with_size.type_id);
+}
+
 /**
  * @brief At least one input type object must be TK_ALIAS
  */
@@ -399,6 +440,13 @@ bool TypeAssignability::assignable_struct(const MinimalTypeObject& ta,
   // There is at least one member m1 of T1 and one corresponding member
   // m2 of T2 such that m1.id == m2.id
   if (matched_members.size() == 0) {
+    return false;
+  }
+
+  // If prevent_type_widening is true, T1 can't have members that don't appear
+  // in T2.
+  if (type_consistency_.prevent_type_widening &&
+      matched_members.size() != ta.struct_type.member_seq.length()) {
     return false;
   }
 
@@ -912,6 +960,11 @@ bool TypeAssignability::assignable_sequence(const MinimalTypeObject& ta,
   if (TK_SEQUENCE != tb.kind) {
     return false;
   }
+  if (!type_consistency_.ignore_sequence_bounds &&
+      !bound_assignable(ta.sequence_type.header.common.bound,
+                        tb.sequence_type.header.common.bound)) {
+    return false;
+  }
   return strongly_assignable(ta.sequence_type.element.common.type,
                              tb.sequence_type.element.common.type);
 }
@@ -924,9 +977,17 @@ bool TypeAssignability::assignable_sequence(const MinimalTypeObject& ta,
                                             const TypeIdentifier& tb) const
 {
   if (TI_PLAIN_SEQUENCE_SMALL == tb.kind()) {
+    if (!type_consistency_.ignore_sequence_bounds &&
+        !bound_assignable(ta.sequence_type.header.common.bound, tb.seq_sdefn().bound)) {
+      return false;
+    }
     return strongly_assignable(ta.sequence_type.element.common.type,
                                *tb.seq_sdefn().element_identifier);
   } else if (TI_PLAIN_SEQUENCE_LARGE == tb.kind()) {
+    if (!type_consistency_.ignore_sequence_bounds &&
+        !bound_assignable(ta.sequence_type.header.common.bound, tb.seq_ldefn().bound)) {
+      return false;
+    }
     return strongly_assignable(ta.sequence_type.element.common.type,
                                *tb.seq_ldefn().element_identifier);
   } else if (EK_MINIMAL == tb.kind()) {
@@ -1295,10 +1356,18 @@ bool TypeAssignability::assignable_string(const TypeIdentifier& ta,
 {
   if (TI_STRING8_SMALL == tb.kind() || TI_STRING8_LARGE == tb.kind()) {
     if (TI_STRING8_SMALL == ta.kind() || TI_STRING8_LARGE == ta.kind()) {
+      if (!type_consistency_.ignore_string_bounds &&
+          !bound_assignable(string_bound(ta), string_bound(tb))) {
+        return false;
+      }
       return true;
     }
   } else if (TI_STRING16_SMALL == tb.kind() || TI_STRING16_LARGE == tb.kind()) {
     if (TI_STRING16_SMALL == ta.kind() || TI_STRING16_LARGE == ta.kind()) {
+      if (!type_consistency_.ignore_string_bounds &&
+          !bound_assignable(string_bound(ta), string_bound(tb))) {
+        return false;
+      }
       return true;
     }
   } else if (EK_MINIMAL == tb.kind()) {
@@ -1335,6 +1404,10 @@ bool TypeAssignability::assignable_plain_sequence(const TypeIdentifier& ta,
                                                   const TypeIdentifier& tb) const
 {
   if (TI_PLAIN_SEQUENCE_SMALL == tb.kind()) {
+    if (!type_consistency_.ignore_sequence_bounds &&
+        !bound_assignable(sequence_bound(ta), tb.seq_sdefn().bound)) {
+      return false;
+    }
     if (TI_PLAIN_SEQUENCE_SMALL == ta.kind()) {
       return strongly_assignable(*ta.seq_sdefn().element_identifier,
                                  *tb.seq_sdefn().element_identifier);
@@ -1343,6 +1416,10 @@ bool TypeAssignability::assignable_plain_sequence(const TypeIdentifier& ta,
                                  *tb.seq_sdefn().element_identifier);
     }
   } else if (TI_PLAIN_SEQUENCE_LARGE == tb.kind()) {
+    if (!type_consistency_.ignore_sequence_bounds &&
+        !bound_assignable(sequence_bound(ta), tb.seq_ldefn().bound)) {
+      return false;
+    }
     if (TI_PLAIN_SEQUENCE_SMALL == ta.kind()) {
       return strongly_assignable(*ta.seq_sdefn().element_identifier,
                                  *tb.seq_ldefn().element_identifier);
@@ -1377,6 +1454,10 @@ bool TypeAssignability::assignable_plain_sequence(const TypeIdentifier& ta,
                                                   const MinimalTypeObject& tb) const
 {
   if (TK_SEQUENCE == tb.kind) {
+    if (!type_consistency_.ignore_sequence_bounds &&
+        !bound_assignable(sequence_bound(ta), tb.sequence_type.header.common.bound)) {
+      return false;
+    }
     if (TI_PLAIN_SEQUENCE_SMALL == ta.kind()) {
       return strongly_assignable(*ta.seq_sdefn().element_identifier,
                                  tb.sequence_type.element.common.type);
@@ -1606,6 +1687,13 @@ bool TypeAssignability::strongly_assignable(const TypeIdentifier& tia,
     return true;
   }
   return false;
+}
+
+bool TypeAssignability::use_complete_type_objects() const
+{
+  return type_consistency_.prevent_type_widening ||
+    !type_consistency_.ignore_sequence_bounds ||
+    !type_consistency_.ignore_string_bounds;
 }
 
 /**

--- a/dds/DCPS/XTypes/TypeAssignability.h
+++ b/dds/DCPS/XTypes/TypeAssignability.h
@@ -29,7 +29,7 @@ struct TypeConsistencyAttributes {
   bool prevent_type_widening;
   bool ignore_sequence_bounds;
   bool ignore_string_bounds;
-  bool ignore_member_names; // Only this affects assignability currently
+  bool ignore_member_names;
 };
 
 class OpenDDS_Dcps_Export TypeAssignability {
@@ -54,29 +54,26 @@ public:
   bool assignable(const TypeObject& ta, const TypeIdentifier& tb) const;
   bool assignable(const TypeIdentifier& ta, const TypeIdentifier& tb) const;
   bool assignable(const TypeIdentifier& ta, const TypeObject& tb) const;
+  bool assignable(const TypeInformation& ta, const TypeInformation& tb) const;
 
   // The following set_* functions, if called prior to the assignable
   // functions, can change the behavior of type assignability
 
-  // No affect on assignability currently
   void set_prevent_type_widening(bool value)
   {
     type_consistency_.prevent_type_widening = value;
   }
 
-  // No affect on assignability currently
   void set_ignore_sequence_bounds(bool value)
   {
     type_consistency_.ignore_sequence_bounds = value;
   }
 
-  // No affect on assignability currently
   void set_ignore_string_bounds(bool value)
   {
     type_consistency_.ignore_string_bounds = value;
   }
 
-  // Currently, only this affects assignability's behavior
   void set_ignore_member_names(bool value)
   {
     type_consistency_.ignore_member_names = value;
@@ -121,6 +118,7 @@ private:
   bool assignable_plain_map(const TypeIdentifier& ta, const MinimalTypeObject& tb) const;
 
   // General helpers
+  bool use_complete_type_objects() const;
   bool strongly_assignable(const TypeIdentifier& ta, const TypeIdentifier& tb) const;
   bool is_delimited(const TypeIdentifier& ti) const;
   bool is_delimited(const MinimalTypeObject& tobj) const;
@@ -146,9 +144,6 @@ private:
 
   XTypes::TypeLookupService_rch tl_service_;
 
-  // For now, type assignability applies only ignore_member_names.
-  // In the future, it needs to consider other attibutes as well:
-  // prevent_type_widening, ignore_sequence_bounds, ignore_string_bounds.
   TypeConsistencyAttributes type_consistency_;
 };
 

--- a/dds/DCPS/XTypes/TypeLookupService.cpp
+++ b/dds/DCPS/XTypes/TypeLookupService.cpp
@@ -237,7 +237,10 @@ bool TypeLookupService::get_minimal_type_identifier(const TypeIdentifier& ct, Ty
       complete_elem_ti = *ct.map_ldefn().element_identifier;
       break;
     }
-    get_minimal_type_identifier(complete_elem_ti, minimal_elem_ti);
+    if (!get_minimal_type_identifier(complete_elem_ti, minimal_elem_ti)) {
+      mt = TypeIdentifier(TK_NONE);
+      return false;
+    }
 
     switch (mt.kind()) {
     case TI_PLAIN_SEQUENCE_SMALL:
@@ -256,7 +259,10 @@ bool TypeLookupService::get_minimal_type_identifier(const TypeIdentifier& ct, Ty
       {
         mt.map_sdefn().element_identifier = minimal_elem_ti;
         TypeIdentifier minimal_key_ti;
-        get_minimal_type_identifier(*ct.map_sdefn().key_identifier, minimal_key_ti);
+        if (!get_minimal_type_identifier(*ct.map_sdefn().key_identifier, minimal_key_ti)) {
+          mt = TypeIdentifier(TK_NONE);
+          return false;
+        }
         mt.map_sdefn().key_identifier = minimal_key_ti;
         break;
       }
@@ -264,7 +270,10 @@ bool TypeLookupService::get_minimal_type_identifier(const TypeIdentifier& ct, Ty
       {
         mt.map_ldefn().element_identifier = minimal_elem_ti;
         TypeIdentifier minimal_key_ti;
-        get_minimal_type_identifier(*ct.map_ldefn().key_identifier, minimal_key_ti);
+        if (!get_minimal_type_identifier(*ct.map_ldefn().key_identifier, minimal_key_ti)) {
+          mt = TypeIdentifier(TK_NONE);
+          return false;
+        }
         mt.map_ldefn().key_identifier = minimal_key_ti;
         break;
       }

--- a/dds/DCPS/XTypes/TypeLookupService.cpp
+++ b/dds/DCPS/XTypes/TypeLookupService.cpp
@@ -808,6 +808,7 @@ void TypeLookupService::complete_to_dynamic_i(DynamicTypeImpl* dt,
     td->discriminator_type(disc_type);
     DDS::MemberDescriptor_var disc_md = new MemberDescriptorImpl();
     disc_md->name("discriminator");
+    handle_tryconstruct_flags(disc_md, cto.union_type.discriminator.common.member_flags);
     disc_md->is_key(cto.union_type.discriminator.common.member_flags & IS_KEY);
     disc_md->type(disc_type);
     disc_md->id(DISCRIMINATOR_ID);

--- a/dds/DCPS/XTypes/TypeLookupService.h
+++ b/dds/DCPS/XTypes/TypeLookupService.h
@@ -43,6 +43,7 @@ public:
   /// For converting between complete to minimal TypeObject of remote types
   ///@{
   void update_type_identifier_map(const TypeIdentifierPairSeq& tid_pairs);
+  bool get_minimal_type_identifier(const TypeIdentifier& complete_ti, TypeIdentifier& minimal_ti) const;
   bool complete_to_minimal_type_object(const TypeObject& cto, TypeObject& mto) const;
   ///@}
 
@@ -95,8 +96,6 @@ private:
   /// Mapping from complete to minimal TypeIdentifiers of dependencies of remote types.
   typedef OPENDDS_MAP(TypeIdentifier, TypeIdentifier) TypeIdentifierMap;
   TypeIdentifierMap complete_to_minimal_ti_map_;
-
-  bool get_minimal_type_identifier(const TypeIdentifier& ct, TypeIdentifier& mt) const;
 
   // Initialize received TypeObjects to defaults.
   bool set_type_object_defaults(TypeObject& to);

--- a/dds/DCPS/XTypes/Utils.cpp
+++ b/dds/DCPS/XTypes/Utils.cpp
@@ -497,6 +497,18 @@ bool is_key(DDS::DynamicType_ptr type, const char* field)
   return false;
 }
 
+void canonicalize_float128_padding(ACE_CDR::LongDouble& value)
+{
+#if ACE_SIZEOF_LONG_DOUBLE == 16 && LDBL_MANT_DIG == 64 && !defined(ACE_BIG_ENDIAN)
+  char* const bytes = reinterpret_cast<char*>(&value);
+  for (size_t i = 10; i != 16; ++i) {
+    bytes[i] = 0;
+  }
+#else
+  ACE_UNUSED_ARG(value);
+#endif
+}
+
 namespace {
   template <typename T>
   void cmp(int& result, T a, T b)
@@ -522,12 +534,7 @@ namespace {
   void float128_big_endian_bytes(const ACE_CDR::LongDouble& value, char bytes[16])
   {
     ACE_CDR::LongDouble canonical = value;
-#if ACE_SIZEOF_LONG_DOUBLE == 16 && LDBL_MANT_DIG == 64 && !defined(ACE_BIG_ENDIAN)
-    char* const canonical_bytes = reinterpret_cast<char*>(&canonical);
-    for (size_t i = 10; i != 16; ++i) {
-      canonical_bytes[i] = 0;
-    }
-#endif
+    canonicalize_float128_padding(canonical);
     const char* const src = float128_bytes(canonical);
 #if defined(ACE_BIG_ENDIAN)
     ACE_OS::memcpy(bytes, src, 16);

--- a/dds/DCPS/XTypes/Utils.cpp
+++ b/dds/DCPS/XTypes/Utils.cpp
@@ -17,6 +17,7 @@
 #  include <ace/OS_NS_string.h>
 
 #  include <algorithm>
+#  include <cfloat>
 #  include <limits>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -520,7 +521,14 @@ namespace {
 
   void float128_big_endian_bytes(const ACE_CDR::LongDouble& value, char bytes[16])
   {
-    const char* const src = float128_bytes(value);
+    ACE_CDR::LongDouble canonical = value;
+#if ACE_SIZEOF_LONG_DOUBLE == 16 && LDBL_MANT_DIG == 64 && !defined(ACE_BIG_ENDIAN)
+    char* const canonical_bytes = reinterpret_cast<char*>(&canonical);
+    for (size_t i = 10; i != 16; ++i) {
+      canonical_bytes[i] = 0;
+    }
+#endif
+    const char* const src = float128_bytes(canonical);
 #if defined(ACE_BIG_ENDIAN)
     ACE_OS::memcpy(bytes, src, 16);
 #else

--- a/dds/DCPS/XTypes/Utils.h
+++ b/dds/DCPS/XTypes/Utils.h
@@ -33,6 +33,7 @@ OpenDDS_Dcps_Export DDS::ReturnCode_t extensibility(
 OpenDDS_Dcps_Export DDS::ReturnCode_t max_extensibility(
   DDS::DynamicType_ptr type, DCPS::Extensibility& ext);
 OpenDDS_Dcps_Export DCPS::Extensibility dds_to_opendds_ext(DDS::ExtensibilityKind ext);
+OpenDDS_Dcps_Export void canonicalize_float128_padding(ACE_CDR::LongDouble& value);
 
 /**
  * Iterate over parts of a member name path that can be the name of a

--- a/dds/DCPS/XTypes/XmlTypeProvider.cpp
+++ b/dds/DCPS/XTypes/XmlTypeProvider.cpp
@@ -522,6 +522,7 @@ public:
       TypeLookupService& tls = xml_type_lookup_service();
       tls.add(minimal_type_map_.begin(), minimal_type_map_.end());
       tls.add(complete_type_map_.begin(), complete_type_map_.end());
+      tls.update_type_identifier_map(complete_to_minimal_ti_pairs_);
       loaded = tls.complete_to_dynamic(root->second.complete, xml_type_guid);
       tls.release_guid_from_dynamic_map(xml_type_guid);
     }
@@ -632,6 +633,9 @@ private:
         pair.length(1);
         pair[0] = TypeIdentifierPair(complete->first, minimal_ti);
         converter.update_type_identifier_map(pair);
+        const ACE_CDR::ULong length = complete_to_minimal_ti_pairs_.length();
+        complete_to_minimal_ti_pairs_.length(length + 1);
+        complete_to_minimal_ti_pairs_[length] = pair[0];
 
         if (complete->first == root_ti) {
           root_minimal_ti = minimal_ti;
@@ -1713,6 +1717,7 @@ private:
   NameSet building_;
   TypeMap complete_type_map_;
   TypeMap minimal_type_map_;
+  TypeIdentifierPairSeq complete_to_minimal_ti_pairs_;
 };
 
 } // namespace

--- a/docs/news.d/xtypes-interop-fixes.rst
+++ b/docs/news.d/xtypes-interop-fixes.rst
@@ -1,4 +1,4 @@
-.. news-prs: 0
+.. news-prs: 5238
 
 .. news-start-section: Fixes
 - DDS XTypes Interoperability: Implemented fixes and completeness updates to align the XTypes implementation with the OMG DDS-XTypes 1.3 specification:

--- a/docs/news.d/xtypes-interop-fixes.rst
+++ b/docs/news.d/xtypes-interop-fixes.rst
@@ -1,0 +1,16 @@
+.. news-prs: 0
+
+.. news-start-section: Fixes
+- DDS XTypes Interoperability: Implemented fixes and completeness updates to align the XTypes implementation with the OMG DDS-XTypes 1.3 specification:
+
+  - **Type Assignability**: Enforced checking for sequence and string bounds, structural member validation under the ``prevent_type_widening`` policy, and union default/explicit case label compatibility rules.
+
+    *Backwards Compatibility Note*: If reader endpoints are configured with non-default QoS attributes (``ignore_sequence_bounds = false``, ``ignore_string_bounds = false``, or ``prevent_type_widening = true``), the assignability checks will now correctly reject matching writers that violate these constraints. Previously, these settings were ignored, meaning upgraded readers might now reject writers they previously matched.
+
+  - **TryConstruct Annotation Support**: Enforced try-construct policies (``TRIM``, ``USE_DEFAULT``, ``DISCARD``) on sequences, strings, and enums during runtime deserialization, ensuring correct behavior when deserializing samples that exceed bounds or contain invalid enum literals.
+
+  - **TypeLookup & Discovery**: Pre-populated complete-to-minimal type mappings during type registration and discovery, resolving queries to the TypeLookupService.
+
+  - **Deterministic Serialization**: Canonicalized floating-point padding bytes for 128-bit floats (``float128`` / ``long double``) on platforms with 80-bit x87 representation (e.g., Linux x86_64), ensuring consistent network serialization, hashing, and JSON output.
+
+.. news-end-section

--- a/tests/unit-tests/dds/DCPS/XTypes/DynamicDataJson.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/DynamicDataJson.cpp
@@ -145,6 +145,26 @@ TEST(dds_DCPS_XTypes_DynamicDataJson, StructPopulateAndRoundTrip)
   EXPECT_TRUE(copy->equals(data));
 }
 
+TEST(dds_DCPS_XTypes_DynamicDataJson, Float128HexRoundTrip)
+{
+  DDS::DynamicData_var data = create_data("XmlTypeProviderTest::Float128Sample");
+  ASSERT_TRUE(data);
+
+  const char* const json = "{\"x1\":\"0x0000000000000000000000003f800000\"}";
+  ASSERT_EQ(DDS::RETCODE_OK, OpenDDS::XTypes::dynamic_data_from_json(data, json));
+
+  std::string round_trip;
+  ASSERT_EQ(DDS::RETCODE_OK, OpenDDS::XTypes::dynamic_data_to_json(round_trip, data));
+  EXPECT_EQ(json, round_trip);
+
+  DDS::DynamicData_var copy = create_data("XmlTypeProviderTest::Float128Sample");
+  ASSERT_TRUE(copy);
+  ASSERT_EQ(DDS::RETCODE_OK, OpenDDS::XTypes::dynamic_data_from_json(copy, json));
+  EXPECT_TRUE(OpenDDS::XTypes::dynamic_data_equal(data, copy));
+  EXPECT_TRUE(data->equals(copy));
+  EXPECT_TRUE(copy->equals(data));
+}
+
 TEST(dds_DCPS_XTypes_DynamicDataJson, UnionActiveMemberJson)
 {
   DDS::DynamicType_var type = load_type("XmlTypeProviderTest::Choice");

--- a/tests/unit-tests/dds/DCPS/XTypes/DynamicDataJson.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/DynamicDataJson.cpp
@@ -688,4 +688,41 @@ TEST(dds_DCPS_XTypes_DynamicDataJson, EqualsSerializedBackingStore)
   EXPECT_TRUE(wrapped->equals(data));
 }
 
+TEST(dds_DCPS_XTypes_DynamicDataJson, TryConstructTrimSerializedBackingStore)
+{
+  DDS::DynamicType_var writer_type = load_type("XmlTypeProviderTest::Seq20");
+  DDS::DynamicData_var writer_data =
+    DDS::DynamicDataFactory::get_instance()->create_data(writer_type);
+  ASSERT_TRUE(writer_data);
+  ASSERT_EQ(DDS::RETCODE_OK, OpenDDS::XTypes::dynamic_data_from_json(writer_data,
+    "{\"x1\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]}"));
+
+  DDS::DynamicType_var reader_type = load_type("XmlTypeProviderTest::Seq10Trim");
+  DDS::MemberDescriptor_var x1 = member_descriptor(reader_type, "x1");
+  ASSERT_EQ(DDS::TRIM, x1->try_construct_kind());
+
+  ACE_Message_Block buffer(4096);
+  const OpenDDS::DCPS::Encoding encoding(
+    OpenDDS::DCPS::Encoding::KIND_XCDR2, OpenDDS::DCPS::ENDIAN_BIG);
+  OpenDDS::DCPS::Serializer serializer(&buffer, encoding);
+  ASSERT_TRUE(serializer << writer_data.in());
+
+  DDS::DynamicData_var backing =
+    new OpenDDS::XTypes::DynamicDataXcdrReadImpl(&buffer, encoding, reader_type);
+  DDS::DynamicData_var wrapped =
+    new OpenDDS::XTypes::DynamicDataImpl(reader_type, backing);
+
+  std::string actual;
+  ASSERT_EQ(DDS::RETCODE_OK, OpenDDS::XTypes::dynamic_data_to_json(actual, wrapped));
+  EXPECT_EQ("{\"x1\":[1,2,3,4,5,6,7,8,9,10]}", actual);
+
+  DDS::DynamicData_var expected =
+    DDS::DynamicDataFactory::get_instance()->create_data(reader_type);
+  ASSERT_TRUE(expected);
+  ASSERT_EQ(DDS::RETCODE_OK, OpenDDS::XTypes::dynamic_data_from_json(expected,
+    "{\"x1\":[1,2,3,4,5,6,7,8,9,10]}"));
+  EXPECT_TRUE(OpenDDS::XTypes::dynamic_data_equal(wrapped, expected));
+  EXPECT_TRUE(wrapped->equals(expected));
+}
+
 #endif

--- a/tests/unit-tests/dds/DCPS/XTypes/DynamicDataJson.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/DynamicDataJson.cpp
@@ -15,6 +15,7 @@
 
 #include "gtest/gtest.h"
 
+#include <cfloat>
 #include <vector>
 
 namespace {
@@ -150,7 +151,12 @@ TEST(dds_DCPS_XTypes_DynamicDataJson, Float128HexRoundTrip)
   DDS::DynamicData_var data = create_data("XmlTypeProviderTest::Float128Sample");
   ASSERT_TRUE(data);
 
-  const char* const json = "{\"x1\":\"0x0000000000000000000000003f800000\"}";
+  const char* const json =
+#if ACE_SIZEOF_LONG_DOUBLE == 16 && LDBL_MANT_DIG == 64 && !defined(ACE_BIG_ENDIAN)
+    "{\"x1\":\"0x0000000000003fff8000000000000000\"}";
+#else
+    "{\"x1\":\"0x0000000000000000000000003f800000\"}";
+#endif
   ASSERT_EQ(DDS::RETCODE_OK, OpenDDS::XTypes::dynamic_data_from_json(data, json));
 
   std::string round_trip;

--- a/tests/unit-tests/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -362,6 +362,27 @@ TEST(dds_DCPS_XTypes_TypeAssignability, StringTypesTest_Assignable)
   }
 }
 
+TEST(dds_DCPS_XTypes_TypeAssignability, StringTypesTest_Bounds)
+{
+  TypeAssignability test(make_rch<TypeLookupService>());
+  const TypeIdentifier string8_10 = makeString(false, StringSTypeDefn(10));
+  const TypeIdentifier string8_20 = makeString(false, StringSTypeDefn(20));
+  const TypeIdentifier string8_unbounded = makeString(false, StringLTypeDefn(0));
+  const TypeIdentifier string16_10 = makeString(true, StringSTypeDefn(10));
+  const TypeIdentifier string16_20 = makeString(true, StringSTypeDefn(20));
+
+  EXPECT_TRUE(test.assignable(string8_10, string8_20));
+  EXPECT_TRUE(test.assignable(string16_10, string16_20));
+
+  test.set_ignore_string_bounds(false);
+  EXPECT_FALSE(test.assignable(string8_10, string8_20));
+  EXPECT_TRUE(test.assignable(string8_20, string8_10));
+  EXPECT_FALSE(test.assignable(string8_10, string8_unbounded));
+  EXPECT_TRUE(test.assignable(string8_unbounded, string8_20));
+  EXPECT_FALSE(test.assignable(string16_10, string16_20));
+  EXPECT_TRUE(test.assignable(string16_20, string16_10));
+}
+
 void string_expect_false(const TypeAssignability& test, const TypeIdentifier& tia)
 {
   {
@@ -1066,6 +1087,39 @@ TEST(dds_DCPS_XTypes_TypeAssignability, SequenceTypeTest_Assignable)
   test.insert_entry(seq_b.element.common.type, TypeObject(MinimalTypeObject(bitmask_b)));
   EXPECT_TRUE(test.assignable(TypeObject(MinimalTypeObject(seq_a)),
                               TypeObject(MinimalTypeObject(seq_b))));
+}
+
+TEST(dds_DCPS_XTypes_TypeAssignability, SequenceTypeTest_Bounds)
+{
+  TypeAssignability test(make_rch<TypeLookupService>());
+
+  MinimalSequenceType seq_10, seq_20;
+  seq_10.header.common.bound = 10;
+  seq_20.header.common.bound = 20;
+  seq_10.element.common.type = TypeIdentifier(TK_INT32);
+  seq_20.element.common.type = TypeIdentifier(TK_INT32);
+
+  EXPECT_TRUE(test.assignable(TypeObject(MinimalTypeObject(seq_10)),
+                              TypeObject(MinimalTypeObject(seq_20))));
+
+  test.set_ignore_sequence_bounds(false);
+  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(seq_10)),
+                               TypeObject(MinimalTypeObject(seq_20))));
+  EXPECT_TRUE(test.assignable(TypeObject(MinimalTypeObject(seq_20)),
+                              TypeObject(MinimalTypeObject(seq_10))));
+
+  const TypeIdentifier plain_10 = makePlainSequence(TypeIdentifier(TK_INT32), SBound(10));
+  const TypeIdentifier plain_20 = makePlainSequence(TypeIdentifier(TK_INT32), SBound(20));
+  const TypeIdentifier plain_unbounded = makePlainSequence(TypeIdentifier(TK_INT32), LBound(0));
+
+  EXPECT_FALSE(test.assignable(plain_10, plain_20));
+  EXPECT_TRUE(test.assignable(plain_20, plain_10));
+  EXPECT_FALSE(test.assignable(plain_10, plain_unbounded));
+  EXPECT_TRUE(test.assignable(plain_unbounded, plain_20));
+  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(seq_10)), plain_20));
+  EXPECT_TRUE(test.assignable(TypeObject(MinimalTypeObject(seq_20)), plain_10));
+  EXPECT_FALSE(test.assignable(plain_10, TypeObject(MinimalTypeObject(seq_20))));
+  EXPECT_TRUE(test.assignable(plain_20, TypeObject(MinimalTypeObject(seq_10))));
 }
 
 TEST(dds_DCPS_XTypes_TypeAssignability, SequenceTypeTest_NotAssignable)
@@ -3656,6 +3710,34 @@ void expect_false_final()
   a.member_seq.append(ma1).append(ma2);
   b.member_seq.append(mb1).append(mb2);
   EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(a)), TypeObject(MinimalTypeObject(b))));
+}
+
+TEST(dds_DCPS_XTypes_TypeAssignability, StructTypeTest_PreventTypeWidening)
+{
+  TypeAssignability test(make_rch<TypeLookupService>());
+
+  MinimalStructType a, b;
+  a.struct_flags = IS_APPENDABLE;
+  b.struct_flags = IS_APPENDABLE;
+  a.member_seq.append(MinimalStructMember(CommonStructMember(1, StructMemberFlag(),
+                                                             TypeIdentifier(TK_INT32)),
+                                          MinimalMemberDetail("m1")));
+  a.member_seq.append(MinimalStructMember(CommonStructMember(2, StructMemberFlag(),
+                                                             TypeIdentifier(TK_INT32)),
+                                          MinimalMemberDetail("m2")));
+  b.member_seq.append(MinimalStructMember(CommonStructMember(1, StructMemberFlag(),
+                                                             TypeIdentifier(TK_INT32)),
+                                          MinimalMemberDetail("m1")));
+
+  EXPECT_TRUE(test.assignable(TypeObject(MinimalTypeObject(a)), TypeObject(MinimalTypeObject(b))));
+  test.set_prevent_type_widening(true);
+  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(a)), TypeObject(MinimalTypeObject(b))));
+  EXPECT_TRUE(test.assignable(TypeObject(MinimalTypeObject(b)), TypeObject(MinimalTypeObject(a))));
+
+  a.struct_flags = IS_MUTABLE;
+  b.struct_flags = IS_MUTABLE;
+  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(a)), TypeObject(MinimalTypeObject(b))));
+  EXPECT_TRUE(test.assignable(TypeObject(MinimalTypeObject(b)), TypeObject(MinimalTypeObject(a))));
 }
 
 TEST(dds_DCPS_XTypes_TypeAssignability, StructTypeTest_NotAssignable)

--- a/tests/unit-tests/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -3471,6 +3471,7 @@ void expect_false_keys_must_in_both()
 void expect_false_string_keys()
 {
   TypeAssignability test(make_rch<TypeLookupService>());
+  test.set_ignore_string_bounds(false);
   MinimalStructType a, b;
 
   MinimalStructMember ma1(CommonStructMember(1, StructMemberFlag(),
@@ -3501,7 +3502,7 @@ void expect_false_enum_keys()
   literal_seq_b.append(MinimalEnumeratedLiteral(CommonEnumeratedLiteral(1, EnumeratedLiteralFlag()),
                                                 MinimalMemberDetail("LITERAL1")));
   literal_seq_b.append(MinimalEnumeratedLiteral(CommonEnumeratedLiteral(3, EnumeratedLiteralFlag()),
-                                                MinimalMemberDetail("LITERAL3")));
+                                                MinimalMemberDetail("LITERAL4")));
   MinimalEnumeratedType enum_a(IS_APPENDABLE, MinimalEnumeratedHeader(CommonEnumeratedHeader(3)), literal_seq_a);
   MinimalEnumeratedType enum_b(IS_APPENDABLE, MinimalEnumeratedHeader(CommonEnumeratedHeader(3)), literal_seq_b);
   EquivalenceHash hash;
@@ -3521,6 +3522,7 @@ void expect_false_enum_keys()
 void expect_false_sequence_keys()
 {
   TypeAssignability test(make_rch<TypeLookupService>());
+  test.set_ignore_sequence_bounds(false);
   MinimalStructType a, b;
 
   // Sequence key members
@@ -3563,6 +3565,7 @@ void expect_false_sequence_keys()
 void expect_false_map_keys()
 {
   TypeAssignability test(make_rch<TypeLookupService>());
+  test.set_ignore_sequence_bounds(false);
   MinimalStructType a, b;
 
   // Map key members

--- a/tests/unit-tests/dds/DCPS/XTypes/XmlTypeProvider.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/XmlTypeProvider.cpp
@@ -3,7 +3,10 @@
 #include <XmlTypeProviderTypeSupportImpl.h>
 
 #include <dds/DCPS/debug.h>
+#include <dds/DCPS/XTypes/DynamicTypeSupport.h>
 #include <dds/DCPS/XTypes/DynamicTypeImpl.h>
+#include <dds/DCPS/XTypes/TypeAssignability.h>
+#include <dds/DCPS/XTypes/TypeLookupService.h>
 #include <dds/DCPS/XTypes/XmlTypeProvider.h>
 
 #include "gtest/gtest.h"
@@ -67,6 +70,28 @@ void expect_complete_type_object(DDS::DynamicType_ptr type)
   const OpenDDS::XTypes::TypeMap::const_iterator actual = actual_map.find(expected_ti);
   ASSERT_NE(actual_map.end(), actual);
   EXPECT_TRUE(expected->second == actual->second);
+}
+
+OpenDDS::XTypes::TypeInformation type_information(
+  DDS::DynamicType_ptr type,
+  const OpenDDS::XTypes::TypeLookupService_rch& tls)
+{
+  DDS::DynamicTypeSupport_var ts = new DDS::DynamicTypeSupport(type);
+  ts->add_types(tls);
+
+  OpenDDS::DCPS::TypeInformation dcps_type_info;
+  ts->to_type_info(dcps_type_info);
+  return dcps_type_info.xtypes_type_info_;
+}
+
+OpenDDS::XTypes::TypeConsistencyAttributes strict_type_consistency()
+{
+  OpenDDS::XTypes::TypeConsistencyAttributes attrs;
+  attrs.ignore_sequence_bounds = false;
+  attrs.ignore_string_bounds = false;
+  attrs.ignore_member_names = true;
+  attrs.prevent_type_widening = true;
+  return attrs;
 }
 
 } // namespace
@@ -241,6 +266,29 @@ TEST(dds_DCPS_XTypes_XmlTypeProvider, RejectsWideBitmaskUnionLabel)
             OpenDDS::XTypes::load_xml_type(
               type, INVALID_XML_TYPE_FILE, "XmlTypeProviderInvalid::WideFlagUnion"));
   EXPECT_FALSE(type);
+}
+
+TEST(dds_DCPS_XTypes_XmlTypeProvider, TypeAssignabilityPolicy)
+{
+  const OpenDDS::XTypes::TypeLookupService_rch tls =
+    OpenDDS::DCPS::make_rch<OpenDDS::XTypes::TypeLookupService>();
+  const OpenDDS::XTypes::TypeConsistencyAttributes attrs = strict_type_consistency();
+  OpenDDS::XTypes::TypeAssignability assignability(tls, attrs);
+
+  DDS::DynamicType_var seq10 = load_type("XmlTypeProviderTest::Seq10");
+  DDS::DynamicType_var seq20 = load_type("XmlTypeProviderTest::Seq20");
+  EXPECT_FALSE(assignability.assignable(type_information(seq10, tls),
+                                        type_information(seq20, tls)));
+
+  DDS::DynamicType_var string10 = load_type("XmlTypeProviderTest::String10");
+  DDS::DynamicType_var string20 = load_type("XmlTypeProviderTest::String20");
+  EXPECT_FALSE(assignability.assignable(type_information(string10, tls),
+                                        type_information(string20, tls)));
+
+  DDS::DynamicType_var one_member = load_type("XmlTypeProviderTest::OneMember");
+  DDS::DynamicType_var two_members = load_type("XmlTypeProviderTest::TwoMembers");
+  EXPECT_FALSE(assignability.assignable(type_information(two_members, tls),
+                                        type_information(one_member, tls)));
 }
 
 #endif

--- a/tests/unit-tests/dds/DCPS/XTypes/XmlTypeProvider.xml
+++ b/tests/unit-tests/dds/DCPS/XTypes/XmlTypeProvider.xml
@@ -59,6 +59,10 @@
         <member name="x1" type="int32" sequenceMaxLength="10"/>
       </struct>
 
+      <struct name="Seq10Trim" extensibility="final">
+        <member name="x1" type="int32" sequenceMaxLength="10" tryConstruct="trim"/>
+      </struct>
+
       <struct name="Seq20" extensibility="final">
         <member name="x1" type="int32" sequenceMaxLength="20"/>
       </struct>

--- a/tests/unit-tests/dds/DCPS/XTypes/XmlTypeProvider.xml
+++ b/tests/unit-tests/dds/DCPS/XTypes/XmlTypeProvider.xml
@@ -55,6 +55,31 @@
         </member>
       </struct>
 
+      <struct name="Seq10" extensibility="final">
+        <member name="x1" type="int32" sequenceMaxLength="10"/>
+      </struct>
+
+      <struct name="Seq20" extensibility="final">
+        <member name="x1" type="int32" sequenceMaxLength="20"/>
+      </struct>
+
+      <struct name="String10" extensibility="final">
+        <member name="x1" type="string" stringMaxLength="10"/>
+      </struct>
+
+      <struct name="String20" extensibility="final">
+        <member name="x1" type="string" stringMaxLength="20"/>
+      </struct>
+
+      <struct name="OneMember" extensibility="appendable">
+        <member name="x1" type="int32"/>
+      </struct>
+
+      <struct name="TwoMembers" extensibility="appendable">
+        <member name="x1" type="int32"/>
+        <member name="x2" type="int32"/>
+      </struct>
+
       <union name="Choice" extensibility="appendable">
         <discriminator type="nonBasic" nonBasicTypeName="Kind"/>
         <case>

--- a/tests/unit-tests/dds/DCPS/XTypes/XmlTypeProvider.xml
+++ b/tests/unit-tests/dds/DCPS/XTypes/XmlTypeProvider.xml
@@ -43,6 +43,9 @@
           <value type="uint32"/>
         </member>
       </struct>
+      <struct name="Float128Sample" extensibility="final">
+        <member name="x1" type="float128"/>
+      </struct>
 
       <struct name="MapSample" extensibility="appendable">
         <member name="lookup" type="map" id="20" mapMaxLength="4">


### PR DESCRIPTION
A number of fixes required to get the omg-dds/dds-xtypes interoperability tests working between OpenDDS and OpenDDS (self-interop).