### PR TITLE
Check for null `ACE_Message_Block` in `peek_helper`

### DIFF
--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -679,6 +679,10 @@ public:
   template <typename T>
   bool peek_helper(ACE_Message_Block* const block, size_t bytes, T& t)
   {
+    if (!block) {
+      return false;
+    }
+
     bool result = false;
     char* const rd_ptr = block->rd_ptr();
     const size_t length = block->length();

--- a/tests/unit-tests/dds/DCPS/Serializer.cpp
+++ b/tests/unit-tests/dds/DCPS/Serializer.cpp
@@ -591,7 +591,7 @@ TEST(dds_DCPS_Serializer, read_parameter_id_xcdr2)
 
   const Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
   ACE_Message_Block mb(sizeof(xcdr));
-  mb.copy((const char*)xcdr, sizeof(xcdr));
+  mb.copy(reinterpret_cast<const char*>(xcdr), sizeof(xcdr));
   Serializer ser(&mb, enc);
   unsigned id;
   size_t size;
@@ -651,7 +651,7 @@ namespace {
   {
     const Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
     ACE_Message_Block mb(size);
-    if (xcdr && mb.copy(reinterpret_cast<const char *>(xcdr), size) != 0) {
+    if (xcdr && mb.copy(reinterpret_cast<const char*>(xcdr), size) != 0) {
       ACE_ERROR((LM_ERROR, "read_parameter_id_xcdr2: failed to copy data to message block!\n"));
       return false;
     }
@@ -687,9 +687,9 @@ TEST(dds_DCPS_Serializer, read_parameter_id_xcdr2_ok)
     const Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
     const size_t total_size = sizeof(xcdr);
     ACE_Message_Block mb(total_size - 3);
-    mb.copy((const char *)xcdr, total_size - 3);
+    mb.copy(reinterpret_cast<const char*>(xcdr), total_size - 3);
     ACE_Message_Block mb2(3);
-    mb2.copy((const char *)xcdr + total_size - 3, 3);
+    mb2.copy(reinterpret_cast<const char*>(xcdr) + total_size - 3, 3);
     mb.cont(&mb2);
     Serializer ser(&mb, enc);
     unsigned id;

--- a/tests/unit-tests/dds/DCPS/Serializer.cpp
+++ b/tests/unit-tests/dds/DCPS/Serializer.cpp
@@ -651,7 +651,10 @@ namespace {
   {
     const Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
     ACE_Message_Block mb(size);
-    mb.copy((const char *)xcdr, size);
+    if (xcdr && mb.copy(reinterpret_cast<const char *>(xcdr), size) != 0) {
+      ACE_ERROR((LM_ERROR, "read_parameter_id_xcdr2: failed to copy data to message block!\n"));
+      return false;
+    }
     Serializer ser(&mb, enc);
     unsigned id;
     size_t member_size;
@@ -714,8 +717,7 @@ TEST(dds_DCPS_Serializer, read_parameter_id_xcdr2_malformed_emheader)
 {
   {
     // Emheader is absent
-    unsigned char xcdr[] = {};
-    test_read_parameter_id_xcdr2_malformed(xcdr, sizeof(xcdr));
+    test_read_parameter_id_xcdr2_malformed(0, 0);
   }
   {
     // Emheader is truncated

--- a/tests/unit-tests/dds/DCPS/Serializer.cpp
+++ b/tests/unit-tests/dds/DCPS/Serializer.cpp
@@ -645,3 +645,151 @@ TEST(dds_DCPS_Serializer, read_parameter_id_xcdr2)
   EXPECT_FALSE(must_understand);
   ASSERT_TRUE(ser.skip(size));
 }
+
+namespace {
+  bool read_parameter_id_xcdr2(const unsigned char* xcdr, size_t size)
+  {
+    const Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
+    ACE_Message_Block mb(size);
+    mb.copy((const char *)xcdr, size);
+    Serializer ser(&mb, enc);
+    unsigned id;
+    size_t member_size;
+    bool must_understand;
+    return ser.read_parameter_id(id, member_size, must_understand);
+  }
+
+  void test_read_parameter_id_xcdr2_ok(const unsigned char* xcdr, size_t size)
+  {
+    ASSERT_TRUE(read_parameter_id_xcdr2(xcdr, size));
+  }
+
+  void test_read_parameter_id_xcdr2_malformed(const unsigned char* xcdr, size_t size)
+  {
+    ASSERT_FALSE(read_parameter_id_xcdr2(xcdr, size));
+  }
+}
+
+TEST(dds_DCPS_Serializer, read_parameter_id_xcdr2_ok)
+{
+  // well-formed emheader and nextint for LC=5,6,7 cases
+  {
+    unsigned char xcdr[] = {
+      0x50, 0x00, 0x00, 0x01,
+      0x00, 0x00, 0x00, 0x04
+    };
+    test_read_parameter_id_xcdr2_ok(xcdr, sizeof(xcdr));
+
+    // Splitted message into multiple blocks should also work
+    const Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
+    const size_t total_size = sizeof(xcdr);
+    ACE_Message_Block mb(total_size - 3);
+    mb.copy((const char *)xcdr, total_size - 3);
+    ACE_Message_Block mb2(3);
+    mb2.copy((const char *)xcdr + total_size - 3, 3);
+    mb.cont(&mb2);
+    Serializer ser(&mb, enc);
+    unsigned id;
+    size_t member_size;
+    bool must_understand;
+    ASSERT_TRUE(ser.read_parameter_id(id, member_size, must_understand));
+  }
+  {
+    unsigned char xcdr[] = {
+      0x60, 0x00, 0x00, 0x01,
+      0x00, 0x00, 0x00, 0x04
+    };
+    test_read_parameter_id_xcdr2_ok(xcdr, sizeof(xcdr));
+  }
+  {
+    unsigned char xcdr[] = {
+      0x70, 0x00, 0x00, 0x01,
+      0x00, 0x00, 0x00, 0x04
+    };
+    test_read_parameter_id_xcdr2_ok(xcdr, sizeof(xcdr));
+  }
+}
+
+TEST(dds_DCPS_Serializer, read_parameter_id_xcdr2_malformed_emheader)
+{
+  {
+    // Emheader is absent
+    unsigned char xcdr[] = {};
+    test_read_parameter_id_xcdr2_malformed(xcdr, sizeof(xcdr));
+  }
+  {
+    // Emheader is truncated
+    unsigned char xcdr[] = {
+      0x40, 0x00, 0x00
+    };
+    test_read_parameter_id_xcdr2_malformed(xcdr, sizeof(xcdr));
+  }
+}
+
+TEST(dds_DCPS_Serializer, read_parameter_id_xcdr2_missing_nextint)
+{
+  {
+    // LC=4
+    unsigned char xcdr[] = {
+      0x40, 0x00, 0x00, 0x01,
+    };
+    test_read_parameter_id_xcdr2_malformed(xcdr, sizeof(xcdr));
+  }
+  {
+    // LC=5
+    unsigned char xcdr[] = {
+      0x50, 0x00, 0x00, 0x01,
+    };
+    test_read_parameter_id_xcdr2_malformed(xcdr, sizeof(xcdr));
+  }
+  {
+    // LC=6
+    unsigned char xcdr[] = {
+      0x60, 0x00, 0x00, 0x01,
+    };
+    test_read_parameter_id_xcdr2_malformed(xcdr, sizeof(xcdr));
+  }
+  {
+    // LC=7
+    unsigned char xcdr[] = {
+      0x70, 0x00, 0x00, 0x01,
+    };
+    test_read_parameter_id_xcdr2_malformed(xcdr, sizeof(xcdr));
+  }
+}
+
+TEST(dds_DCPS_Serializer, read_parameter_id_xcdr2_truncated_nextint)
+{
+  {
+    // LC=4
+    unsigned char xcdr[] = {
+      0x40, 0x00, 0x00, 0x01,
+      0x00, 0x00, 0x03
+    };
+    test_read_parameter_id_xcdr2_malformed(xcdr, sizeof(xcdr));
+  }
+  {
+    // LC=5
+    unsigned char xcdr[] = {
+      0x50, 0x00, 0x00, 0x01,
+      0x01
+    };
+    test_read_parameter_id_xcdr2_malformed(xcdr, sizeof(xcdr));
+  }
+  {
+    // LC=6
+    unsigned char xcdr[] = {
+      0x60, 0x00, 0x00, 0x01,
+      0x00, 0x02
+    };
+    test_read_parameter_id_xcdr2_malformed(xcdr, sizeof(xcdr));
+  }
+  {
+    // LC=7
+    unsigned char xcdr[] = {
+      0x70, 0x00, 0x00, 0x01,
+      0x00, 0x00, 0x03
+    };
+    test_read_parameter_id_xcdr2_malformed(xcdr, sizeof(xcdr));
+  }
+}


### PR DESCRIPTION
**Problem**
For XCDR2 mutable data, with length code values of 5, 6, or 7, `read_parameter_id` calls `peek` to preview the value of the nextint field. Malformed data that doesn't have nextint can cause `Serializer` to have a null `current_` data member and crash the process.

**Solution**
Check for null in `peek_helper`. Also added tests for malformed input to `read_parameter_id`.