### PR TITLE
Fix for Coverity Issue 1671625 - Uninitialized Values in MinimalUnionType Header

### DIFF
--- a/dds/DCPS/XTypes/TypeLookupService.cpp
+++ b/dds/DCPS/XTypes/TypeLookupService.cpp
@@ -470,6 +470,7 @@ bool TypeLookupService::complete_to_minimal_union(const CompleteUnionType& ct,
                                                   MinimalUnionType& mt) const
 {
   mt.union_flags = ct.union_flags;
+  mt.header = MinimalUnionHeader();
   mt.discriminator.common.member_flags = ct.discriminator.common.member_flags;
   if (!get_minimal_type_identifier(ct.discriminator.common.type_id,
                                    mt.discriminator.common.type_id)) {


### PR DESCRIPTION
Coverity is flagging a technically harmless omission rather than an active runtime bug, but it's still worth 'fixing'.

  What’s happening:

  - TypeObject and MinimalTypeObject are flattened representations of IDL unions.
  - complete_to_minimal_type_object() correctly selects EK_MINIMAL and TK_UNION.
  - complete_to_minimal_union() initializes the union flags, discriminator, and members, but never explicitly assigns mt.header.
  - MinimalUnionHeader contains only MinimalTypeDetail, which is deliberately empty.
  - assignable_union() never reads the header.

  Therefore there is no meaningful uninitialized data affecting assignability. Still, Coverity reasonably observes that the output object’s active union variant is only partially written.
