### PR TITLE
Map Ownership By Topic Name

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -160,7 +160,7 @@ DataReaderImpl::cleanup()
 #ifndef OPENDDS_NO_OWNERSHIP_KIND_EXCLUSIVE
   OwnershipManagerPtr owner_manager = this->ownership_manager();
   if (owner_manager) {
-    owner_manager->unregister_reader(topic_servant_->type_name(), this);
+    owner_manager->unregister_reader(topic_servant_->topic_name(), this);
   }
 #endif
 

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -1250,7 +1250,7 @@ protected:
     if (owner_manager) {
       ACE_GUARD(ACE_Recursive_Thread_Mutex, instance_guard, instances_lock_);
 
-      SharedInstanceMap_rch inst = dynamic_rchandle_cast<SharedInstanceMap>(owner_manager->get_instance_map(topic_servant_->type_name(), this));
+      SharedInstanceMap_rch inst = dynamic_rchandle_cast<SharedInstanceMap>(owner_manager->get_instance_map(topic_servant_->topic_name(), this));
       if (inst != 0) {
         const typename ReverseInstanceMap::iterator pos = reverse_instance_map_.find(handle);
         if (pos != reverse_instance_map_.end()) {
@@ -1825,7 +1825,7 @@ void store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_data,
         }
 
         inst = dynamic_rchandle_cast<SharedInstanceMap>(
-          owner_manager->get_instance_map(topic_servant_->type_name(), this));
+          owner_manager->get_instance_map(topic_servant_->topic_name(), this));
         if (inst != 0) {
           typename InstanceMap::const_iterator const iter = inst->find(*instance_data);
           if (iter != inst->end ()) {
@@ -1870,7 +1870,7 @@ void store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_data,
         if (!inst) {
           inst = make_rch<SharedInstanceMap>();
           owner_manager->set_instance_map(
-            topic_servant_->type_name(),
+            topic_servant_->topic_name(),
             inst,
             this);
         }

--- a/dds/DCPS/OwnershipManager.cpp
+++ b/dds/DCPS/OwnershipManager.cpp
@@ -36,15 +36,15 @@ OwnershipManager::OwnershipManager()
 
 OwnershipManager::~OwnershipManager()
 {
-  // The type->instance should be empty if unregister instance are performed
+  // The topic->instance map should be empty if unregister instance is performed
   // by all readers, but in case the instance not unregistered for some reason,
   // an error will be logged.
-  if (!type_instance_map_.empty()) {
+  if (!topic_instance_map_.empty()) {
     // There is no way to pass the instance map to concrete datareader
     // to delete, so it will be leaked.
     ACE_DEBUG((LM_WARNING,
                ACE_TEXT("(%P|%t) OwnershipManager::~OwnershipManager ")
-               ACE_TEXT("- non-empty type_instance_map_\n")));
+               ACE_TEXT("- non-empty topic_instance_map_\n")));
   }
 }
 
@@ -61,11 +61,11 @@ OwnershipManager::instance_lock_release()
 }
 
 RcHandle<RcObject>
-OwnershipManager::get_instance_map(const char* type_name,
+OwnershipManager::get_instance_map(const char* topic_name,
                                    DataReaderImpl* reader)
 {
   InstanceMap* instance = 0;
-  if (0 != find(type_instance_map_, type_name, instance)) {
+  if (0 != find(topic_instance_map_, topic_name, instance)) {
     return RcHandle<RcObject>();
   }
 
@@ -74,7 +74,7 @@ OwnershipManager::get_instance_map(const char* type_name,
 }
 
 void
-OwnershipManager::set_instance_map(const char* type_name,
+OwnershipManager::set_instance_map(const char* topic_name,
                                    const RcHandle<RcObject>& instance_map,
                                    DataReaderImpl* reader)
 {
@@ -84,21 +84,21 @@ OwnershipManager::set_instance_map(const char* type_name,
                instance_map.in(), reader));
   }
 
-  if (0 != OpenDDS::DCPS::bind(type_instance_map_, type_name,
+  if (0 != OpenDDS::DCPS::bind(topic_instance_map_, topic_name,
                                InstanceMap(instance_map, reader))) {
     ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: OwnershipManager::set_instance_map "
-               "failed to bind instance for type \"%C\"\n", type_name));
+               "failed to bind instance for topic \"%C\"\n", topic_name));
   }
 }
 
 void
-OwnershipManager::unregister_reader(const char* type_name,
+OwnershipManager::unregister_reader(const char* topic_name,
                                     DataReaderImpl* reader)
 {
   ACE_GUARD(ACE_Thread_Mutex, guard, instance_lock_);
 
   InstanceMap* instance = 0;
-  if (0 != find(type_instance_map_, type_name, instance)) {
+  if (0 != find(topic_instance_map_, topic_name, instance)) {
     return;
   }
 
@@ -111,7 +111,7 @@ OwnershipManager::unregister_reader(const char* type_name,
                  ACE_TEXT(" instance map %@ is deleted by reader %@\n"),
                  instance->map_.in(), reader));
     }
-    unbind(type_instance_map_, type_name);
+    unbind(topic_instance_map_, topic_name);
   }
 }
 

--- a/dds/DCPS/OwnershipManager.h
+++ b/dds/DCPS/OwnershipManager.h
@@ -32,7 +32,7 @@ class OpenDDS_Dcps_Export OwnershipManager {
 public:
   typedef OPENDDS_SET(DataReaderImpl*) ReaderSet;
 
-  // TypeInstanceMap is only used for EXCLUSIVE ownership.
+  // TopicInstanceMap is only used for EXCLUSIVE ownership.
   struct InstanceMap {
     InstanceMap()  {}
     InstanceMap(const RcHandle<RcObject>& map, DataReaderImpl* reader)
@@ -45,7 +45,7 @@ public:
     ReaderSet readers_;
   };
 
-  typedef OPENDDS_MAP(OPENDDS_STRING, InstanceMap) TypeInstanceMap;
+  typedef OPENDDS_MAP(OPENDDS_STRING, InstanceMap) TopicInstanceMap;
 
   struct WriterInfo {
     WriterInfo(const GUID_t& pub_id,
@@ -86,27 +86,27 @@ public:
   int instance_lock_release();
 
   /**
-  * The instance map per type is created by the concrete datareader
-  * when first sample with the type is received.
+  * The instance map per topic is created by the concrete datareader
+  * when the first sample for the topic is received.
   */
-  void set_instance_map(const char* type_name,
+  void set_instance_map(const char* topic_name,
                         const RcHandle<RcObject>& instance_map,
                         DataReaderImpl* reader);
 
   /**
-  * Accesor of the instance map for provided type. It is called once
+  * Accessor of the instance map for the provided topic. It is called once
   * for each new instance in a datareader.
   */
-  RcHandle<RcObject> get_instance_map(const char* type_name, DataReaderImpl* reader);
+  RcHandle<RcObject> get_instance_map(const char* topic_name, DataReaderImpl* reader);
 
   /**
   * The readers that access the instance map are keep tracked as ref
   * counting to the instance map. The readers need unregister itself
   * with the instance map upon unregistering instance.The instance map
   * is deleted upon the last reader unregistering an instance of the
-  * type.
+  * topic.
   */
-  void unregister_reader(const char* type_name,
+  void unregister_reader(const char* topic_name,
                          DataReaderImpl* reader);
 
   /**
@@ -171,7 +171,7 @@ private:
                            const GUID_t& owner);
 
   ACE_Thread_Mutex instance_lock_;
-  TypeInstanceMap type_instance_map_;
+  TopicInstanceMap topic_instance_map_;
   InstanceOwnershipWriterInfos instance_ownership_infos_;
 
 };

--- a/docs/news.d/5260.rst
+++ b/docs/news.d/5260.rst
@@ -1,0 +1,6 @@
+.. news-prs: 5260
+
+.. news-start-section: Fixes
+- Fixed exclusive ownership conflicts between topics that use the same data type and instance key by scoping shared instance handles by topic.
+
+.. news-end-section

--- a/tests/DCPS/Ownership/DataReaderListener.cpp
+++ b/tests/DCPS/Ownership/DataReaderListener.cpp
@@ -20,9 +20,11 @@
 extern int testcase;
 const int num_messages_per_writer = 20;
 
-DataReaderListenerImpl::DataReaderListenerImpl(const char* reader_id)
+DataReaderListenerImpl::DataReaderListenerImpl(const char* reader_id,
+                                               long expected_strength)
   : num_reads_(0),
     reader_id_(reader_id),
+    expected_strength_(expected_strength),
     verify_result_(true),
     result_verify_complete_(false)
 {
@@ -240,6 +242,14 @@ DataReaderListenerImpl::verify(const Messenger::Message& msg)
 
   }
   break;
+  case shared_type:
+    if (msg.strength != expected_strength_) {
+      ACE_ERROR((LM_ERROR,
+        "(%P|%t) ERROR: strength %d does not match expected strength %d\n",
+        msg.strength, expected_strength_));
+      return false;
+    }
+    break;
   default:
   ACE_OS::exit(1);
   break;
@@ -275,6 +285,11 @@ DataReaderListenerImpl::verify_result()
   {
   }
   break;
+  case shared_type:
+    verify_result_ &= num_reads_ > 0
+      && current_strength_[0] == expected_strength_
+      && current_strength_[1] == expected_strength_;
+    break;
   default:
   ACE_OS::exit(1);
   break;

--- a/tests/DCPS/Ownership/DataReaderListener.h
+++ b/tests/DCPS/Ownership/DataReaderListener.h
@@ -20,13 +20,14 @@ enum TESTCASE {
   strength,
   liveliness_change,
   miss_deadline,
-  update_strength
+  update_strength,
+  shared_type
 };
 
 class DataReaderListenerImpl
   : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener> {
 public:
-  DataReaderListenerImpl(const char* reader_id);
+  DataReaderListenerImpl(const char* reader_id, long expected_strength = -1);
 
   virtual ~DataReaderListenerImpl();
 
@@ -71,6 +72,7 @@ private:
   DDS::DataReader_var  reader_;
   long                 num_reads_;
   const char*          reader_id_;
+  const long           expected_strength_;
 
   bool  verify_result_;
   bool  result_verify_complete_;

--- a/tests/DCPS/Ownership/Writer.cpp
+++ b/tests/DCPS/Ownership/Writer.cpp
@@ -23,9 +23,11 @@ extern ACE_Time_Value dds_delay;
 extern ACE_Time_Value reset_delay;
 extern int ownership_strength;
 
-Writer::Writer(DDS::DataWriter_ptr writer, const char* ownership_dw_id)
+Writer::Writer(DDS::DataWriter_ptr writer, const char* ownership_dw_id,
+               int expected_readers)
   : writer_(DDS::DataWriter::_duplicate(writer)),
     ownership_dw_id_(ownership_dw_id),
+    expected_readers_(expected_readers),
     finished_instances_(0),
     timeout_writes_(0)
 {
@@ -82,7 +84,7 @@ Writer::svc()
         ACE_OS::exit(-1);
       }
 
-    } while (matches.current_count < 2);
+    } while (matches.current_count < expected_readers_);
 
     ws->detach_condition(condition);
 

--- a/tests/DCPS/Ownership/Writer.h
+++ b/tests/DCPS/Ownership/Writer.h
@@ -14,7 +14,8 @@
 class Writer : public ACE_Task_Base {
 public:
 
-  Writer(DDS::DataWriter_ptr writer, const char* ownership_dw_id);
+  Writer(DDS::DataWriter_ptr writer, const char* ownership_dw_id,
+         int expected_readers = 2);
 
   void start();
 
@@ -32,6 +33,7 @@ public:
 private:
   DDS::DataWriter_var writer_;
   ACE_CString ownership_dw_id_;
+  const int expected_readers_;
   OpenDDS::DCPS::Atomic<int> finished_instances_;
   OpenDDS::DCPS::Atomic<int> timeout_writes_;
 };

--- a/tests/DCPS/Ownership/publisher.cpp
+++ b/tests/DCPS/Ownership/publisher.cpp
@@ -34,13 +34,15 @@ int ownership_strength = 0;
 int reset_ownership_strength = -1;
 ACE_CString ownership_dw_id = "OwnershipDataWriter";
 bool delay_reset = false;
+ACE_CString topic_name = "Movie Discussion List";
+int expected_readers = 2;
 
 namespace {
 
 int
 parse_args(int argc, ACE_TCHAR *argv[])
 {
-  ACE_Get_Opt get_opts(argc, argv, ACE_TEXT("s:i:r:d:y:l:c"));
+  ACE_Get_Opt get_opts(argc, argv, ACE_TEXT("s:i:r:d:y:l:cn:m:"));
 
   int c;
   while ((c = get_opts()) != -1) {
@@ -68,12 +70,19 @@ parse_args(int argc, ACE_TCHAR *argv[])
     case 'c':
       delay_reset = true;
       break;
+    case 'n':
+      topic_name = ACE_TEXT_ALWAYS_CHAR(get_opts.opt_arg());
+      break;
+    case 'm':
+      expected_readers = ACE_OS::atoi(get_opts.opt_arg());
+      break;
     case '?':
     default:
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("usage: %C -s <ownership_strength> ")
                         ACE_TEXT("-i <ownership_dw_id> -r <reset_ownership_strength> ")
-                        ACE_TEXT("-d <deadline> -y <delay> -l <liveliness>\n"),
+                        ACE_TEXT("-d <deadline> -y <delay> -l <liveliness> ")
+                        ACE_TEXT("-n <topic_name> -m <expected_readers>\n"),
                         argv[0]),
                         -1);
     }
@@ -137,7 +146,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
 
     // Create Topic
     DDS::Topic_var topic =
-      participant->create_topic("Movie Discussion List",
+      participant->create_topic(topic_name.c_str(),
                                 CORBA::String_var(mts->get_type_name()),
                                 TOPIC_QOS_DEFAULT,
                                 DDS::TopicListener::_nil(),
@@ -188,7 +197,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
     }
 
     // Start writing threads
-    Writer* writer = new Writer(dw.in(), ownership_dw_id.c_str());
+    Writer* writer = new Writer(dw.in(), ownership_dw_id.c_str(), expected_readers);
     writer->start();
 
     while (!writer->is_finished()) {

--- a/tests/DCPS/Ownership/run_test.pl
+++ b/tests/DCPS/Ownership/run_test.pl
@@ -46,6 +46,9 @@ elsif ($ARGV[0] eq 'update_strength') {
     $pub1_reset_strength = "-r 15";
     $testcase = 3;
 }
+elsif ($ARGV[0] eq 'shared_type') {
+    $testcase = 4;
+}
 elsif ($ARGV[0] eq 'rtps') {
     $is_rtps_disc = 1;
 }
@@ -77,8 +80,14 @@ my $test = new PerlDDS::TestFramework();
 $test->setup_discovery("$debug_opts -ORBLogFile DCPSInfoRepo.log");
 
 $test->process('subscriber', 'subscriber', " $sub_opts -ORBLogFile sub.log $sub_deadline $sub_liveliness -t $testcase");
-$test->process('publisher1', 'publisher', "$pub_opts -ORBLogFile pub1.log -s 10 -i datawriter1 $pub1_reset_strength $pub1_deadline $pub1_liveliness");
-$test->process('publisher2', 'publisher', "$pub_opts -ORBLogFile pub2.log -s 12 -i datawriter2 $pub2_deadline $pub2_liveliness");
+if ($testcase == 4) {
+  $test->process('publisher1', 'publisher', "$pub_opts -ORBLogFile pub1.log -s 10 -i datawriter1 -m 1 -y 0");
+  $test->process('publisher2', 'publisher', "$pub_opts -ORBLogFile pub2.log -s 10 -i datawriter2 -m 1 -y 0 -n Movie_Discussion_List_2");
+}
+else {
+  $test->process('publisher1', 'publisher', "$pub_opts -ORBLogFile pub1.log -s 10 -i datawriter1 $pub1_reset_strength $pub1_deadline $pub1_liveliness");
+  $test->process('publisher2', 'publisher', "$pub_opts -ORBLogFile pub2.log -s 12 -i datawriter2 $pub2_deadline $pub2_liveliness");
+}
 
 $test->start_process('publisher1');
 $test->start_process('subscriber');

--- a/tests/DCPS/Ownership/subscriber.cpp
+++ b/tests/DCPS/Ownership/subscriber.cpp
@@ -122,6 +122,20 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                           ACE_TEXT(" ERROR: create_topic() failed!\n")), -1);
       }
 
+      DDS::Topic_var topic2;
+      if (testcase == shared_type) {
+        topic2 = participant->create_topic("Movie_Discussion_List_2",
+                                           CORBA::String_var(ts->get_type_name()),
+                                           TOPIC_QOS_DEFAULT,
+                                           DDS::TopicListener::_nil(),
+                                           OpenDDS::DCPS::DEFAULT_STATUS_MASK);
+        if (CORBA::is_nil(topic2.in())) {
+          ACE_ERROR_RETURN((LM_ERROR,
+                            ACE_TEXT("%N:%l main()")
+                            ACE_TEXT(" ERROR: create_topic() failed!\n")), -1);
+        }
+      }
+
       // Create Subscriber
       DDS::Subscriber_var sub =
         participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT,
@@ -135,8 +149,10 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       }
 
       // Create DataReader
-      DataReaderListenerImpl* listener_svt1 = new DataReaderListenerImpl("DataReader1");
-      DataReaderListenerImpl* listener_svt2 = new DataReaderListenerImpl("DataReader2");
+      DataReaderListenerImpl* listener_svt1 =
+        new DataReaderListenerImpl("DataReader1", testcase == shared_type ? 10 : -1);
+      DataReaderListenerImpl* listener_svt2 =
+        new DataReaderListenerImpl("DataReader2", testcase == shared_type ? 10 : -1);
 
       DDS::DataReaderListener_var listener1(listener_svt1);
       DDS::DataReaderListener_var listener2(listener_svt2);
@@ -162,7 +178,7 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       }
 
       DDS::DataReader_var reader2 =
-        sub->create_datareader(topic.in(),
+        sub->create_datareader(testcase == shared_type ? topic2.in() : topic.in(),
                                dr_qos,
                                listener2.in(),
                                OpenDDS::DCPS::DEFAULT_STATUS_MASK);

--- a/tests/dcps_tests.lst
+++ b/tests/dcps_tests.lst
@@ -390,6 +390,7 @@ tests/DCPS/Ownership/run_test.pl rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_KIND_EXC
 tests/DCPS/Ownership/run_test.pl update_strength rtps: !DCPS_MIN RTPS !NO_BUILT_IN_TOPICS  !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Ownership/run_test.pl liveliness_change rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Ownership/run_test.pl miss_deadline rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Ownership/run_test.pl shared_type rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/GroupPresentation/run_test.pl: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/GroupPresentation/run_test.pl topic: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/GroupPresentation/run_test.pl instance: !DCPS_MIN !DDS_NO_OBJECT_MODEL_PROFILE !DDS_NO_OWNERSHIP_PROFILE

--- a/tests/tsan_tests.lst
+++ b/tests/tsan_tests.lst
@@ -80,6 +80,7 @@ tests/DCPS/Ownership/run_test.pl rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_KIND_EXC
 tests/DCPS/Ownership/run_test.pl update_strength rtps: !DCPS_MIN RTPS !NO_BUILT_IN_TOPICS  !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Ownership/run_test.pl liveliness_change rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE
 tests/DCPS/Ownership/run_test.pl miss_deadline rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE
+tests/DCPS/Ownership/run_test.pl shared_type rtps: !DCPS_MIN RTPS !DDS_NO_OWNERSHIP_KIND_EXCLUSIVE !DDS_NO_OWNERSHIP_PROFILE
 
 tests/DCPS/SharedTransport/run_test.pl: !DCPS_MIN !OPENDDS_SAFETY_PROFILE
 tests/DCPS/SharedTransport/run_test.pl rtps: !DCPS_MIN RTPS !OPENDDS_SAFETY_PROFILE


### PR DESCRIPTION
Changes:
- Exclusive-ownership shared instance maps are now keyed by topic name instead of type name.
- Renamed TypeInstanceMap and related variables/comments to topic-oriented terminology.
- Updated lookup, insertion, release, and reader-cleanup call sites.
- Added an RTPS regression scenario with:
  - Two topics
    - The same generated type
    - Identical key values
    - Equal ownership strengths
    - One reader and writer per topic
    - Assertions that both readers receive their topic’s samples
  - Preserved the existing same-topic/two-reader coverage.

Fixes: #5249
