### PR TITLE
Misc IPv6 Cleanup

### DIFF
--- a/dds/DCPS/NetworkResource.cpp
+++ b/dds/DCPS/NetworkResource.cpp
@@ -164,8 +164,8 @@ String get_fully_qualified_hostname(ACE_INET_Addr* addr)
     for (OpenDDS::DCPS::HostnameInfoVector::iterator it = itBegin; it != itEnd; ++it) {
       if (!addr_array[it->index_].is_loopback()) {
         ACE_DEBUG((LM_WARNING, "(%P|%t) WARNING: get_fully_qualified_hostname: Could not find FQDN. Using "
-                   "\"%C\" as fully qualified hostname, please "
-                   "correct system configuration.\n", it->hostname_.c_str()));
+                   "\"%C\" as fully qualified hostname. Configure DCPSDefaultAddress "
+                   "or the transport's local address to override this selection.\n", it->hostname_.c_str()));
         selected_address = addr_array[it->index_];
         fullname = it->hostname_;
         if (addr) {
@@ -182,8 +182,8 @@ String get_fully_qualified_hostname(ACE_INET_Addr* addr)
         char addr_str[MAXHOSTNAMELEN+1] = "";
         addr_array[i].get_host_addr(addr_str, MAXHOSTNAMELEN);
         ACE_DEBUG((LM_WARNING, "(%P|%t) WARNING: get_fully_qualified_hostname: Could not find FQDN. Using "
-                   "\"%C\" as fully qualified hostname, please "
-                   "correct system configuration.\n", addr_str));
+                   "\"%C\" as fully qualified hostname. Configure DCPSDefaultAddress "
+                   "or the transport's local address to override this selection.\n", addr_str));
         selected_address = addr_array[i];
         fullname = addr_str;
         if (addr) {
@@ -196,8 +196,8 @@ String get_fully_qualified_hostname(ACE_INET_Addr* addr)
     // As a last resort, return the first loopback address from the non-FQDNs list if not empty.
     if (itBegin != itEnd) {
       ACE_DEBUG((LM_WARNING, "(%P|%t) WARNING: get_fully_qualified_hostname: Could not find FQDN. Using "
-                 "\"%C\" as fully qualified hostname, please "
-                 "correct system configuration.\n", itBegin->hostname_.c_str()));
+                 "\"%C\" as fully qualified hostname. Configure DCPSDefaultAddress "
+                 "or the transport's local address to override this selection.\n", itBegin->hostname_.c_str()));
       selected_address = addr_array[itBegin->index_];
       fullname = itBegin->hostname_;
       if (addr) {

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -655,6 +655,17 @@ void RtpsDiscoveryConfig::ipv6_spdp_multicast_address(const DCPS::NetworkAddress
                                              DCPS::ConfigStoreImpl::Kind_IPV6);
 }
 
+DCPS::NetworkAddress
+RtpsDiscoveryConfig::ipv6_sedp_multicast_address(DDS::DomainId_t domain) const
+{
+  ACE_UNUSED_ARG(domain);
+  return TheServiceParticipant->config_store()->get(
+    config_key("IPV6_SEDP_MULTICAST_ADDRESS").c_str(),
+    ipv6_default_multicast_group(),
+    DCPS::ConfigStoreImpl::Format_Optional_Port,
+    DCPS::ConfigStoreImpl::Kind_IPV6);
+}
+
 void RtpsDiscoveryConfig::ipv6_sedp_multicast_address(const DCPS::NetworkAddress& addr)
 {
   TheServiceParticipant->config_store()->set(config_key("IPV6_SEDP_MULTICAST_ADDRESS").c_str(),
@@ -684,7 +695,7 @@ RtpsDiscoveryConfig::spdp_send_addrs() const
   return TheServiceParticipant->config_store()->get(config_key("SPDP_SEND_ADDRS").c_str(),
                                                     DCPS::NetworkAddressSet(),
                                                     DCPS::ConfigStoreImpl::Format_Required_Port,
-                                                    DCPS::ConfigStoreImpl::Kind_IPV4);
+                                                    DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -693,7 +704,7 @@ RtpsDiscoveryConfig::spdp_send_addrs(const DCPS::NetworkAddressSet& addrs)
   TheServiceParticipant->config_store()->set(config_key("SPDP_SEND_ADDRS").c_str(),
                                              addrs,
                                              DCPS::ConfigStoreImpl::Format_Required_Port,
-                                             DCPS::ConfigStoreImpl::Kind_IPV4);
+                                             DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 DCPS::TimeDuration

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -479,6 +479,12 @@ Sedp::init(const GUID_t& guid,
                        disco.config()->sedp_multicast_address(domainId),
                        ConfigStoreImpl::Format_Optional_Port,
                        ConfigStoreImpl::Kind_IPV4);
+#ifdef ACE_HAS_IPV6
+    config_store_->set(transport_inst_->config_key("IPV6_MULTICAST_GROUP_ADDRESS").c_str(),
+                       disco.config()->ipv6_sedp_multicast_address(domainId),
+                       ConfigStoreImpl::Format_Optional_Port,
+                       ConfigStoreImpl::Kind_IPV6);
+#endif
 
     config_store_->set_uint32(transport_inst_->config_key("TTL").c_str(), disco.ttl());
     config_store_->set(transport_inst_->config_key("MULTICAST_INTERFACE").c_str(), disco.multicast_interface());

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -153,6 +153,61 @@ This causes the different configuration mechanisms to be processed in the follow
 Users can store configuration data for their applications in the configuration store.
 Users taking advantage of this capability should use the section names of ``APP`` and ``USER`` which are reserved for this purpose.
 
+.. _config-network-addresses:
+
+Network Addresses, Hostnames, and IPv6
+======================================
+
+OpenDDS network address properties accept numeric IP addresses or hostnames.
+Using a numeric address avoids dependence on hostname and DNS configuration.
+When a port is included with a numeric IPv6 address, enclose the address in
+brackets, for example ``[2001:db8::10]:7400``.
+
+Some transports need to advertise an address that peers can use to reach the
+local process.
+An explicitly configured transport ``local_address`` determines this address.
+For IPv4, :prop:`[common]DCPSDefaultAddress` can provide a process-wide default
+when a transport-specific address is not set.
+Otherwise, TCP and UDP can bind a wildcard address and use a hostname selected
+from the system's network interfaces as the advertised address.
+
+OpenDDS prefers a non-loopback fully qualified domain name (FQDN) that resolves
+back to one of the host's network interfaces.
+If it can not find one, it falls back in order to a resolvable short hostname,
+a numeric non-loopback address, or a loopback hostname.
+The warning that begins ``Could not find FQDN`` identifies the selected
+fallback.
+The fallback may be sufficient for same-host testing but may not be reachable
+by peers on other hosts.
+
+FQDN resolution depends on operating-system configuration:
+
+* On Linux and other Unix-like systems, ensure that the hostname resolves to a
+  local non-loopback address using DNS or the system hosts file.
+* On Windows, ensure that the computer has an appropriate primary or
+  connection-specific DNS suffix and that the resulting full computer name
+  resolves to a local address.
+  The full computer name and DNS suffixes are shown by ``ipconfig /all``.
+
+If changing system hostname or DNS configuration is undesirable, set
+:prop:`[common]DCPSDefaultAddress` to an externally reachable IPv4 address or
+set the applicable transport's ``local_address`` explicitly.
+Transport-specific settings are preferable when different transports should
+use different interfaces.
+
+IPv6 support is enabled at build time with the OpenDDS ``configure`` script's
+``--ipv6`` option, which builds ACE/TAO and OpenDDS with ``ACE_HAS_IPV6``.
+An IPv6-enabled build also supports IPv4; it is not an IPv6-only build.
+Properties whose names begin with ``Ipv6`` or ``ipv6_`` configure IPv6
+addresses separately from their IPv4 counterparts.
+In particular, :prop:`[common]DCPSDefaultAddress` is IPv4-only and is not the
+default for IPv6 local-address properties.
+
+RTPS discovery and the :ref:`rtps-udp-transport` use separate IPv4 and IPv6
+sockets in an IPv6-enabled build.
+Configuring one family's addresses does not currently disable the other
+family.
+
 .. _config-environment-variables:
 
 Configuration with Environment Variables
@@ -444,7 +499,6 @@ For example:
     - :prop:`[transport@udp]local_address`
     - :prop:`[transport@multicast]local_address`
     - :prop:`[transport@rtps_udp]local_address`
-    - :prop:`[transport@rtps_udp]ipv6_local_address`
     - :prop:`[transport@rtps_udp]multicast_interface`
     - :prop:`[rtps_discovery]SedpLocalAddress`
     - :prop:`[rtps_discovery]SpdpLocalAddress`
@@ -1268,7 +1322,7 @@ Those properties, along with options specific to OpenDDS's RTPS discovery implem
     If ``<port>`` is ``0`` or not specified, it is calculated as described in :ref:`config-ports-used-by-sedp-unicast`.
 
   .. prop:: Ipv6SedpLocalAddress=<host>:[<port>]
-    :default: :prop:`[common]DCPSDefaultAddress`
+    :default: ``[::]:``
 
     IPv6 variant of :prop:`SedpLocalAddress`.
 
@@ -1281,7 +1335,7 @@ Those properties, along with options specific to OpenDDS's RTPS discovery implem
   .. prop:: Ipv6SpdpMulticastAddress=<host>[:<port>]
     :default: :prop:`Ipv6DefaultMulticastGroup`
 
-    IPv6 variant of :prop:`Ipv6SpdpMulticastAddress`.
+    IPv6 variant of :prop:`SpdpMulticastAddress`.
 
   .. prop:: SpdpLocalAddress=<host>[:<port>]
     :default: :prop:`[common]DCPSDefaultAddress`
@@ -1290,7 +1344,7 @@ Those properties, along with options specific to OpenDDS's RTPS discovery implem
     If ``<port>`` is ``0`` or not specified, it is calculated as described in :ref:`config-ports-used-by-spdp-unicast`.
 
   .. prop:: Ipv6SpdpLocalAddress=<host>[:<port>]
-    :default: :prop:`[common]DCPSDefaultAddress`
+    :default: ``[::]``
 
     IPv6 variant of :prop:`SpdpLocalAddress`.
 
@@ -1299,6 +1353,10 @@ Those properties, along with options specific to OpenDDS's RTPS discovery implem
     Sets the address advertised by :ref:`SEDP <sedp>`.
     Typically used when the participant is behind a firewall or NAT.
     In order to leave the port unspecified, it can be omitted from the setting but the trailing ``:`` must be present.
+
+  .. prop:: Ipv6SedpAdvertisedLocalAddress=<host>:[<port>]
+
+    IPv6 variant of :prop:`SedpAdvertisedLocalAddress`.
 
   .. prop:: SedpSendDelay=<msec>
     :default: ``10``
@@ -1318,7 +1376,8 @@ Those properties, along with options specific to OpenDDS's RTPS discovery implem
   .. prop:: SpdpSendAddrs=<host>:<port>[,<host>:<port>]...
 
     A list (comma or whitespace separated) of ``<host>:<port>`` pairs used as destinations for :ref:`SPDP <spdp>` messages.
-    This can be a combination of Unicast and Multicast addresses.
+    This can be a combination of IPv4 and IPv6 Unicast and Multicast addresses.
+    IPv6 addresses must use brackets, for example ``[::1]:7400``.
 
   .. prop:: MaxSpdpSequenceMsgResetChecks=<n>
     :default: ``3``
@@ -2823,7 +2882,7 @@ Some implementation notes related to using the ``rtps_udp`` transport protocol a
     If ``<port>`` is ``0`` or not specified, it is calculated as described in :ref:`config-ports-used-by-rtps-udp-unicast`.
 
   .. prop:: ipv6_local_address=<host>:[<port>]
-    :default: :prop:`[common]DCPSDefaultAddress`
+    :default: ``[::]:``
 
     Bind the socket to the given address and port.
     ``<port>`` can be omitted but the trailing ``:`` is required.

--- a/docs/news.d/ipv6-rtps-config-fixes.rst
+++ b/docs/news.d/ipv6-rtps-config-fixes.rst
@@ -1,0 +1,10 @@
+.. news-prs: 0
+
+.. news-start-section: Fixes
+- Fixed RTPS discovery IPv6 configuration so that
+  :cfg:prop:`[rtps_discovery]Ipv6SedpMulticastAddress` is applied to SEDP and
+  :cfg:prop:`[rtps_discovery]SpdpSendAddrs` accepts IPv6 destinations.
+- Documented network address selection, FQDN fallback, and IPv6 behavior, and
+  updated the FQDN fallback warning to identify the configuration overrides.
+
+.. news-end-section

--- a/docs/news.d/ipv6-rtps-config-fixes.rst
+++ b/docs/news.d/ipv6-rtps-config-fixes.rst
@@ -1,4 +1,4 @@
-.. news-prs: 0
+.. news-prs: 5257
 
 .. news-start-section: Fixes
 - Fixed RTPS discovery IPv6 configuration so that

--- a/tests/unit-tests/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -162,6 +162,19 @@ TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, spdp_multicast_address)
   }
 }
 
+TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, spdp_send_addrs)
+{
+  AddressTest t;
+  NetworkAddressSet expected;
+  expected.insert(fake_ipv4_addr);
+#ifdef ACE_HAS_IPV6
+  expected.insert(fake_ipv6_addr);
+#endif
+
+  t.rtps.spdp_send_addrs(expected);
+  EXPECT_EQ(expected, t.rtps.spdp_send_addrs());
+}
+
 
 #ifdef ACE_HAS_IPV6
 TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, ipv6_spdp_unicast_address)
@@ -281,6 +294,21 @@ TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, ipv6_spdp_multicast_address)
     ASSERT_TRUE(t.rtps.ipv6_spdp_multicast_address(t.addr, 1));
     EXPECT_ADDR_EQ(t.addr, fake_ipv6_addr);
     EXPECT_FALSE(t.fixed);
+  }
+}
+
+TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, ipv6_sedp_multicast_address)
+{
+  {
+    AddressTest t;
+    EXPECT_ADDR_EQ(t.rtps.ipv6_sedp_multicast_address(1),
+                   NetworkAddress(0, "ff03::1"));
+  }
+
+  {
+    AddressTest t;
+    t.rtps.ipv6_sedp_multicast_address(fake_ipv6_addr);
+    EXPECT_ADDR_EQ(t.rtps.ipv6_sedp_multicast_address(1), fake_ipv6_addr);
   }
 }
 #endif


### PR DESCRIPTION
Fixes:
- Ipv6SedpMulticastAddress is now read and propagated to SEDP’s internal RTPS transport in dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp:658 and dds/DCPS/RTPS/Sedp.cpp:475.
- SpdpSendAddrs now accepts mixed IPv4/IPv6 address lists instead of enforcing IPv4 in dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp:692.
- Added regression coverage in tests/unit-tests/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp:165.
- Corrected IPv6 defaults, documented Ipv6SedpAdvertisedLocalAddress, clarified bracketed IPv6 SpdpSendAddrs, and fixed a cross-reference in docs/devguide/run_time_configuration.rst:1269.
- Added a release-note fragment at docs/news.d/ipv6-rtps-config-fixes.rst:1. Its news-prs value remains 0 until a PR number exists.
- Fixes: #4584
- Fixes: #453
