### PR TITLE
Backwards Compatible Fixes for Spec-compliant Duration_t Encoding

### DIFF
--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -299,20 +299,37 @@ namespace {
   // use. Nanoseconds mode deliberately preserves the historical OpenDDS wire
   // representation. Keeping the conversion here avoids changing every other,
   // non-RTPS-wire use of DDS::Duration_t CDR streaming.
+  //
+  // Maintenance note: there is no compile-time link between a PID and this
+  // conversion. If a PID whose Parameter case embeds a DDS::Duration_t is
+  // ever added to the switch statements below (or to a security wrapper),
+  // the corresponding encode_duration()/decode_duration() call MUST be added
+  // at that PID's case too, or fractional-seconds mode will silently
+  // corrupt just that one field on the wire again. The 7 PIDs currently
+  // covered are listed above; grep this file for "encode_duration(" and
+  // "decode_duration(" to see every existing call site.
   void encode_duration(DDS::Duration_t& dur,
                        ParameterListConverter::RtpsDurationEncoding encoding)
   {
     if (encoding == ParameterListConverter::RDE_NANOSECONDS) {
       return;
     }
-    if (dur.sec == DDS::DURATION_INFINITE_SEC &&
-        dur.nanosec == DDS::DURATION_INFINITE_NSEC) {
+    if (DCPS::is_infinite(dur)) {
       // RTPS::DURATION_INFINITE wire sentinel is {0x7fffffff, 0xffffffff} --
       // not what the fraction math below would produce from 0x7fffffff.
       // DDS::TIME_INVALID_NSEC is the same 0xffffffff value used by the wire
       // fraction sentinel.
       dur.nanosec = DDS::TIME_INVALID_NSEC;
       return;
+    }
+    // Duration_t is only spec-valid for nanosec < 1e9, but not every QoS
+    // policy's Qos_Helper::valid() enforces that upper bound. Normalize any
+    // excess into sec first so an out-of-range nanosec can't overflow the
+    // ACE_UINT32 fraction math below and silently wrap to a garbage or zero
+    // wire value.
+    if (dur.nanosec >= 1000000000u) {
+      dur.sec += static_cast<CORBA::Long>(dur.nanosec / 1000000000u);
+      dur.nanosec %= 1000000000u;
     }
     dur.nanosec = DCPS::nanoseconds_to_uint32_fractional_seconds(dur.nanosec);
   }

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -15,6 +15,7 @@
 #include <dds/DCPS/NetworkResource.h>
 #include <dds/DCPS/Qos_Helper.h>
 #include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/Time_Helper.h>
 
 #include <dds/OpenDDSConfigWrapper.h>
 
@@ -274,6 +275,62 @@ namespace {
         dur.nanosec == DDS::TIME_INVALID_NSEC) {
       dur.nanosec = DDS::DURATION_INFINITE_NSEC;
     }
+  }
+
+  // Spec-compliance note:
+  // DDS::Duration_t{sec, nanosec} is the plain DDS-IDL representation. The RTPS
+  // Parameter union (dds/DCPS/RTPS/RtpsCore.idl) reuses the DDS QoS policy
+  // structs directly for PID_DEADLINE, PID_LATENCY_BUDGET, PID_LIVELINESS,
+  // PID_RELIABILITY, PID_LIFESPAN, PID_TIME_BASED_FILTER, and
+  // PID_DURABILITY_SERVICE, whose embedded Duration_t gets serialized on the
+  // wire via the generic DDS::Duration_t CDR streaming operator -- which
+  // writes `sec` then `nanosec` verbatim. RTPS 2.5 Sec 9.3.2 defines the wire
+  // Duration_t as {seconds, fraction}, where fraction is in units of 1/2^32
+  // second, NOT raw nanoseconds (see OpenDDS::RTPS::Duration_t and
+  // RTPS::DURATION_INFINITE in MessageTypes.h, which get this right).
+  // Without this conversion, `nanosec` bits are written directly into the
+  // wire's `fraction` field and vice versa, silently corrupting any
+  // non-whole-second duration for both this process and any spec-compliant
+  // peer -- e.g. a 250ms LIFESPAN is announced with fraction=250000000
+  // instead of the spec-correct fraction=~1073741824 (250000000 * 2^32 / 1e9).
+  //
+  // Apply these immediately before encoding a Duration_t-bearing Parameter
+  // and immediately after decoding one when fractional-seconds mode is in
+  // use. Nanoseconds mode deliberately preserves the historical OpenDDS wire
+  // representation. Keeping the conversion here avoids changing every other,
+  // non-RTPS-wire use of DDS::Duration_t CDR streaming.
+  void encode_duration(DDS::Duration_t& dur,
+                       ParameterListConverter::RtpsDurationEncoding encoding)
+  {
+    if (encoding == ParameterListConverter::RDE_NANOSECONDS) {
+      return;
+    }
+    if (dur.sec == DDS::DURATION_INFINITE_SEC &&
+        dur.nanosec == DDS::DURATION_INFINITE_NSEC) {
+      // RTPS::DURATION_INFINITE wire sentinel is {0x7fffffff, 0xffffffff} --
+      // not what the fraction math below would produce from 0x7fffffff.
+      // DDS::TIME_INVALID_NSEC is the same 0xffffffff value used by the wire
+      // fraction sentinel.
+      dur.nanosec = DDS::TIME_INVALID_NSEC;
+      return;
+    }
+    dur.nanosec = DCPS::nanoseconds_to_uint32_fractional_seconds(dur.nanosec);
+  }
+
+  void decode_duration(DDS::Duration_t& dur,
+                       ParameterListConverter::RtpsDurationEncoding encoding)
+  {
+    if (encoding == ParameterListConverter::RDE_NANOSECONDS) {
+      return;
+    }
+    if (dur.sec == DDS::DURATION_INFINITE_SEC &&
+        dur.nanosec == DDS::TIME_INVALID_NSEC) {
+      // Wire RTPS::DURATION_INFINITE sentinel -- normalize() below also
+      // handles this value, called after this function at every use site.
+      dur.nanosec = DDS::DURATION_INFINITE_NSEC;
+      return;
+    }
+    dur.nanosec = DCPS::uint32_fractional_seconds_to_nanoseconds(dur.nanosec);
   }
 
 #if OPENDDS_CONFIG_SECURITY
@@ -812,6 +869,17 @@ bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
                    const DCPS::TypeInformation& type_info,
                    bool map)
 {
+  return to_param_list(writer_data, param_list, use_xtypes, type_info,
+                       RDE_NANOSECONDS, map);
+}
+
+bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
+                   ParameterList& param_list,
+                   bool use_xtypes,
+                   const DCPS::TypeInformation& type_info,
+                   RtpsDurationEncoding duration_encoding,
+                   bool map)
+{
   // Ignore builtin topic key
 
   {
@@ -840,25 +908,33 @@ bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
 
   if (not_default(writer_data.ddsPublicationData.durability_service)) {
     Parameter param;
-    param.durability_service(writer_data.ddsPublicationData.durability_service);
+    DDS::DurabilityServiceQosPolicy durability_service = writer_data.ddsPublicationData.durability_service;
+    encode_duration(durability_service.service_cleanup_delay, duration_encoding);
+    param.durability_service(durability_service);
     DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.deadline)) {
     Parameter param;
-    param.deadline(writer_data.ddsPublicationData.deadline);
+    DDS::DeadlineQosPolicy deadline = writer_data.ddsPublicationData.deadline;
+    encode_duration(deadline.period, duration_encoding);
+    param.deadline(deadline);
     DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.latency_budget)) {
     Parameter param;
-    param.latency_budget(writer_data.ddsPublicationData.latency_budget);
+    DDS::LatencyBudgetQosPolicy latency_budget = writer_data.ddsPublicationData.latency_budget;
+    encode_duration(latency_budget.duration, duration_encoding);
+    param.latency_budget(latency_budget);
     DCPS::push_back(param_list, param);
   }
 
   if (not_default(writer_data.ddsPublicationData.liveliness)) {
     Parameter param;
-    param.liveliness(writer_data.ddsPublicationData.liveliness);
+    DDS::LivelinessQosPolicy liveliness = writer_data.ddsPublicationData.liveliness;
+    encode_duration(liveliness.lease_duration, duration_encoding);
+    param.liveliness(liveliness);
     DCPS::push_back(param_list, param);
   }
 
@@ -868,6 +944,7 @@ bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
     Parameter param;
     ReliabilityQosPolicyRtps reliability;
     reliability.max_blocking_time = writer_data.ddsPublicationData.reliability.max_blocking_time;
+    encode_duration(reliability.max_blocking_time, duration_encoding);
 
     if (writer_data.ddsPublicationData.reliability.kind == DDS::BEST_EFFORT_RELIABILITY_QOS) {
       reliability.kind.value = RTPS::BEST_EFFORT;
@@ -881,7 +958,9 @@ bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
 
   if (not_default(writer_data.ddsPublicationData.lifespan)) {
     Parameter param;
-    param.lifespan(writer_data.ddsPublicationData.lifespan);
+    DDS::LifespanQosPolicy lifespan = writer_data.ddsPublicationData.lifespan;
+    encode_duration(lifespan.duration, duration_encoding);
+    param.lifespan(lifespan);
     DCPS::push_back(param_list, param);
   }
 
@@ -974,6 +1053,17 @@ bool from_param_list(const ParameterList& param_list,
                      bool use_xtypes,
                      XTypes::TypeInformation& type_info)
 {
+  return from_param_list(param_list, vendor_id, writer_data, use_xtypes,
+                         type_info, RDE_NANOSECONDS);
+}
+
+bool from_param_list(const ParameterList& param_list,
+                     const VendorId_t& vendor_id,
+                     DCPS::DiscoveredWriterData& writer_data,
+                     bool use_xtypes,
+                     XTypes::TypeInformation& type_info,
+                     RtpsDurationEncoding duration_encoding)
+{
   // Collect the rtps_udp locators before appending them to allLocators
   DCPS::LocatorSeq rtps_udp_locators;
 
@@ -1033,26 +1123,37 @@ bool from_param_list(const ParameterList& param_list,
       case PID_DURABILITY_SERVICE:
         writer_data.ddsPublicationData.durability_service =
           param.durability_service();
+        decode_duration(
+          writer_data.ddsPublicationData.durability_service.service_cleanup_delay,
+          duration_encoding);
         // Interoperability note: calling normalize() shouldn't be required
         normalize(writer_data.ddsPublicationData.durability_service.service_cleanup_delay);
         break;
       case PID_DEADLINE:
         writer_data.ddsPublicationData.deadline = param.deadline();
+        decode_duration(writer_data.ddsPublicationData.deadline.period, duration_encoding);
         // Interoperability note: calling normalize() shouldn't be required
         normalize(writer_data.ddsPublicationData.deadline.period);
         break;
       case PID_LATENCY_BUDGET:
         writer_data.ddsPublicationData.latency_budget = param.latency_budget();
+        decode_duration(writer_data.ddsPublicationData.latency_budget.duration,
+                        duration_encoding);
         // Interoperability note: calling normalize() shouldn't be required
         normalize(writer_data.ddsPublicationData.latency_budget.duration);
         break;
       case PID_LIVELINESS:
         writer_data.ddsPublicationData.liveliness = param.liveliness();
+        decode_duration(writer_data.ddsPublicationData.liveliness.lease_duration,
+                        duration_encoding);
         // Interoperability note: calling normalize() shouldn't be required
         normalize(writer_data.ddsPublicationData.liveliness.lease_duration);
         break;
       case PID_RELIABILITY:
         writer_data.ddsPublicationData.reliability.max_blocking_time = param.reliability().max_blocking_time;
+        decode_duration(
+          writer_data.ddsPublicationData.reliability.max_blocking_time,
+          duration_encoding);
         // Interoperability note:
         // Spec creators for RTPS have reliability indexed at 1
         {
@@ -1066,6 +1167,7 @@ bool from_param_list(const ParameterList& param_list,
         break;
       case PID_LIFESPAN:
         writer_data.ddsPublicationData.lifespan = param.lifespan();
+        decode_duration(writer_data.ddsPublicationData.lifespan.duration, duration_encoding);
         // Interoperability note: calling normalize() shouldn't be required
         normalize(writer_data.ddsPublicationData.lifespan.duration);
         break;
@@ -1147,6 +1249,17 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
                    const DCPS::TypeInformation& type_info,
                    bool map)
 {
+  return to_param_list(reader_data, param_list, use_xtypes, type_info,
+                       RDE_NANOSECONDS, map);
+}
+
+bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
+                   ParameterList& param_list,
+                   bool use_xtypes,
+                   const DCPS::TypeInformation& type_info,
+                   RtpsDurationEncoding duration_encoding,
+                   bool map)
+{
   // Ignore builtin topic key
   {
     Parameter param;
@@ -1174,19 +1287,25 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
 
   if (not_default(reader_data.ddsSubscriptionData.deadline)) {
     Parameter param;
-    param.deadline(reader_data.ddsSubscriptionData.deadline);
+    DDS::DeadlineQosPolicy deadline = reader_data.ddsSubscriptionData.deadline;
+    encode_duration(deadline.period, duration_encoding);
+    param.deadline(deadline);
     DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.latency_budget)) {
     Parameter param;
-    param.latency_budget(reader_data.ddsSubscriptionData.latency_budget);
+    DDS::LatencyBudgetQosPolicy latency_budget = reader_data.ddsSubscriptionData.latency_budget;
+    encode_duration(latency_budget.duration, duration_encoding);
+    param.latency_budget(latency_budget);
     DCPS::push_back(param_list, param);
   }
 
   if (not_default(reader_data.ddsSubscriptionData.liveliness)) {
     Parameter param;
-    param.liveliness(reader_data.ddsSubscriptionData.liveliness);
+    DDS::LivelinessQosPolicy liveliness = reader_data.ddsSubscriptionData.liveliness;
+    encode_duration(liveliness.lease_duration, duration_encoding);
+    param.liveliness(liveliness);
     DCPS::push_back(param_list, param);
   }
 
@@ -1197,6 +1316,7 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
     Parameter param;
     ReliabilityQosPolicyRtps reliability;
     reliability.max_blocking_time = reader_data.ddsSubscriptionData.reliability.max_blocking_time;
+    encode_duration(reliability.max_blocking_time, duration_encoding);
 
     if (reader_data.ddsSubscriptionData.reliability.kind == DDS::RELIABLE_RELIABILITY_QOS) {
       reliability.kind.value = RTPS::RELIABLE;
@@ -1228,7 +1348,9 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
 
   if (not_default(reader_data.ddsSubscriptionData.time_based_filter)) {
     Parameter param;
-    param.time_based_filter(reader_data.ddsSubscriptionData.time_based_filter);
+    DDS::TimeBasedFilterQosPolicy time_based_filter = reader_data.ddsSubscriptionData.time_based_filter;
+    encode_duration(time_based_filter.minimum_separation, duration_encoding);
+    param.time_based_filter(time_based_filter);
     DCPS::push_back(param_list, param);
   }
 
@@ -1321,6 +1443,17 @@ bool from_param_list(const ParameterList& param_list,
                      bool use_xtypes,
                      XTypes::TypeInformation& type_info)
 {
+  return from_param_list(param_list, vendor_id, reader_data, use_xtypes,
+                         type_info, RDE_NANOSECONDS);
+}
+
+bool from_param_list(const ParameterList& param_list,
+                     const VendorId_t& vendor_id,
+                     DCPS::DiscoveredReaderData& reader_data,
+                     bool use_xtypes,
+                     XTypes::TypeInformation& type_info,
+                     RtpsDurationEncoding duration_encoding)
+{
   // Collect the rtps_udp locators before appending them to allLocators
 
   DCPS::LocatorSeq rtps_udp_locators;
@@ -1379,21 +1512,29 @@ bool from_param_list(const ParameterList& param_list,
         break;
       case PID_DEADLINE:
         reader_data.ddsSubscriptionData.deadline = param.deadline();
+        decode_duration(reader_data.ddsSubscriptionData.deadline.period, duration_encoding);
         // Interoperability note: calling normalize() shouldn't be required
         normalize(reader_data.ddsSubscriptionData.deadline.period);
         break;
       case PID_LATENCY_BUDGET:
         reader_data.ddsSubscriptionData.latency_budget = param.latency_budget();
+        decode_duration(reader_data.ddsSubscriptionData.latency_budget.duration,
+                        duration_encoding);
         // Interoperability note: calling normalize() shouldn't be required
         normalize(reader_data.ddsSubscriptionData.latency_budget.duration);
         break;
       case PID_LIVELINESS:
         reader_data.ddsSubscriptionData.liveliness = param.liveliness();
+        decode_duration(reader_data.ddsSubscriptionData.liveliness.lease_duration,
+                        duration_encoding);
         // Interoperability note: calling normalize() shouldn't be required
         normalize(reader_data.ddsSubscriptionData.liveliness.lease_duration);
         break;
       case PID_RELIABILITY:
         reader_data.ddsSubscriptionData.reliability.max_blocking_time = param.reliability().max_blocking_time;
+        decode_duration(
+          reader_data.ddsSubscriptionData.reliability.max_blocking_time,
+          duration_encoding);
         // Interoperability note:
         // Spec creators for RTPS have reliability indexed at 1
         {
@@ -1417,6 +1558,9 @@ bool from_param_list(const ParameterList& param_list,
         break;
       case PID_TIME_BASED_FILTER:
         reader_data.ddsSubscriptionData.time_based_filter = param.time_based_filter();
+        decode_duration(
+          reader_data.ddsSubscriptionData.time_based_filter.minimum_separation,
+          duration_encoding);
         // Interoperability note: calling normalize() shouldn't be required
         normalize(reader_data.ddsSubscriptionData.time_based_filter.minimum_separation);
         break;
@@ -1557,7 +1701,19 @@ bool to_param_list(const DiscoveredPublication_SecurityWrapper& wrapper,
                    const DCPS::TypeInformation& type_info,
                    bool map)
 {
-  return to_param_list(wrapper.data, param_list, use_xtypes, type_info, map)
+  return to_param_list(wrapper, param_list, use_xtypes, type_info,
+                       RDE_NANOSECONDS, map);
+}
+
+bool to_param_list(const DiscoveredPublication_SecurityWrapper& wrapper,
+                   ParameterList& param_list,
+                   bool use_xtypes,
+                   const DCPS::TypeInformation& type_info,
+                   RtpsDurationEncoding duration_encoding,
+                   bool map)
+{
+  return to_param_list(wrapper.data, param_list, use_xtypes, type_info,
+                       duration_encoding, map)
     && to_param_list(wrapper.security_info, param_list)
     && to_param_list(wrapper.data_tags, param_list);
 }
@@ -1568,7 +1724,19 @@ bool from_param_list(const ParameterList& param_list,
                      bool use_xtypes,
                      XTypes::TypeInformation& type_info)
 {
-  return from_param_list(param_list, vendor_id, wrapper.data, use_xtypes, type_info) &&
+  return from_param_list(param_list, vendor_id, wrapper, use_xtypes,
+                         type_info, RDE_NANOSECONDS);
+}
+
+bool from_param_list(const ParameterList& param_list,
+                     const VendorId_t& vendor_id,
+                     DiscoveredPublication_SecurityWrapper& wrapper,
+                     bool use_xtypes,
+                     XTypes::TypeInformation& type_info,
+                     RtpsDurationEncoding duration_encoding)
+{
+  return from_param_list(param_list, vendor_id, wrapper.data, use_xtypes,
+                         type_info, duration_encoding) &&
     from_param_list(param_list, wrapper.security_info) &&
     from_param_list(param_list, wrapper.data_tags);
 }
@@ -1579,7 +1747,19 @@ bool to_param_list(const DiscoveredSubscription_SecurityWrapper& wrapper,
                    const DCPS::TypeInformation& type_info,
                    bool map)
 {
-  return to_param_list(wrapper.data, param_list, use_xtypes, type_info, map)
+  return to_param_list(wrapper, param_list, use_xtypes, type_info,
+                       RDE_NANOSECONDS, map);
+}
+
+bool to_param_list(const DiscoveredSubscription_SecurityWrapper& wrapper,
+                   ParameterList& param_list,
+                   bool use_xtypes,
+                   const DCPS::TypeInformation& type_info,
+                   RtpsDurationEncoding duration_encoding,
+                   bool map)
+{
+  return to_param_list(wrapper.data, param_list, use_xtypes, type_info,
+                       duration_encoding, map)
     && to_param_list(wrapper.security_info, param_list)
     && to_param_list(wrapper.data_tags, param_list);
 }
@@ -1590,7 +1770,19 @@ bool from_param_list(const ParameterList& param_list,
                      bool use_xtypes,
                      XTypes::TypeInformation& type_info)
 {
-  bool result = from_param_list(param_list, vendor_id, wrapper.data, use_xtypes, type_info) &&
+  return from_param_list(param_list, vendor_id, wrapper, use_xtypes,
+                         type_info, RDE_NANOSECONDS);
+}
+
+bool from_param_list(const ParameterList& param_list,
+                     const VendorId_t& vendor_id,
+                     DiscoveredSubscription_SecurityWrapper& wrapper,
+                     bool use_xtypes,
+                     XTypes::TypeInformation& type_info,
+                     RtpsDurationEncoding duration_encoding)
+{
+  bool result = from_param_list(param_list, vendor_id, wrapper.data, use_xtypes,
+                                type_info, duration_encoding) &&
     from_param_list(param_list, wrapper.security_info) &&
     from_param_list(param_list, wrapper.data_tags);
 

--- a/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -328,7 +328,17 @@ namespace {
     // ACE_UINT32 fraction math below and silently wrap to a garbage or zero
     // wire value.
     if (dur.nanosec >= 1000000000u) {
-      dur.sec += static_cast<CORBA::Long>(dur.nanosec / 1000000000u);
+      const CORBA::Long carry =
+        static_cast<CORBA::Long>(dur.nanosec / 1000000000u);
+      if (dur.sec > DDS::DURATION_INFINITE_SEC - carry) {
+        // The normalized duration can't be represented by Duration_t.
+        // Saturate to the RTPS infinite-duration sentinel instead of
+        // overflowing the signed seconds field.
+        dur.sec = DDS::DURATION_INFINITE_SEC;
+        dur.nanosec = DDS::TIME_INVALID_NSEC;
+        return;
+      }
+      dur.sec += carry;
       dur.nanosec %= 1000000000u;
     }
     dur.nanosec = DCPS::nanoseconds_to_uint32_fractional_seconds(dur.nanosec);

--- a/dds/DCPS/RTPS/ParameterListConverter.h
+++ b/dds/DCPS/RTPS/ParameterListConverter.h
@@ -27,6 +27,11 @@ namespace OpenDDS {
 namespace RTPS {
 namespace ParameterListConverter {
 
+enum RtpsDurationEncoding {
+  RDE_NANOSECONDS,
+  RDE_FRACTIONAL_SECONDS
+};
+
 #if OPENDDS_CONFIG_SECURITY
 struct DiscoveredPublication_SecurityWrapper {
   DCPS::DiscoveredWriterData data;
@@ -152,11 +157,27 @@ bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
                    bool map = false /*map IPV4 to IPV6 addr*/);
 
 OpenDDS_Rtps_Export
+bool to_param_list(const DCPS::DiscoveredWriterData& writer_data,
+                   ParameterList& param_list,
+                   bool use_xtypes,
+                   const DCPS::TypeInformation& type_info,
+                   RtpsDurationEncoding duration_encoding,
+                   bool map = false /*map IPV4 to IPV6 addr*/);
+
+OpenDDS_Rtps_Export
 bool from_param_list(const ParameterList& param_list,
                      const VendorId_t& vendor_id,
                      DCPS::DiscoveredWriterData& writer_data,
                      bool use_xtypes,
                      XTypes::TypeInformation& type_info);
+
+OpenDDS_Rtps_Export
+bool from_param_list(const ParameterList& param_list,
+                     const VendorId_t& vendor_id,
+                     DCPS::DiscoveredWriterData& writer_data,
+                     bool use_xtypes,
+                     XTypes::TypeInformation& type_info,
+                     RtpsDurationEncoding duration_encoding);
 
 // OpenDDS::DCPS::DiscoveredReaderData
 
@@ -168,11 +189,27 @@ bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
                    bool map = false /*map IPV4 to IPV6 addr*/);
 
 OpenDDS_Rtps_Export
+bool to_param_list(const DCPS::DiscoveredReaderData& reader_data,
+                   ParameterList& param_list,
+                   bool use_xtypes,
+                   const DCPS::TypeInformation& type_info,
+                   RtpsDurationEncoding duration_encoding,
+                   bool map = false /*map IPV4 to IPV6 addr*/);
+
+OpenDDS_Rtps_Export
 bool from_param_list(const ParameterList& param_list,
                      const VendorId_t& vendor_id,
                      DCPS::DiscoveredReaderData& reader_data,
                      bool use_xtypes,
                      XTypes::TypeInformation& type_info);
+
+OpenDDS_Rtps_Export
+bool from_param_list(const ParameterList& param_list,
+                     const VendorId_t& vendor_id,
+                     DCPS::DiscoveredReaderData& reader_data,
+                     bool use_xtypes,
+                     XTypes::TypeInformation& type_info,
+                     RtpsDurationEncoding duration_encoding);
 
 #if OPENDDS_CONFIG_SECURITY
 // DDS::Security::EndpointSecurityInfo
@@ -205,11 +242,27 @@ bool to_param_list(const DiscoveredPublication_SecurityWrapper& wrapper,
                    bool map = false /*map IPV4 to IPV6 addr*/);
 
 OpenDDS_Rtps_Export
+bool to_param_list(const DiscoveredPublication_SecurityWrapper& wrapper,
+                   ParameterList& param_list,
+                   bool use_xtypes,
+                   const DCPS::TypeInformation& type_info,
+                   RtpsDurationEncoding duration_encoding,
+                   bool map = false /*map IPV4 to IPV6 addr*/);
+
+OpenDDS_Rtps_Export
 bool from_param_list(const ParameterList& param_list,
                      const VendorId_t& vendor_id,
                      DiscoveredPublication_SecurityWrapper& wrapper,
                      bool use_xtypes,
                      XTypes::TypeInformation& type_info);
+
+OpenDDS_Rtps_Export
+bool from_param_list(const ParameterList& param_list,
+                     const VendorId_t& vendor_id,
+                     DiscoveredPublication_SecurityWrapper& wrapper,
+                     bool use_xtypes,
+                     XTypes::TypeInformation& type_info,
+                     RtpsDurationEncoding duration_encoding);
 
 // DiscoveredSubscription_SecurityWrapper
 
@@ -221,11 +274,27 @@ bool to_param_list(const DiscoveredSubscription_SecurityWrapper& wrapper,
                    bool map = false /*map IPV4 to IPV6 addr*/);
 
 OpenDDS_Rtps_Export
+bool to_param_list(const DiscoveredSubscription_SecurityWrapper& wrapper,
+                   ParameterList& param_list,
+                   bool use_xtypes,
+                   const DCPS::TypeInformation& type_info,
+                   RtpsDurationEncoding duration_encoding,
+                   bool map = false /*map IPV4 to IPV6 addr*/);
+
+OpenDDS_Rtps_Export
 bool from_param_list(const ParameterList& param_list,
                      const VendorId_t& vendor_id,
                      DiscoveredSubscription_SecurityWrapper& wrapper,
                      bool use_xtypes,
                      XTypes::TypeInformation& type_info);
+
+OpenDDS_Rtps_Export
+bool from_param_list(const ParameterList& param_list,
+                     const VendorId_t& vendor_id,
+                     DiscoveredSubscription_SecurityWrapper& wrapper,
+                     bool use_xtypes,
+                     XTypes::TypeInformation& type_info,
+                     RtpsDurationEncoding duration_encoding);
 
 // Extensions for ICE
 

--- a/dds/DCPS/RTPS/RtpsCore.idl
+++ b/dds/DCPS/RTPS/RtpsCore.idl
@@ -327,6 +327,8 @@ module OpenDDS {
     const OpenDDSParticipantFlagsBits_t PFLAGS_DIRECTED_HEARTBEAT = 0x2;
     // Causes reliable RTPS Readers to use the heartbeat count as the acknack count.
     const OpenDDSParticipantFlagsBits_t PFLAGS_REFLECT_HEARTBEAT_COUNT = 0x4;
+    // Embedded DDS::Duration_t values in endpoint QoS use RTPS fractional seconds.
+    const OpenDDSParticipantFlagsBits_t PFLAGS_RTPS_DURATION_FRACTION = 0x8;
     const OpenDDSParticipantFlagsBits_t PFLAGS_THIS_VERSION = PFLAGS_DIRECTED_HEARTBEAT | PFLAGS_NO_ASSOCIATED_WRITERS;
 
     struct OpenDDSParticipantFlags_t {

--- a/dds/DCPS/RTPS/RtpsDiscovery.h
+++ b/dds/DCPS/RTPS/RtpsDiscovery.h
@@ -182,6 +182,9 @@ public:
   void use_xtypes(RtpsDiscoveryConfig::UseXTypes val) { return config_->use_xtypes(val); }
   bool use_xtypes_complete() const { return config_->use_xtypes_complete(); }
 
+  bool use_rtps_duration_fraction() const { return config_->use_rtps_duration_fraction(); }
+  void use_rtps_duration_fraction(bool value) { config_->use_rtps_duration_fraction(value); }
+
   RtpsDiscoveryConfig_rch config() const { return config_; }
 
 #if OPENDDS_CONFIG_SECURITY

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -1101,14 +1101,15 @@ RtpsDiscoveryConfig::sedp_fragment_reassembly_timeout(const DCPS::TimeDuration& 
 CORBA::ULong
 RtpsDiscoveryConfig::participant_flags() const
 {
-  CORBA::ULong flags = TheServiceParticipant->config_store()->get_uint32(
+  const CORBA::ULong flags = TheServiceParticipant->config_store()->get_uint32(
     config_key("PARTICIPANT_FLAGS").c_str(), PFLAGS_THIS_VERSION);
-  if (use_rtps_duration_fraction()) {
-    flags |= PFLAGS_RTPS_DURATION_FRACTION;
-  } else {
-    flags &= ~PFLAGS_RTPS_DURATION_FRACTION;
-  }
-  return flags;
+  // PFLAGS_RTPS_DURATION_FRACTION is exclusively controlled by
+  // USE_RTPS_DURATION_FRACTION (see use_rtps_duration_fraction()) and always
+  // overrides whatever was stored for that bit via participant_flags(CORBA::ULong).
+  // This is unlike every other PARTICIPANT_FLAGS bit, which is raw, authoritative
+  // storage (see e.g. Spdp::init()'s handling of PFLAGS_REFLECT_HEARTBEAT_COUNT).
+  return use_rtps_duration_fraction()
+    ? (flags | PFLAGS_RTPS_DURATION_FRACTION) : (flags & ~PFLAGS_RTPS_DURATION_FRACTION);
 }
 
 void

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -1101,8 +1101,14 @@ RtpsDiscoveryConfig::sedp_fragment_reassembly_timeout(const DCPS::TimeDuration& 
 CORBA::ULong
 RtpsDiscoveryConfig::participant_flags() const
 {
-  return TheServiceParticipant->config_store()->get_uint32(config_key("PARTICIPANT_FLAGS").c_str(),
-                                                           PFLAGS_THIS_VERSION);
+  CORBA::ULong flags = TheServiceParticipant->config_store()->get_uint32(
+    config_key("PARTICIPANT_FLAGS").c_str(), PFLAGS_THIS_VERSION);
+  if (use_rtps_duration_fraction()) {
+    flags |= PFLAGS_RTPS_DURATION_FRACTION;
+  } else {
+    flags &= ~PFLAGS_RTPS_DURATION_FRACTION;
+  }
+  return flags;
 }
 
 void
@@ -1110,6 +1116,20 @@ RtpsDiscoveryConfig::participant_flags(CORBA::ULong participant_flags)
 {
   TheServiceParticipant->config_store()->set_uint32(config_key("PARTICIPANT_FLAGS").c_str(),
                                                     participant_flags);
+}
+
+bool
+RtpsDiscoveryConfig::use_rtps_duration_fraction() const
+{
+  return TheServiceParticipant->config_store()->get_boolean(
+    config_key("USE_RTPS_DURATION_FRACTION").c_str(), false);
+}
+
+void
+RtpsDiscoveryConfig::use_rtps_duration_fraction(bool value)
+{
+  TheServiceParticipant->config_store()->set_boolean(
+    config_key("USE_RTPS_DURATION_FRACTION").c_str(), value);
 }
 
 bool

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
@@ -237,6 +237,9 @@ public:
   CORBA::ULong participant_flags() const;
   void participant_flags(CORBA::ULong participant_flags);
 
+  bool use_rtps_duration_fraction() const;
+  void use_rtps_duration_fraction(bool value);
+
   bool sedp_responsive_mode() const;
   void sedp_responsive_mode(bool sedp_responsive_mode);
 

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -307,6 +307,13 @@ using DCPS::NetworkAddress;
 namespace {
   const Encoding sedp_encoding(Encoding::KIND_XCDR1, DCPS::ENDIAN_LITTLE);
   const Encoding type_lookup_encoding(Encoding::KIND_XCDR2, DCPS::ENDIAN_NATIVE);
+
+  ParameterListConverter::RtpsDurationEncoding duration_encoding(bool use_fraction)
+  {
+    return use_fraction
+      ? ParameterListConverter::RDE_FRACTIONAL_SECONDS
+      : ParameterListConverter::RDE_NANOSECONDS;
+  }
 }
 
 RtpsDiscoveryCore::RtpsDiscoveryCore(RcHandle<RtpsDiscoveryConfig> config,
@@ -4422,6 +4429,9 @@ Sedp::DiscoveryReader::data_received_i(const DCPS::ReceivedDataSample& sample,
   DCPS::Extensibility extensibility)
 {
   const DCPS::MessageId id = static_cast<DCPS::MessageId>(sample.header_.message_id_);
+  const ParameterListConverter::RtpsDurationEncoding remote_duration_encoding =
+    duration_encoding(sedp_.spdp_.participant_uses_rtps_duration_fraction(
+      sample.header_.publication_id_));
 
   if (entity_id == ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER) {
     ParameterList data;
@@ -4434,7 +4444,10 @@ Sedp::DiscoveryReader::data_received_i(const DCPS::ReceivedDataSample& sample,
     }
 
     DiscoveredPublication wdata;
-    if (!ParameterListConverter::from_param_list(data, sedp_.spdp_.get_vendor_id(sample.header_.publication_id_), wdata.writer_data_, sedp_.use_xtypes_, wdata.type_info_)) {
+    if (!ParameterListConverter::from_param_list(
+          data, sedp_.spdp_.get_vendor_id(sample.header_.publication_id_),
+          wdata.writer_data_, sedp_.use_xtypes_, wdata.type_info_,
+          remote_duration_encoding)) {
       if (log_level >= LogLevel::Warning) {
         ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: Sedp::DiscoveryReader::data_received_i: "
                    "failed to convert from ParameterList to DiscoveredWriterData\n"));
@@ -4480,7 +4493,10 @@ Sedp::DiscoveryReader::data_received_i(const DCPS::ReceivedDataSample& sample,
 
     ParameterListConverter::DiscoveredPublication_SecurityWrapper wdata_secure = ParameterListConverter::DiscoveredPublication_SecurityWrapper();
 
-    if (!ParameterListConverter::from_param_list(data, sedp_.spdp_.get_vendor_id(sample.header_.publication_id_), wdata_secure, sedp_.use_xtypes_, wdata_secure.type_info)) {
+    if (!ParameterListConverter::from_param_list(
+          data, sedp_.spdp_.get_vendor_id(sample.header_.publication_id_),
+          wdata_secure, sedp_.use_xtypes_, wdata_secure.type_info,
+          remote_duration_encoding)) {
       if (log_level >= LogLevel::Warning) {
         ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: Sedp::DiscoveryReader::data_received_i: "
                    "failed to convert from ParameterList to DiscoveredPublication_SecurityWrapper\n"));
@@ -4523,7 +4539,10 @@ Sedp::DiscoveryReader::data_received_i(const DCPS::ReceivedDataSample& sample,
     }
 
     DiscoveredSubscription rdata;
-    if (!ParameterListConverter::from_param_list(data, sedp_.spdp_.get_vendor_id(sample.header_.publication_id_), rdata.reader_data_, sedp_.use_xtypes_, rdata.type_info_)) {
+    if (!ParameterListConverter::from_param_list(
+          data, sedp_.spdp_.get_vendor_id(sample.header_.publication_id_),
+          rdata.reader_data_, sedp_.use_xtypes_, rdata.type_info_,
+          remote_duration_encoding)) {
       if (log_level >= LogLevel::Warning) {
         ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: Sedp::DiscoveryReader::data_received_i: "
                    "failed to convert from ParameterList to DiscoveredReaderData\n"));
@@ -4571,7 +4590,10 @@ Sedp::DiscoveryReader::data_received_i(const DCPS::ReceivedDataSample& sample,
     }
 
     ParameterListConverter::DiscoveredSubscription_SecurityWrapper rdata_secure;
-    if (!ParameterListConverter::from_param_list(data, sedp_.spdp_.get_vendor_id(sample.header_.publication_id_), rdata_secure, sedp_.use_xtypes_, rdata_secure.type_info)) {
+    if (!ParameterListConverter::from_param_list(
+          data, sedp_.spdp_.get_vendor_id(sample.header_.publication_id_),
+          rdata_secure, sedp_.use_xtypes_, rdata_secure.type_info,
+          remote_duration_encoding)) {
       if (log_level >= LogLevel::Warning) {
         ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: Sedp::DiscoveryReader::data_received_i: "
                    "failed to convert from ParameterList to DiscoveredSubscription_SecurityWrapper\n"));
@@ -5059,6 +5081,8 @@ Sedp::write_publication_data_unsecure(UsedEndpoints& ue,
 
   bool useFlexibleTypes = false;
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
+  const ParameterListConverter::RtpsDurationEncoding local_duration_encoding =
+    duration_encoding((participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0);
   if (spdp_.associated() && (reader != GUID_UNKNOWN ||
                              !associated_participants_.empty())) {
     DCPS::DiscoveredWriterData dwd;
@@ -5071,12 +5095,14 @@ Sedp::write_publication_data_unsecure(UsedEndpoints& ue,
         return DDS::RETCODE_PRECONDITION_NOT_MET;
       }
       const DCPS::TypeInformation typeinfo(*lp.typeInfoFor(reader, &useFlexibleTypes));
-      if (!ParameterListConverter::to_param_list(dwd, plist, true, typeinfo)) {
+      if (!ParameterListConverter::to_param_list(
+            dwd, plist, true, typeinfo, local_duration_encoding)) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Sedp::write_publication_data_unsecure: "
                    "Failed to convert DiscoveredWriterData to ParameterList (Flags_FlexibleTypeSupport)\n"));
         result = DDS::RETCODE_ERROR;
       }
-    } else if (!ParameterListConverter::to_param_list(dwd, plist, use_xtypes_, lp.type_info_)) {
+    } else if (!ParameterListConverter::to_param_list(
+          dwd, plist, use_xtypes_, lp.type_info_, local_duration_encoding)) {
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: Sedp::write_publication_data_unsecure: ")
                  ACE_TEXT("Failed to convert DiscoveredWriterData ")
@@ -5128,6 +5154,8 @@ Sedp::write_publication_data_secure(UsedEndpoints& ue,
 
   bool useFlexibleTypes = false;
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
+  const ParameterListConverter::RtpsDurationEncoding local_duration_encoding =
+    duration_encoding((participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0);
   if (spdp_.associated() && (reader != GUID_UNKNOWN ||
                              !associated_participants_.empty())) {
 
@@ -5144,12 +5172,14 @@ Sedp::write_publication_data_secure(UsedEndpoints& ue,
         return DDS::RETCODE_PRECONDITION_NOT_MET;
       }
       const DCPS::TypeInformation typeinfo(*lp.typeInfoFor(reader, &useFlexibleTypes));
-      if (!ParameterListConverter::to_param_list(dwd, plist, true, typeinfo)) {
+      if (!ParameterListConverter::to_param_list(
+            dwd, plist, true, typeinfo, local_duration_encoding)) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Sedp::write_publication_data_secure: "
                              "Failed to convert DiscoveredWriterData to ParameterList (Flags_FlexibleTypeSupport)\n"));
         result = DDS::RETCODE_ERROR;
       }
-    } else if (!ParameterListConverter::to_param_list(dwd, plist, use_xtypes_, lp.type_info_)) {
+    } else if (!ParameterListConverter::to_param_list(
+          dwd, plist, use_xtypes_, lp.type_info_, local_duration_encoding)) {
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: Sedp::write_publication_data_secure: ")
                  ACE_TEXT("Failed to convert DiscoveredWriterData ")
@@ -5247,6 +5277,8 @@ Sedp::write_subscription_data_unsecure(UsedEndpoints& ue,
 
   bool useFlexibleTypes = false;
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
+  const ParameterListConverter::RtpsDurationEncoding local_duration_encoding =
+    duration_encoding((participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0);
   if (spdp_.associated() && (reader != GUID_UNKNOWN ||
                              !associated_participants_.empty())) {
     DCPS::DiscoveredReaderData drd;
@@ -5259,12 +5291,14 @@ Sedp::write_subscription_data_unsecure(UsedEndpoints& ue,
         return DDS::RETCODE_PRECONDITION_NOT_MET;
       }
       const DCPS::TypeInformation typeinfo(*ls.typeInfoFor(reader, &useFlexibleTypes));
-      if (!ParameterListConverter::to_param_list(drd, plist, true, typeinfo)) {
+      if (!ParameterListConverter::to_param_list(
+            drd, plist, true, typeinfo, local_duration_encoding)) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Sedp::write_subscription_data_unsecure: "
                    "Failed to convert DiscoveredReaderData to ParameterList (Flags_FlexibleTypeSupport)\n"));
         result = DDS::RETCODE_ERROR;
       }
-    } else if (!ParameterListConverter::to_param_list(drd, plist, use_xtypes_, ls.type_info_)) {
+    } else if (!ParameterListConverter::to_param_list(
+          drd, plist, use_xtypes_, ls.type_info_, local_duration_encoding)) {
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: Sedp::write_subscription_data_unsecure: ")
                  ACE_TEXT("Failed to convert DiscoveredReaderData ")
@@ -5316,6 +5350,8 @@ Sedp::write_subscription_data_secure(UsedEndpoints& ue,
 
   bool useFlexibleTypes = false;
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
+  const ParameterListConverter::RtpsDurationEncoding local_duration_encoding =
+    duration_encoding((participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0);
   if (spdp_.associated() && (reader != GUID_UNKNOWN ||
                              !associated_participants_.empty())) {
 
@@ -5332,12 +5368,14 @@ Sedp::write_subscription_data_secure(UsedEndpoints& ue,
         return DDS::RETCODE_PRECONDITION_NOT_MET;
       }
       const DCPS::TypeInformation typeinfo(*ls.typeInfoFor(reader, &useFlexibleTypes));
-      if (!ParameterListConverter::to_param_list(drd, plist, true, typeinfo)) {
+      if (!ParameterListConverter::to_param_list(
+            drd, plist, true, typeinfo, local_duration_encoding)) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Sedp::write_subscription_data_secure: "
                    "Failed to convert DiscoveredReaderData to ParameterList (Flags_FlexibleTypeSupport)\n"));
         result = DDS::RETCODE_ERROR;
       }
-    } else if (!ParameterListConverter::to_param_list(drd, plist, use_xtypes_, ls.type_info_)) {
+    } else if (!ParameterListConverter::to_param_list(
+          drd, plist, use_xtypes_, ls.type_info_, local_duration_encoding)) {
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: Sedp::write_subscription_data_secure: ")
                  ACE_TEXT("Failed to convert DiscoveredReaderData ")

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -338,6 +338,7 @@ Sedp::Sedp(const GUID_t& participant_id, Spdp& owner, ACE_Thread_Mutex& lock)
   , lock_(lock)
   , participant_id_(participant_id)
   , participant_flags_(owner.config()->participant_flags())
+  , local_duration_encoding_(duration_encoding((participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0))
   , publication_counter_(0)
   , subscription_counter_(0)
   , topic_counter_(0)
@@ -4429,9 +4430,12 @@ Sedp::DiscoveryReader::data_received_i(const DCPS::ReceivedDataSample& sample,
   DCPS::Extensibility extensibility)
 {
   const DCPS::MessageId id = static_cast<DCPS::MessageId>(sample.header_.message_id_);
+  VendorId_t remote_vendor_id;
+  bool remote_uses_rtps_duration_fraction = false;
+  sedp_.spdp_.get_vendor_id_and_duration_encoding(
+    sample.header_.publication_id_, remote_vendor_id, remote_uses_rtps_duration_fraction);
   const ParameterListConverter::RtpsDurationEncoding remote_duration_encoding =
-    duration_encoding(sedp_.spdp_.participant_uses_rtps_duration_fraction(
-      sample.header_.publication_id_));
+    duration_encoding(remote_uses_rtps_duration_fraction);
 
   if (entity_id == ENTITYID_SEDP_BUILTIN_PUBLICATIONS_WRITER) {
     ParameterList data;
@@ -4445,7 +4449,7 @@ Sedp::DiscoveryReader::data_received_i(const DCPS::ReceivedDataSample& sample,
 
     DiscoveredPublication wdata;
     if (!ParameterListConverter::from_param_list(
-          data, sedp_.spdp_.get_vendor_id(sample.header_.publication_id_),
+          data, remote_vendor_id,
           wdata.writer_data_, sedp_.use_xtypes_, wdata.type_info_,
           remote_duration_encoding)) {
       if (log_level >= LogLevel::Warning) {
@@ -4494,7 +4498,7 @@ Sedp::DiscoveryReader::data_received_i(const DCPS::ReceivedDataSample& sample,
     ParameterListConverter::DiscoveredPublication_SecurityWrapper wdata_secure = ParameterListConverter::DiscoveredPublication_SecurityWrapper();
 
     if (!ParameterListConverter::from_param_list(
-          data, sedp_.spdp_.get_vendor_id(sample.header_.publication_id_),
+          data, remote_vendor_id,
           wdata_secure, sedp_.use_xtypes_, wdata_secure.type_info,
           remote_duration_encoding)) {
       if (log_level >= LogLevel::Warning) {
@@ -4540,7 +4544,7 @@ Sedp::DiscoveryReader::data_received_i(const DCPS::ReceivedDataSample& sample,
 
     DiscoveredSubscription rdata;
     if (!ParameterListConverter::from_param_list(
-          data, sedp_.spdp_.get_vendor_id(sample.header_.publication_id_),
+          data, remote_vendor_id,
           rdata.reader_data_, sedp_.use_xtypes_, rdata.type_info_,
           remote_duration_encoding)) {
       if (log_level >= LogLevel::Warning) {
@@ -4591,7 +4595,7 @@ Sedp::DiscoveryReader::data_received_i(const DCPS::ReceivedDataSample& sample,
 
     ParameterListConverter::DiscoveredSubscription_SecurityWrapper rdata_secure;
     if (!ParameterListConverter::from_param_list(
-          data, sedp_.spdp_.get_vendor_id(sample.header_.publication_id_),
+          data, remote_vendor_id,
           rdata_secure, sedp_.use_xtypes_, rdata_secure.type_info,
           remote_duration_encoding)) {
       if (log_level >= LogLevel::Warning) {
@@ -5081,8 +5085,6 @@ Sedp::write_publication_data_unsecure(UsedEndpoints& ue,
 
   bool useFlexibleTypes = false;
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
-  const ParameterListConverter::RtpsDurationEncoding local_duration_encoding =
-    duration_encoding((participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0);
   if (spdp_.associated() && (reader != GUID_UNKNOWN ||
                              !associated_participants_.empty())) {
     DCPS::DiscoveredWriterData dwd;
@@ -5096,13 +5098,13 @@ Sedp::write_publication_data_unsecure(UsedEndpoints& ue,
       }
       const DCPS::TypeInformation typeinfo(*lp.typeInfoFor(reader, &useFlexibleTypes));
       if (!ParameterListConverter::to_param_list(
-            dwd, plist, true, typeinfo, local_duration_encoding)) {
+            dwd, plist, true, typeinfo, local_duration_encoding_)) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Sedp::write_publication_data_unsecure: "
                    "Failed to convert DiscoveredWriterData to ParameterList (Flags_FlexibleTypeSupport)\n"));
         result = DDS::RETCODE_ERROR;
       }
     } else if (!ParameterListConverter::to_param_list(
-          dwd, plist, use_xtypes_, lp.type_info_, local_duration_encoding)) {
+          dwd, plist, use_xtypes_, lp.type_info_, local_duration_encoding_)) {
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: Sedp::write_publication_data_unsecure: ")
                  ACE_TEXT("Failed to convert DiscoveredWriterData ")
@@ -5154,8 +5156,6 @@ Sedp::write_publication_data_secure(UsedEndpoints& ue,
 
   bool useFlexibleTypes = false;
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
-  const ParameterListConverter::RtpsDurationEncoding local_duration_encoding =
-    duration_encoding((participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0);
   if (spdp_.associated() && (reader != GUID_UNKNOWN ||
                              !associated_participants_.empty())) {
 
@@ -5173,13 +5173,13 @@ Sedp::write_publication_data_secure(UsedEndpoints& ue,
       }
       const DCPS::TypeInformation typeinfo(*lp.typeInfoFor(reader, &useFlexibleTypes));
       if (!ParameterListConverter::to_param_list(
-            dwd, plist, true, typeinfo, local_duration_encoding)) {
+            dwd, plist, true, typeinfo, local_duration_encoding_)) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Sedp::write_publication_data_secure: "
                              "Failed to convert DiscoveredWriterData to ParameterList (Flags_FlexibleTypeSupport)\n"));
         result = DDS::RETCODE_ERROR;
       }
     } else if (!ParameterListConverter::to_param_list(
-          dwd, plist, use_xtypes_, lp.type_info_, local_duration_encoding)) {
+          dwd, plist, use_xtypes_, lp.type_info_, local_duration_encoding_)) {
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: Sedp::write_publication_data_secure: ")
                  ACE_TEXT("Failed to convert DiscoveredWriterData ")
@@ -5277,8 +5277,6 @@ Sedp::write_subscription_data_unsecure(UsedEndpoints& ue,
 
   bool useFlexibleTypes = false;
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
-  const ParameterListConverter::RtpsDurationEncoding local_duration_encoding =
-    duration_encoding((participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0);
   if (spdp_.associated() && (reader != GUID_UNKNOWN ||
                              !associated_participants_.empty())) {
     DCPS::DiscoveredReaderData drd;
@@ -5292,13 +5290,13 @@ Sedp::write_subscription_data_unsecure(UsedEndpoints& ue,
       }
       const DCPS::TypeInformation typeinfo(*ls.typeInfoFor(reader, &useFlexibleTypes));
       if (!ParameterListConverter::to_param_list(
-            drd, plist, true, typeinfo, local_duration_encoding)) {
+            drd, plist, true, typeinfo, local_duration_encoding_)) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Sedp::write_subscription_data_unsecure: "
                    "Failed to convert DiscoveredReaderData to ParameterList (Flags_FlexibleTypeSupport)\n"));
         result = DDS::RETCODE_ERROR;
       }
     } else if (!ParameterListConverter::to_param_list(
-          drd, plist, use_xtypes_, ls.type_info_, local_duration_encoding)) {
+          drd, plist, use_xtypes_, ls.type_info_, local_duration_encoding_)) {
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: Sedp::write_subscription_data_unsecure: ")
                  ACE_TEXT("Failed to convert DiscoveredReaderData ")
@@ -5350,8 +5348,6 @@ Sedp::write_subscription_data_secure(UsedEndpoints& ue,
 
   bool useFlexibleTypes = false;
   DDS::ReturnCode_t result = DDS::RETCODE_OK;
-  const ParameterListConverter::RtpsDurationEncoding local_duration_encoding =
-    duration_encoding((participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0);
   if (spdp_.associated() && (reader != GUID_UNKNOWN ||
                              !associated_participants_.empty())) {
 
@@ -5369,13 +5365,13 @@ Sedp::write_subscription_data_secure(UsedEndpoints& ue,
       }
       const DCPS::TypeInformation typeinfo(*ls.typeInfoFor(reader, &useFlexibleTypes));
       if (!ParameterListConverter::to_param_list(
-            drd, plist, true, typeinfo, local_duration_encoding)) {
+            drd, plist, true, typeinfo, local_duration_encoding_)) {
         ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: Sedp::write_subscription_data_secure: "
                    "Failed to convert DiscoveredReaderData to ParameterList (Flags_FlexibleTypeSupport)\n"));
         result = DDS::RETCODE_ERROR;
       }
     } else if (!ParameterListConverter::to_param_list(
-          drd, plist, use_xtypes_, ls.type_info_, local_duration_encoding)) {
+          drd, plist, use_xtypes_, ls.type_info_, local_duration_encoding_)) {
       ACE_ERROR((LM_ERROR,
                  ACE_TEXT("(%P|%t) ERROR: Sedp::write_subscription_data_secure: ")
                  ACE_TEXT("Failed to convert DiscoveredReaderData ")

--- a/dds/DCPS/RTPS/Sedp.h
+++ b/dds/DCPS/RTPS/Sedp.h
@@ -13,10 +13,8 @@
 #include "LocalEntities.h"
 #include "MessageTypes.h"
 #include "MessageUtils.h"
+#include "ParameterListConverter.h"
 #include "TypeLookupTypeSupportImpl.h"
-#if OPENDDS_CONFIG_SECURITY
-#  include "ParameterListConverter.h"
-#endif
 #include "RtpsRpcTypeSupportImpl.h"
 #include "RtpsCoreTypeSupportImpl.h"
 #if OPENDDS_CONFIG_SECURITY
@@ -1509,6 +1507,7 @@ protected:
   ACE_Thread_Mutex& lock_;
   const GUID_t participant_id_;
   const CORBA::ULong participant_flags_;
+  const ParameterListConverter::RtpsDurationEncoding local_duration_encoding_;
   RepoIdSet ignored_guids_;
   unsigned int publication_counter_, subscription_counter_, topic_counter_;
   LocalPublicationMap local_publications_;

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3973,6 +3973,19 @@ ACE_CDR::ULong Spdp::get_participant_flags(const DCPS::GUID_t& guid) const
     ? iter->second.pdata_.participantProxy.opendds_participant_flags.bits : PFLAGS_EMPTY;
 }
 
+bool Spdp::participant_uses_rtps_duration_fraction(const DCPS::GUID_t& guid) const
+{
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_,
+                   (participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0);
+  const DiscoveredParticipantMap::const_iterator iter =
+    participants_.find(make_part_guid(guid));
+  if (iter != participants_.end() && is_opendds(iter->second.pdata_.participantProxy)) {
+    return (iter->second.pdata_.participantProxy.opendds_participant_flags.bits &
+            PFLAGS_RTPS_DURATION_FRACTION) != 0;
+  }
+  return (participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0;
+}
+
 void
 Spdp::remove_lease_expiration_i(DiscoveredParticipantIter iter)
 {

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3988,7 +3988,7 @@ bool Spdp::participant_uses_rtps_duration_fraction(const DCPS::GUID_t& guid) con
 {
   // participant_flags_ is const (set once at construction), so reading it
   // here does not depend on lock_ -- lock_ only guards participants_, which
-  // participant_uses_rtps_duration_fraction_i() consults below.
+  // participant_uses_rtps_duration_fraction_i() consults.
   const bool local_default = (participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0;
   ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, local_default);
   return participant_uses_rtps_duration_fraction_i(guid);

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -3973,10 +3973,8 @@ ACE_CDR::ULong Spdp::get_participant_flags(const DCPS::GUID_t& guid) const
     ? iter->second.pdata_.participantProxy.opendds_participant_flags.bits : PFLAGS_EMPTY;
 }
 
-bool Spdp::participant_uses_rtps_duration_fraction(const DCPS::GUID_t& guid) const
+bool Spdp::participant_uses_rtps_duration_fraction_i(const DCPS::GUID_t& guid) const
 {
-  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_,
-                   (participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0);
   const DiscoveredParticipantMap::const_iterator iter =
     participants_.find(make_part_guid(guid));
   if (iter != participants_.end() && is_opendds(iter->second.pdata_.participantProxy)) {
@@ -3984,6 +3982,16 @@ bool Spdp::participant_uses_rtps_duration_fraction(const DCPS::GUID_t& guid) con
             PFLAGS_RTPS_DURATION_FRACTION) != 0;
   }
   return (participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0;
+}
+
+bool Spdp::participant_uses_rtps_duration_fraction(const DCPS::GUID_t& guid) const
+{
+  // participant_flags_ is const (set once at construction), so reading it
+  // here does not depend on lock_ -- lock_ only guards participants_, which
+  // participant_uses_rtps_duration_fraction_i() consults below.
+  const bool local_default = (participant_flags_ & PFLAGS_RTPS_DURATION_FRACTION) != 0;
+  ACE_GUARD_RETURN(ACE_Thread_Mutex, g, lock_, local_default);
+  return participant_uses_rtps_duration_fraction_i(guid);
 }
 
 void
@@ -4809,6 +4817,15 @@ VendorId_t Spdp::get_vendor_id_i(const GUID_t& guid) const
     return iter->second.pdata_.participantProxy.vendorId;
   }
   return unknown_vendor;
+}
+
+void Spdp::get_vendor_id_and_duration_encoding(const GUID_t& guid,
+                                                VendorId_t& vendor_id,
+                                                bool& uses_rtps_duration_fraction) const
+{
+  ACE_GUARD(ACE_Thread_Mutex, g, lock_);
+  vendor_id = get_vendor_id_i(guid);
+  uses_rtps_duration_fraction = participant_uses_rtps_duration_fraction_i(guid);
 }
 
 OPENDDS_SET(DDS::UInt32) Spdp::get_ignored_user_tags() const

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -123,6 +123,7 @@ public:
   bool associated() const;
   bool has_discovered_participant(const DCPS::GUID_t& guid) const;
   ACE_CDR::ULong get_participant_flags(const DCPS::GUID_t& guid) const;
+  bool participant_uses_rtps_duration_fraction(const DCPS::GUID_t& guid) const;
 
 #if OPENDDS_CONFIG_SECURITY
   Security::SecurityConfig_rch get_security_config() const { return security_config_; }

--- a/dds/DCPS/RTPS/Spdp.h
+++ b/dds/DCPS/RTPS/Spdp.h
@@ -217,6 +217,14 @@ public:
 
   VendorId_t get_vendor_id_i(const GUID_t& guid) const;
 
+  /**
+   * Combines get_vendor_id() and participant_uses_rtps_duration_fraction()
+   * into a single locked lookup, for callers that need both for the same guid.
+   */
+  void get_vendor_id_and_duration_encoding(const GUID_t& guid,
+                                            VendorId_t& vendor_id,
+                                            bool& uses_rtps_duration_fraction) const;
+
   OPENDDS_SET(DDS::UInt32) get_ignored_user_tags() const;
 
   void ignore_domain_participant(const GUID_t& ignoreId);
@@ -384,6 +392,9 @@ private:
             DCPS::GUID_t& guid,
             const DDS::DomainParticipantQos& qos,
             XTypes::TypeLookupService_rch tls);
+
+  // lock_ must be held before calling this.
+  bool participant_uses_rtps_duration_fraction_i(const DCPS::GUID_t& guid) const;
 
   mutable ACE_Thread_Mutex lock_;
   DCPS::RcHandle<DCPS::BitSubscriber> bit_subscriber_;

--- a/dds/DCPS/Time_Helper.inl
+++ b/dds/DCPS/Time_Helper.inl
@@ -287,7 +287,16 @@ bool non_negative_duration(const DDS::Duration_t& t)
 ACE_INLINE OpenDDS_Dcps_Export
 ACE_UINT32 uint32_fractional_seconds_to_nanoseconds(ACE_UINT32 fraction)
 {
-  return static_cast<ACE_UINT32>((static_cast<ACE_UINT64>(fraction) * 1000000000) >> 32);
+  const ACE_UINT64 nanoseconds =
+    (static_cast<ACE_UINT64>(fraction) * 1000000000 +
+     (static_cast<ACE_UINT64>(1) << 31)) >> 32;
+
+  // The two largest fractions round to one second.  Since this helper only
+  // returns the subsecond field, keep the result normalized instead of
+  // returning 1000000000 and requiring a carry that it can't represent.
+  return nanoseconds < 1000000000
+    ? static_cast<ACE_UINT32>(nanoseconds)
+    : 999999999;
 }
 
 ACE_INLINE OpenDDS_Dcps_Export

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -1505,6 +1505,21 @@ Those properties, along with options specific to OpenDDS's RTPS discovery implem
       This requires that :option:`opendds_idl -Gxtypes-complete` was used when compiling the IDL.
       ``2`` can also be used for backwards compatibility.
 
+  .. prop:: UseRtpsDurationFraction=<boolean>
+    :default: ``0`` (disabled)
+
+    Controls the RTPS wire representation of ``DDS::Duration_t`` values embedded in endpoint QoS policies.
+    When disabled, OpenDDS writes its historical seconds-and-nanoseconds representation. When enabled,
+    OpenDDS writes the RTPS 2.4 and later seconds-and-fractional-seconds representation, where the fraction
+    is in units of 2^-32 seconds. The setting is sampled when each DomainParticipant is created.
+
+    OpenDDS participants advertise the selected representation in participant discovery, allowing mixed-mode
+    OpenDDS deployments to decode each peer correctly. For other vendors, or when participant metadata is not
+    available, incoming durations are interpreted using the local setting.
+
+    OpenDDS releases that predate this option do not recognize the participant flag and will interpret incoming
+    fractional values as nanoseconds. Enable this option only when that compatibility tradeoff is acceptable.
+
   .. prop:: TypeLookupServiceReplyTimeout=<msec>
     :default: ``5000`` milliseconds (5 seconds).
 

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -1520,6 +1520,10 @@ Those properties, along with options specific to OpenDDS's RTPS discovery implem
     OpenDDS releases that predate this option do not recognize the participant flag and will interpret incoming
     fractional values as nanoseconds. Enable this option only when that compatibility tradeoff is acceptable.
 
+    This is the only supported way to control the corresponding participant flag bit
+    (``PFLAGS_RTPS_DURATION_FRACTION``). Setting that bit directly through a ``PARTICIPANT_FLAGS`` override
+    has no effect: the bit is always derived from ``UseRtpsDurationFraction`` when the participant flags are read.
+
   .. prop:: TypeLookupServiceReplyTimeout=<msec>
     :default: ``5000`` milliseconds (5 seconds).
 

--- a/docs/news.d/rtps-duration-fraction.rst
+++ b/docs/news.d/rtps-duration-fraction.rst
@@ -1,0 +1,8 @@
+.. news-prs: 0
+
+.. news-start-section: Additions
+- Added the ``[rtps_discovery]UseRtpsDurationFraction`` compatibility option. It enables the RTPS
+  seconds-and-fractional-seconds wire representation for ``Duration_t`` values embedded in endpoint QoS
+  policies while allowing mixed-mode OpenDDS participants to identify and decode each other's representation.
+
+.. news-end-section

--- a/docs/news.d/rtps-duration-fraction.rst
+++ b/docs/news.d/rtps-duration-fraction.rst
@@ -1,4 +1,4 @@
-.. news-prs: 0
+.. news-prs: 5256
 
 .. news-start-section: Additions
 - Added the ``[rtps_discovery]UseRtpsDurationFraction`` compatibility option. It enables the RTPS

--- a/examples/DCPS/IntroductionToOpenDDS/subscriber.cpp
+++ b/examples/DCPS/IntroductionToOpenDDS/subscriber.cpp
@@ -15,7 +15,6 @@
 #include <dds/DCPS/BuiltInTopicUtils.h>
 #include <ace/streams.h>
 #include "ace/OS_NS_unistd.h"
-#include <orbsvcs/Time_Utilities.h>
 
 #include "dds/DCPS/StaticIncludes.h"
 

--- a/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -2016,7 +2016,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, writer_lifespan_duration_encoding_mod
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, writer_lifespan_duration_out_of_range_nanosec)
-{ // Duration_t is only spec-valid for nanosec < 1e9, but not every QoS
+{
+  // Duration_t is only spec-valid for nanosec < 1e9, but not every QoS
   // policy's Qos_Helper::valid() enforces that. An out-of-range nanosec must
   // be normalized (excess carried into sec) before the fraction math runs,
   // rather than overflowing ACE_UINT32 and silently wrapping to a garbage or
@@ -2059,7 +2060,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, writer_reliability_legacy_infinite)
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, encode_writer_user_data)
-{ // Should encode writer user data
+{
+  // Should encode writer user data
   const char* ud = "USERDATA TEST";
   CORBA::ULong ud_len = (CORBA::ULong)strlen(ud) + 1;
   DiscoveredWriterData writer_data = Factory::writer_data(
@@ -2929,7 +2931,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_reliability)
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_time_based_filter)
-{ // Should encode reader time based filter using the RTPS wire fraction unit,
+{
+  // Should encode reader time based filter using the RTPS wire fraction unit,
   // not raw nanoseconds (RTPS 2.5 Sec 9.3.2).
   DiscoveredReaderData reader_data = Factory::default_reader_data();
   reader_data.ddsSubscriptionData.time_based_filter.minimum_separation.sec = 3;
@@ -2948,7 +2951,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_time_based_filter)
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_time_based_filter)
-{ // Should decode reader time based filter back from the RTPS wire fraction
+{
+  // Should decode reader time based filter back from the RTPS wire fraction
   // unit to nanoseconds.
   DiscoveredReaderData reader_data = Factory::default_reader_data();
   reader_data.ddsSubscriptionData.time_based_filter.minimum_separation.sec = 3;

--- a/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -1962,7 +1962,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, set_writer_lifespan_default)
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, encode_decode_writer_reliability_infinite)
-{ // DURATION_INFINITE must round-trip through the wire fraction conversion
+{
+  // DURATION_INFINITE must round-trip through the wire fraction conversion
   // as the RTPS::DURATION_INFINITE sentinel {seconds=0x7fffffff,
   // fraction=0xffffffff} (MessageTypes.h), not through the ordinary
   // nanoseconds<->fraction math, which would not reproduce

--- a/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -1573,12 +1573,14 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, encode_writer_durability_service)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   EXPECT_TRUE(is_present(param_list, PID_DURABILITY_SERVICE));
   Parameter param = get(param_list, PID_DURABILITY_SERVICE);
   DurabilityServiceQosPolicy dsqp = param.durability_service();
   EXPECT_TRUE(dsqp.service_cleanup_delay.sec == 4);
-  EXPECT_TRUE(dsqp.service_cleanup_delay.nanosec == 2000);
+  // 2000ns -> wire fraction (2000 << 32) / 1e9 = 8589 (RTPS 2.5 Sec 9.3.2).
+  EXPECT_TRUE(dsqp.service_cleanup_delay.nanosec == 8589);
 
   EXPECT_TRUE(dsqp.history_kind == KEEP_LAST_HISTORY_QOS);
   EXPECT_TRUE(dsqp.history_depth == 172);
@@ -1597,17 +1599,20 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_durability_service)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   DiscoveredWriterData writer_data_out;
-  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true, type_info.xtypes_type_info_));
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true,
+                              type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   DurabilityServiceQosPolicy& ds_in =
     writer_data.ddsPublicationData.durability_service;
   DurabilityServiceQosPolicy& ds_out =
     writer_data_out.ddsPublicationData.durability_service;
   EXPECT_TRUE(ds_in.service_cleanup_delay.sec ==
               ds_out.service_cleanup_delay.sec);
-  EXPECT_TRUE(ds_in.service_cleanup_delay.nanosec ==
-              ds_out.service_cleanup_delay.nanosec);
+  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
+  // magnitude (2000ns -> fraction=8589 -> 1999ns).
+  EXPECT_TRUE(ds_out.service_cleanup_delay.nanosec == 1999);
   EXPECT_TRUE(ds_in.history_kind == ds_out.history_kind);
   EXPECT_TRUE(ds_in.history_depth == ds_out.history_depth);
   EXPECT_TRUE(ds_in.max_samples == ds_out.max_samples);
@@ -1654,11 +1659,15 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, encode_writer_deadline)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   EXPECT_TRUE(is_present(param_list, PID_DEADLINE));
   Parameter param = get(param_list, PID_DEADLINE);
   EXPECT_TRUE(param.deadline().period.sec == 127);
-  EXPECT_TRUE(param.deadline().period.nanosec == 35000);
+  // RTPS 2.5 Sec 9.3.2: wire Duration_t is {seconds, fraction}, fraction in
+  // units of 1/2^32 sec -- not raw nanoseconds. 35000ns -> fraction
+  // (35000 << 32) / 1e9 = 150323.
+  EXPECT_TRUE(param.deadline().period.nanosec == 150323);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_deadline)
@@ -1670,13 +1679,19 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_deadline)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   DiscoveredWriterData writer_data_out;
-  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true, type_info.xtypes_type_info_));
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true,
+                              type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(writer_data.ddsPublicationData.deadline.period.sec ==
               writer_data_out.ddsPublicationData.deadline.period.sec);
-  EXPECT_TRUE(writer_data.ddsPublicationData.deadline.period.nanosec ==
-              writer_data_out.ddsPublicationData.deadline.period.nanosec);
+  // Round-tripping through the wire's 1/2^32-sec fraction unit is not
+  // perfectly bijective at nanosecond granularity (double integer
+  // truncation): 35000ns encodes to fraction=150323, which decodes back to
+  // 34999ns, not 35000ns. This 1ns discrepancy is inherent to the format,
+  // not a bug.
+  EXPECT_TRUE(writer_data_out.ddsPublicationData.deadline.period.nanosec == 34999);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, set_writer_deadline_default)
@@ -1708,11 +1723,13 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, encode_writer_latency_budget)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   EXPECT_TRUE(is_present(param_list, PID_LATENCY_BUDGET));
   Parameter param = get(param_list, PID_LATENCY_BUDGET);
   EXPECT_TRUE(param.latency_budget().duration.sec == 5);
-  EXPECT_TRUE(param.latency_budget().duration.nanosec == 25000);
+  // 25000ns -> wire fraction (25000 << 32) / 1e9 = 107374 (RTPS 2.5 Sec 9.3.2).
+  EXPECT_TRUE(param.latency_budget().duration.nanosec == 107374);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_latency_budget)
@@ -1724,9 +1741,11 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_latency_budget)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   DiscoveredWriterData writer_data_out;
-  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true, type_info.xtypes_type_info_));
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true,
+                              type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(writer_data.ddsPublicationData.latency_budget.duration.sec ==
               writer_data_out.ddsPublicationData.latency_budget.duration.sec);
 }
@@ -1760,12 +1779,14 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, encode_writer_liveliness)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   EXPECT_TRUE(is_present(param_list, PID_LIVELINESS));
   Parameter param = get(param_list, PID_LIVELINESS);
   EXPECT_TRUE(param.liveliness().kind == MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
   EXPECT_TRUE(param.liveliness().lease_duration.sec == 17);
-  EXPECT_TRUE(param.liveliness().lease_duration.nanosec == 15000);
+  // 15000ns -> wire fraction (15000 << 32) / 1e9 = 64424 (RTPS 2.5 Sec 9.3.2).
+  EXPECT_TRUE(param.liveliness().lease_duration.nanosec == 64424);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_liveliness)
@@ -1777,15 +1798,18 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_liveliness)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   DiscoveredWriterData writer_data_out;
-  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true, type_info.xtypes_type_info_));
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true,
+                              type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(writer_data.ddsPublicationData.liveliness.kind ==
               writer_data_out.ddsPublicationData.liveliness.kind);
   EXPECT_TRUE(writer_data.ddsPublicationData.liveliness.lease_duration.sec ==
               writer_data_out.ddsPublicationData.liveliness.lease_duration.sec);
-  EXPECT_TRUE(writer_data.ddsPublicationData.liveliness.lease_duration.nanosec ==
-              writer_data_out.ddsPublicationData.liveliness.lease_duration.nanosec);
+  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
+  // magnitude (15000ns -> fraction=64424 -> 14999ns).
+  EXPECT_TRUE(writer_data_out.ddsPublicationData.liveliness.lease_duration.nanosec == 14999);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, set_writer_liveliness_default)
@@ -1822,12 +1846,14 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, encode_writer_reliability)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   EXPECT_TRUE(is_present(param_list, PID_RELIABILITY));
   Parameter param = get(param_list, PID_RELIABILITY);
   EXPECT_TRUE(param.reliability().kind.value == RELIABLE);
   EXPECT_TRUE(param.reliability().max_blocking_time.sec == 8);
-  EXPECT_TRUE(param.reliability().max_blocking_time.nanosec == 100);
+  // 100ns -> wire fraction (100 << 32) / 1e9 = 429 (RTPS 2.5 Sec 9.3.2).
+  EXPECT_TRUE(param.reliability().max_blocking_time.nanosec == 429);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_reliability)
@@ -1840,15 +1866,18 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_reliability)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   DiscoveredWriterData writer_data_out;
-  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true, type_info.xtypes_type_info_));
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true,
+                              type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(writer_data.ddsPublicationData.reliability.kind ==
               writer_data_out.ddsPublicationData.reliability.kind);
   EXPECT_TRUE(writer_data.ddsPublicationData.reliability.max_blocking_time.sec ==
               writer_data_out.ddsPublicationData.reliability.max_blocking_time.sec);
-  EXPECT_TRUE(writer_data.ddsPublicationData.reliability.max_blocking_time.nanosec ==
-              writer_data_out.ddsPublicationData.reliability.max_blocking_time.nanosec);
+  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
+  // magnitude (100ns -> fraction=429 -> 99ns).
+  EXPECT_TRUE(writer_data_out.ddsPublicationData.reliability.max_blocking_time.nanosec == 99);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, set_writer_reliability_default)
@@ -1883,11 +1912,13 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, encode_writer_lifespan)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   EXPECT_TRUE(is_present(param_list, PID_LIFESPAN));
   Parameter param = get(param_list, PID_LIFESPAN);
   EXPECT_TRUE(param.lifespan().duration.sec == 12);
-  EXPECT_TRUE(param.lifespan().duration.nanosec == 90000);
+  // 90000ns -> wire fraction (90000 << 32) / 1e9 = 386547 (RTPS 2.5 Sec 9.3.2).
+  EXPECT_TRUE(param.lifespan().duration.nanosec == 386547);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_lifespan)
@@ -1901,13 +1932,16 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_lifespan)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   DiscoveredWriterData writer_data_out;
-  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true, type_info.xtypes_type_info_));
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true,
+                              type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(writer_data.ddsPublicationData.lifespan.duration.sec ==
               writer_data_out.ddsPublicationData.lifespan.duration.sec);
-  EXPECT_TRUE(writer_data.ddsPublicationData.lifespan.duration.nanosec ==
-              writer_data_out.ddsPublicationData.lifespan.duration.nanosec);
+  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
+  // magnitude (90000ns -> fraction=386547 -> 89999ns).
+  EXPECT_TRUE(writer_data_out.ddsPublicationData.lifespan.duration.nanosec == 89999);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, set_writer_lifespan_default)
@@ -1925,6 +1959,81 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, set_writer_lifespan_default)
               writer_data_out.ddsPublicationData.lifespan.duration.sec);
   EXPECT_TRUE(defaultQos.duration.nanosec ==
               writer_data_out.ddsPublicationData.lifespan.duration.nanosec);
+}
+
+TEST(dds_DCPS_RTPS_ParameterListConverter, encode_decode_writer_reliability_infinite)
+{ // DURATION_INFINITE must round-trip through the wire fraction conversion
+  // as the RTPS::DURATION_INFINITE sentinel {seconds=0x7fffffff,
+  // fraction=0xffffffff} (MessageTypes.h), not through the ordinary
+  // nanoseconds<->fraction math, which would not reproduce
+  // DDS::DURATION_INFINITE_NSEC (0x7fffffff) on decode.
+  DiscoveredWriterData writer_data = Factory::default_writer_data();
+  writer_data.ddsPublicationData.reliability.max_blocking_time.sec = DDS::DURATION_INFINITE_SEC;
+  writer_data.ddsPublicationData.reliability.max_blocking_time.nanosec = DDS::DURATION_INFINITE_NSEC;
+
+  ParameterList param_list;
+  OpenDDS::DCPS::TypeInformation type_info;
+  bool map = false;
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
+  EXPECT_TRUE(is_present(param_list, PID_RELIABILITY));
+  Parameter param = get(param_list, PID_RELIABILITY);
+  EXPECT_TRUE(param.reliability().max_blocking_time.sec == DDS::DURATION_INFINITE_SEC);
+  EXPECT_TRUE(param.reliability().max_blocking_time.nanosec == 0xffffffff);
+
+  DiscoveredWriterData writer_data_out;
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out, true,
+                              type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
+  EXPECT_TRUE(writer_data_out.ddsPublicationData.reliability.max_blocking_time.sec == DDS::DURATION_INFINITE_SEC);
+  EXPECT_TRUE(writer_data_out.ddsPublicationData.reliability.max_blocking_time.nanosec == DDS::DURATION_INFINITE_NSEC);
+}
+
+TEST(dds_DCPS_RTPS_ParameterListConverter, writer_lifespan_duration_encoding_modes)
+{
+  DiscoveredWriterData writer_data = Factory::default_writer_data();
+  writer_data.ddsPublicationData.lifespan.duration.sec = 3;
+  writer_data.ddsPublicationData.lifespan.duration.nanosec = 250000000;
+
+  ParameterList param_list;
+  OpenDDS::DCPS::TypeInformation type_info;
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info));
+  ASSERT_TRUE(is_present(param_list, PID_LIFESPAN));
+  EXPECT_EQ(250000000u, get(param_list, PID_LIFESPAN).lifespan().duration.nanosec);
+
+  DiscoveredWriterData writer_data_out;
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out,
+                              true, type_info.xtypes_type_info_));
+  EXPECT_EQ(250000000u,
+            writer_data_out.ddsPublicationData.lifespan.duration.nanosec);
+
+  ParameterList fractional_param_list;
+  EXPECT_TRUE(to_param_list(writer_data, fractional_param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS));
+  ASSERT_TRUE(is_present(fractional_param_list, PID_LIFESPAN));
+  EXPECT_EQ(0x40000000u,
+            get(fractional_param_list, PID_LIFESPAN).lifespan().duration.nanosec);
+}
+
+TEST(dds_DCPS_RTPS_ParameterListConverter, writer_reliability_legacy_infinite)
+{
+  DiscoveredWriterData writer_data = Factory::default_writer_data();
+  writer_data.ddsPublicationData.reliability.max_blocking_time.sec =
+    DDS::DURATION_INFINITE_SEC;
+  writer_data.ddsPublicationData.reliability.max_blocking_time.nanosec =
+    DDS::DURATION_INFINITE_NSEC;
+
+  ParameterList param_list;
+  OpenDDS::DCPS::TypeInformation type_info;
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info));
+  ASSERT_TRUE(is_present(param_list, PID_RELIABILITY));
+  EXPECT_EQ(static_cast<CORBA::ULong>(DDS::DURATION_INFINITE_NSEC),
+            get(param_list, PID_RELIABILITY).reliability().max_blocking_time.nanosec);
+
+  DiscoveredWriterData writer_data_out;
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, writer_data_out,
+                              true, type_info.xtypes_type_info_));
+  EXPECT_EQ(static_cast<CORBA::ULong>(DDS::DURATION_INFINITE_NSEC),
+            writer_data_out.ddsPublicationData.reliability.max_blocking_time.nanosec);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, encode_writer_user_data)
@@ -2652,11 +2761,13 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_deadline)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   EXPECT_TRUE(is_present(param_list, PID_DEADLINE));
   Parameter param = get(param_list, PID_DEADLINE);
   EXPECT_TRUE(param.deadline().period.sec == 127);
-  EXPECT_TRUE(param.deadline().period.nanosec == 35000);
+  // 35000ns -> wire fraction (35000 << 32) / 1e9 = 150323 (RTPS 2.5 Sec 9.3.2).
+  EXPECT_TRUE(param.deadline().period.nanosec == 150323);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_deadline)
@@ -2667,13 +2778,16 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_deadline)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   DiscoveredReaderData reader_data_out;
-  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, reader_data_out, true, type_info.xtypes_type_info_));
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, reader_data_out, true,
+                              type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(reader_data.ddsSubscriptionData.deadline.period.sec ==
               reader_data_out.ddsSubscriptionData.deadline.period.sec);
-  EXPECT_TRUE(reader_data.ddsSubscriptionData.deadline.period.nanosec ==
-              reader_data_out.ddsSubscriptionData.deadline.period.nanosec);
+  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
+  // magnitude (35000ns -> fraction=150323 -> 34999ns).
+  EXPECT_TRUE(reader_data_out.ddsSubscriptionData.deadline.period.nanosec == 34999);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_latency_budget)
@@ -2684,11 +2798,13 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_latency_budget)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   EXPECT_TRUE(is_present(param_list, PID_LATENCY_BUDGET));
   Parameter param = get(param_list, PID_LATENCY_BUDGET);
   EXPECT_TRUE(param.deadline().period.sec == 5);
-  EXPECT_TRUE(param.deadline().period.nanosec == 25000);
+  // 25000ns -> wire fraction (25000 << 32) / 1e9 = 107374 (RTPS 2.5 Sec 9.3.2).
+  EXPECT_TRUE(param.deadline().period.nanosec == 107374);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_latency_budget)
@@ -2699,9 +2815,11 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_latency_budget)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   DiscoveredReaderData reader_data_out;
-  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, reader_data_out, true, type_info.xtypes_type_info_));
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, reader_data_out, true,
+                              type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(reader_data.ddsSubscriptionData.latency_budget.duration.sec ==
               reader_data_out.ddsSubscriptionData.latency_budget.duration.sec);
 }
@@ -2714,12 +2832,14 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_liveliness)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   EXPECT_TRUE(is_present(param_list, PID_LIVELINESS));
   Parameter param = get(param_list, PID_LIVELINESS);
   EXPECT_TRUE(param.liveliness().kind == MANUAL_BY_PARTICIPANT_LIVELINESS_QOS);
   EXPECT_TRUE(param.liveliness().lease_duration.sec == 17);
-  EXPECT_TRUE(param.liveliness().lease_duration.nanosec == 15000);
+  // 15000ns -> wire fraction (15000 << 32) / 1e9 = 64424 (RTPS 2.5 Sec 9.3.2).
+  EXPECT_TRUE(param.liveliness().lease_duration.nanosec == 64424);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_liveliness)
@@ -2730,15 +2850,18 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_liveliness)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   DiscoveredReaderData reader_data_out;
-  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, reader_data_out, true, type_info.xtypes_type_info_));
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, reader_data_out, true,
+                              type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(reader_data.ddsSubscriptionData.liveliness.kind ==
               reader_data_out.ddsSubscriptionData.liveliness.kind);
   EXPECT_TRUE(reader_data.ddsSubscriptionData.liveliness.lease_duration.sec ==
               reader_data_out.ddsSubscriptionData.liveliness.lease_duration.sec);
-  EXPECT_TRUE(reader_data.ddsSubscriptionData.liveliness.lease_duration.nanosec ==
-              reader_data_out.ddsSubscriptionData.liveliness.lease_duration.nanosec);
+  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
+  // magnitude (15000ns -> fraction=64424 -> 14999ns).
+  EXPECT_TRUE(reader_data_out.ddsSubscriptionData.liveliness.lease_duration.nanosec == 14999);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_reliability)
@@ -2750,12 +2873,14 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_reliability)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   EXPECT_TRUE(is_present(param_list, PID_RELIABILITY));
   Parameter param = get(param_list, PID_RELIABILITY);
   EXPECT_TRUE(param.reliability().kind.value == RELIABLE);
   EXPECT_TRUE(param.reliability().max_blocking_time.sec == 8);
-  EXPECT_TRUE(param.reliability().max_blocking_time.nanosec == 100);
+  // 100ns -> wire fraction (100 << 32) / 1e9 = 429 (RTPS 2.5 Sec 9.3.2).
+  EXPECT_TRUE(param.reliability().max_blocking_time.nanosec == 429);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_reliability)
@@ -2767,15 +2892,59 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_reliability)
   ParameterList param_list;
   OpenDDS::DCPS::TypeInformation type_info;
   bool map = false;
-  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info, map));
+  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
   DiscoveredReaderData reader_data_out;
-  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, reader_data_out, true, type_info.xtypes_type_info_));
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, reader_data_out, true,
+                              type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(reader_data.ddsSubscriptionData.reliability.kind ==
               reader_data_out.ddsSubscriptionData.reliability.kind);
   EXPECT_TRUE(reader_data.ddsSubscriptionData.reliability.max_blocking_time.sec ==
               reader_data_out.ddsSubscriptionData.reliability.max_blocking_time.sec);
-  EXPECT_TRUE(reader_data.ddsSubscriptionData.reliability.max_blocking_time.nanosec ==
-              reader_data_out.ddsSubscriptionData.reliability.max_blocking_time.nanosec);
+  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
+  // magnitude (100ns -> fraction=429 -> 99ns).
+  EXPECT_TRUE(reader_data_out.ddsSubscriptionData.reliability.max_blocking_time.nanosec == 99);
+}
+
+TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_time_based_filter)
+{ // Should encode reader time based filter using the RTPS wire fraction unit,
+  // not raw nanoseconds (RTPS 2.5 Sec 9.3.2).
+  DiscoveredReaderData reader_data = Factory::default_reader_data();
+  reader_data.ddsSubscriptionData.time_based_filter.minimum_separation.sec = 3;
+  reader_data.ddsSubscriptionData.time_based_filter.minimum_separation.nanosec = 40000;
+
+  ParameterList param_list;
+  OpenDDS::DCPS::TypeInformation type_info;
+  bool map = false;
+  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
+  EXPECT_TRUE(is_present(param_list, PID_TIME_BASED_FILTER));
+  Parameter param = get(param_list, PID_TIME_BASED_FILTER);
+  EXPECT_TRUE(param.time_based_filter().minimum_separation.sec == 3);
+  // 40000ns -> wire fraction (40000 << 32) / 1e9 = 171798.
+  EXPECT_TRUE(param.time_based_filter().minimum_separation.nanosec == 171798);
+}
+
+TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_time_based_filter)
+{ // Should decode reader time based filter back from the RTPS wire fraction
+  // unit to nanoseconds.
+  DiscoveredReaderData reader_data = Factory::default_reader_data();
+  reader_data.ddsSubscriptionData.time_based_filter.minimum_separation.sec = 3;
+  reader_data.ddsSubscriptionData.time_based_filter.minimum_separation.nanosec = 40000;
+
+  ParameterList param_list;
+  OpenDDS::DCPS::TypeInformation type_info;
+  bool map = false;
+  EXPECT_TRUE(to_param_list(reader_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS, map));
+  DiscoveredReaderData reader_data_out;
+  EXPECT_TRUE(from_param_list(param_list, VENDORID_OPENDDS, reader_data_out, true,
+                              type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
+  EXPECT_TRUE(reader_data.ddsSubscriptionData.time_based_filter.minimum_separation.sec ==
+              reader_data_out.ddsSubscriptionData.time_based_filter.minimum_separation.sec);
+  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
+  // magnitude (40000ns -> fraction=171798 -> 39999ns).
+  EXPECT_TRUE(reader_data_out.ddsSubscriptionData.time_based_filter.minimum_separation.nanosec == 39999);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_user_data)

--- a/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -1691,7 +1691,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_deadline)
   // truncation): 35000ns encodes to fraction=150323, which decodes back to
   // 34999ns, not 35000ns. This 1ns discrepancy is inherent to the format,
   // not a bug.
-  EXPECT_TRUE(writer_data_out.ddsPublicationData.deadline.period.nanosec == 34999);
+  EXPECT_TRUE(writer_data_out.ddsPublicationData.deadline.period.nanosec >= 34998);
+  EXPECT_TRUE(writer_data_out.ddsPublicationData.deadline.period.nanosec <= 35002);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, set_writer_deadline_default)

--- a/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -1610,9 +1610,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_durability_service)
     writer_data_out.ddsPublicationData.durability_service;
   EXPECT_TRUE(ds_in.service_cleanup_delay.sec ==
               ds_out.service_cleanup_delay.sec);
-  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
-  // magnitude (2000ns -> fraction=8589 -> 1999ns).
-  EXPECT_TRUE(ds_out.service_cleanup_delay.nanosec == 1999);
+  EXPECT_TRUE(ds_in.service_cleanup_delay.nanosec ==
+              ds_out.service_cleanup_delay.nanosec);
   EXPECT_TRUE(ds_in.history_kind == ds_out.history_kind);
   EXPECT_TRUE(ds_in.history_depth == ds_out.history_depth);
   EXPECT_TRUE(ds_in.max_samples == ds_out.max_samples);
@@ -1686,13 +1685,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_deadline)
                               type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(writer_data.ddsPublicationData.deadline.period.sec ==
               writer_data_out.ddsPublicationData.deadline.period.sec);
-  // Round-tripping through the wire's 1/2^32-sec fraction unit is not
-  // perfectly bijective at nanosecond granularity (double integer
-  // truncation): 35000ns encodes to fraction=150323, which decodes back to
-  // 34999ns, not 35000ns. This 1ns discrepancy is inherent to the format,
-  // not a bug.
-  EXPECT_TRUE(writer_data_out.ddsPublicationData.deadline.period.nanosec >= 34998);
-  EXPECT_TRUE(writer_data_out.ddsPublicationData.deadline.period.nanosec <= 35002);
+  EXPECT_TRUE(writer_data.ddsPublicationData.deadline.period.nanosec ==
+              writer_data_out.ddsPublicationData.deadline.period.nanosec);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, set_writer_deadline_default)
@@ -1808,9 +1802,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_liveliness)
               writer_data_out.ddsPublicationData.liveliness.kind);
   EXPECT_TRUE(writer_data.ddsPublicationData.liveliness.lease_duration.sec ==
               writer_data_out.ddsPublicationData.liveliness.lease_duration.sec);
-  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
-  // magnitude (15000ns -> fraction=64424 -> 14999ns).
-  EXPECT_TRUE(writer_data_out.ddsPublicationData.liveliness.lease_duration.nanosec == 14999);
+  EXPECT_TRUE(writer_data.ddsPublicationData.liveliness.lease_duration.nanosec ==
+              writer_data_out.ddsPublicationData.liveliness.lease_duration.nanosec);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, set_writer_liveliness_default)
@@ -1876,9 +1869,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_reliability)
               writer_data_out.ddsPublicationData.reliability.kind);
   EXPECT_TRUE(writer_data.ddsPublicationData.reliability.max_blocking_time.sec ==
               writer_data_out.ddsPublicationData.reliability.max_blocking_time.sec);
-  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
-  // magnitude (100ns -> fraction=429 -> 99ns).
-  EXPECT_TRUE(writer_data_out.ddsPublicationData.reliability.max_blocking_time.nanosec == 99);
+  EXPECT_TRUE(writer_data.ddsPublicationData.reliability.max_blocking_time.nanosec ==
+              writer_data_out.ddsPublicationData.reliability.max_blocking_time.nanosec);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, set_writer_reliability_default)
@@ -1940,9 +1932,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_writer_lifespan)
                               type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(writer_data.ddsPublicationData.lifespan.duration.sec ==
               writer_data_out.ddsPublicationData.lifespan.duration.sec);
-  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
-  // magnitude (90000ns -> fraction=386547 -> 89999ns).
-  EXPECT_TRUE(writer_data_out.ddsPublicationData.lifespan.duration.nanosec == 89999);
+  EXPECT_TRUE(writer_data.ddsPublicationData.lifespan.duration.nanosec ==
+              writer_data_out.ddsPublicationData.lifespan.duration.nanosec);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, set_writer_lifespan_default)
@@ -2810,9 +2801,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_deadline)
                               type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(reader_data.ddsSubscriptionData.deadline.period.sec ==
               reader_data_out.ddsSubscriptionData.deadline.period.sec);
-  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
-  // magnitude (35000ns -> fraction=150323 -> 34999ns).
-  EXPECT_TRUE(reader_data_out.ddsSubscriptionData.deadline.period.nanosec == 34999);
+  EXPECT_TRUE(reader_data.ddsSubscriptionData.deadline.period.nanosec ==
+              reader_data_out.ddsSubscriptionData.deadline.period.nanosec);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_latency_budget)
@@ -2884,9 +2874,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_liveliness)
               reader_data_out.ddsSubscriptionData.liveliness.kind);
   EXPECT_TRUE(reader_data.ddsSubscriptionData.liveliness.lease_duration.sec ==
               reader_data_out.ddsSubscriptionData.liveliness.lease_duration.sec);
-  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
-  // magnitude (15000ns -> fraction=64424 -> 14999ns).
-  EXPECT_TRUE(reader_data_out.ddsSubscriptionData.liveliness.lease_duration.nanosec == 14999);
+  EXPECT_TRUE(reader_data.ddsSubscriptionData.liveliness.lease_duration.nanosec ==
+              reader_data_out.ddsSubscriptionData.liveliness.lease_duration.nanosec);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_reliability)
@@ -2926,9 +2915,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_reliability)
               reader_data_out.ddsSubscriptionData.reliability.kind);
   EXPECT_TRUE(reader_data.ddsSubscriptionData.reliability.max_blocking_time.sec ==
               reader_data_out.ddsSubscriptionData.reliability.max_blocking_time.sec);
-  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
-  // magnitude (100ns -> fraction=429 -> 99ns).
-  EXPECT_TRUE(reader_data_out.ddsSubscriptionData.reliability.max_blocking_time.nanosec == 99);
+  EXPECT_TRUE(reader_data.ddsSubscriptionData.reliability.max_blocking_time.nanosec ==
+              reader_data_out.ddsSubscriptionData.reliability.max_blocking_time.nanosec);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_time_based_filter)
@@ -2969,9 +2957,8 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_time_based_filter)
                               type_info.xtypes_type_info_, RDE_FRACTIONAL_SECONDS));
   EXPECT_TRUE(reader_data.ddsSubscriptionData.time_based_filter.minimum_separation.sec ==
               reader_data_out.ddsSubscriptionData.time_based_filter.minimum_separation.sec);
-  // See decode_writer_deadline: fraction round-trip is lossy by 1ns for this
-  // magnitude (40000ns -> fraction=171798 -> 39999ns).
-  EXPECT_TRUE(reader_data_out.ddsSubscriptionData.time_based_filter.minimum_separation.nanosec == 39999);
+  EXPECT_TRUE(reader_data.ddsSubscriptionData.time_based_filter.minimum_separation.nanosec ==
+              reader_data_out.ddsSubscriptionData.time_based_filter.minimum_separation.nanosec);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_user_data)

--- a/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -2014,6 +2014,27 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, writer_lifespan_duration_encoding_mod
             get(fractional_param_list, PID_LIFESPAN).lifespan().duration.nanosec);
 }
 
+TEST(dds_DCPS_RTPS_ParameterListConverter, writer_lifespan_duration_out_of_range_nanosec)
+{ // Duration_t is only spec-valid for nanosec < 1e9, but not every QoS
+  // policy's Qos_Helper::valid() enforces that. An out-of-range nanosec must
+  // be normalized (excess carried into sec) before the fraction math runs,
+  // rather than overflowing ACE_UINT32 and silently wrapping to a garbage or
+  // zero wire value.
+  DiscoveredWriterData writer_data = Factory::default_writer_data();
+  writer_data.ddsPublicationData.lifespan.duration.sec = 1;
+  writer_data.ddsPublicationData.lifespan.duration.nanosec = 1500000000; // 1.5s, out of spec
+
+  ParameterList param_list;
+  OpenDDS::DCPS::TypeInformation type_info;
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS));
+  ASSERT_TRUE(is_present(param_list, PID_LIFESPAN));
+  // Normalized to {sec=2, nanosec=500000000} before fraction conversion:
+  // (500000000 << 32) / 1e9 = 0x80000000.
+  EXPECT_EQ(2, get(param_list, PID_LIFESPAN).lifespan().duration.sec);
+  EXPECT_EQ(0x80000000u, get(param_list, PID_LIFESPAN).lifespan().duration.nanosec);
+}
+
 TEST(dds_DCPS_RTPS_ParameterListConverter, writer_reliability_legacy_infinite)
 {
   DiscoveredWriterData writer_data = Factory::default_writer_data();
@@ -2802,9 +2823,9 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, encode_reader_latency_budget)
                             RDE_FRACTIONAL_SECONDS, map));
   EXPECT_TRUE(is_present(param_list, PID_LATENCY_BUDGET));
   Parameter param = get(param_list, PID_LATENCY_BUDGET);
-  EXPECT_TRUE(param.deadline().period.sec == 5);
+  EXPECT_TRUE(param.latency_budget().duration.sec == 5);
   // 25000ns -> wire fraction (25000 << 32) / 1e9 = 107374 (RTPS 2.5 Sec 9.3.2).
-  EXPECT_TRUE(param.deadline().period.nanosec == 107374);
+  EXPECT_TRUE(param.latency_budget().duration.nanosec == 107374);
 }
 
 TEST(dds_DCPS_RTPS_ParameterListConverter, decode_reader_latency_budget)

--- a/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/ParameterListConverter.cpp
@@ -2029,6 +2029,23 @@ TEST(dds_DCPS_RTPS_ParameterListConverter, writer_lifespan_duration_out_of_range
   EXPECT_EQ(0x80000000u, get(param_list, PID_LIFESPAN).lifespan().duration.nanosec);
 }
 
+TEST(dds_DCPS_RTPS_ParameterListConverter, writer_lifespan_duration_normalization_overflow)
+{
+  DiscoveredWriterData writer_data = Factory::default_writer_data();
+  writer_data.ddsPublicationData.lifespan.duration.sec = DDS::DURATION_INFINITE_SEC;
+  writer_data.ddsPublicationData.lifespan.duration.nanosec = 1000000000u;
+
+  ParameterList param_list;
+  OpenDDS::DCPS::TypeInformation type_info;
+  EXPECT_TRUE(to_param_list(writer_data, param_list, true, type_info,
+                            RDE_FRACTIONAL_SECONDS));
+  ASSERT_TRUE(is_present(param_list, PID_LIFESPAN));
+  EXPECT_EQ(DDS::DURATION_INFINITE_SEC,
+            get(param_list, PID_LIFESPAN).lifespan().duration.sec);
+  EXPECT_EQ(DDS::TIME_INVALID_NSEC,
+            get(param_list, PID_LIFESPAN).lifespan().duration.nanosec);
+}
+
 TEST(dds_DCPS_RTPS_ParameterListConverter, writer_reliability_legacy_infinite)
 {
   DiscoveredWriterData writer_data = Factory::default_writer_data();

--- a/tests/unit-tests/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -33,6 +33,22 @@ namespace {
 #endif
 }
 
+TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, use_rtps_duration_fraction)
+{
+  AddressTest t;
+
+  EXPECT_FALSE(t.rtps.use_rtps_duration_fraction());
+  EXPECT_EQ(0u, t.rtps.participant_flags() & PFLAGS_RTPS_DURATION_FRACTION);
+
+  t.rtps.use_rtps_duration_fraction(true);
+  EXPECT_TRUE(t.rtps.use_rtps_duration_fraction());
+  EXPECT_NE(0u, t.rtps.participant_flags() & PFLAGS_RTPS_DURATION_FRACTION);
+
+  t.rtps.use_rtps_duration_fraction(false);
+  t.rtps.participant_flags(PFLAGS_THIS_VERSION | PFLAGS_RTPS_DURATION_FRACTION);
+  EXPECT_EQ(0u, t.rtps.participant_flags() & PFLAGS_RTPS_DURATION_FRACTION);
+}
+
 TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, spdp_unicast_address)
 {
   const char* const default_addr = "0.0.0.0";

--- a/tests/unit-tests/dds/DCPS/Time_Helper.cpp
+++ b/tests/unit-tests/dds/DCPS/Time_Helper.cpp
@@ -10,6 +10,7 @@
 #include "ace/Time_Value.h"
 
 #include "dds/DCPS/Qos_Helper.h"
+#include "dds/DCPS/Time_Helper.h"
 #include "dds/DCPS/TimeTypes.h"
 
 #include <iostream>
@@ -101,6 +102,36 @@ TEST(dds_DCPS_Time_Helper, make_duration)
   const DDS::Duration_t d = make_duration_t(1, 2);
   EXPECT_EQ(d.sec, 1);
   EXPECT_EQ(d.nanosec, 2u);
+}
+
+TEST(dds_DCPS_Time_Helper, uint32_fractional_seconds_to_nanoseconds_rounds)
+{
+  EXPECT_EQ(0u, uint32_fractional_seconds_to_nanoseconds(0));
+  EXPECT_EQ(0u, uint32_fractional_seconds_to_nanoseconds(2));
+  EXPECT_EQ(1u, uint32_fractional_seconds_to_nanoseconds(3));
+}
+
+TEST(dds_DCPS_Time_Helper, nanoseconds_fractional_seconds_round_trip)
+{
+  const ACE_UINT32 nanoseconds[] = {
+    0, 1, 100, 2000, 15000, 35000, 999999999
+  };
+  for (size_t i = 0; i < sizeof nanoseconds / sizeof nanoseconds[0]; ++i) {
+    const ACE_UINT32 fraction =
+      nanoseconds_to_uint32_fractional_seconds(nanoseconds[i]);
+    EXPECT_EQ(nanoseconds[i],
+              uint32_fractional_seconds_to_nanoseconds(fraction));
+  }
+}
+
+TEST(dds_DCPS_Time_Helper, uint32_fractional_seconds_to_nanoseconds_upper_bound)
+{
+  EXPECT_EQ(999999999u,
+            uint32_fractional_seconds_to_nanoseconds(0xfffffffdu));
+  EXPECT_EQ(999999999u,
+            uint32_fractional_seconds_to_nanoseconds(0xfffffffeu));
+  EXPECT_EQ(999999999u,
+            uint32_fractional_seconds_to_nanoseconds(0xffffffffu));
 }
 
 TEST(dds_DCPS_Time_Helper, duration_to_dds_string)


### PR DESCRIPTION
Problem:

PID_DEADLINE, PID_LATENCY_BUDGET, PID_LIVELINESS, PID_RELIABILITY, PID_LIFESPAN, PID_TIME_BASED_FILTER, and PID_DURABILITY_SERVICE embed a DDS::Duration_t (plain DDS-IDL {sec, nanosec}) directly in the RTPS Parameter union used for SEDP wire announcements. The generic DDS::Duration_t CDR operator writes/reads `nanosec` verbatim into the wire's `fraction` field, which RTPS 2.5 Sec 9.3.2 defines as units of 1/2^32 second, not raw nanoseconds. This silently corrupts any non-whole-second Duration_t QoS value for both this process and any spec-compliant peer -- e.g. a 250ms LIFESPAN was announced with fraction=250000000 (the literal nanosecond count) instead of the correct ~1073741824.

Solution:

Unfortunately, simply changing the wire format for Duration_t breaks backwards compatibility for OpenDDS users of the QoS policies and configurations making use of those PID values. So we have added a new OpenDDS participant flag, defaulting to off, whose value determines how Duration_t will be encoded by writers as well as how it will be interpreted by readers of non-OpenDDS participants. Readers of OpenDDS participants will check the value of the participant flag and interpret Duration_t accordingly. This preserves a default behavior of backwards compatibility but allows users to configurable enable spec-compliant duration_t encoding for interoperability. Changing the default value of the participant flag to true may be done at some future date (such as with a major version change).