### PR TITLE
Runtime IPv4/IPv6 Address Family Selection

### DIFF
--- a/dds/CMakeLists.txt
+++ b/dds/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(OpenDDS REQUIRED NO_DEFAULTS TAO::tao_idl OpenDDS::opendds_idl ${dc
 include(opendds_build_helpers)
 
 add_library(OpenDDS_Dcps
+  DCPS/AddressFamily.cpp
   DCPS/BitPubListenerImpl.cpp
   DCPS/BuiltInTopicUtils.cpp
   DCPS/CoherentChangeControl.cpp
@@ -209,6 +210,7 @@ target_sources(OpenDDS_Dcps
     ../FACE/common.hpp
     ../FACE/types.hpp
     DCPS/AddressCache.h
+    DCPS/AddressFamily.h
     DCPS/AssociationData.h
     DCPS/AstNodeWrapper.h
     DCPS/Atomic.h

--- a/dds/CMakeLists.txt
+++ b/dds/CMakeLists.txt
@@ -209,6 +209,7 @@ target_sources(OpenDDS_Dcps
     ../FACE/common.hpp
     ../FACE/types.hpp
     DCPS/AddressCache.h
+    DCPS/AddressFamily.h
     DCPS/AssociationData.h
     DCPS/AstNodeWrapper.h
     DCPS/Atomic.h

--- a/dds/DCPS/AddressFamily.cpp
+++ b/dds/DCPS/AddressFamily.cpp
@@ -1,0 +1,63 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "DCPS/DdsDcps_pch.h"
+
+#include "AddressFamily.h"
+
+#include "ConfigStoreImpl.h"
+#include "Service_Participant.h"
+#include "debug.h"
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+AddressFamily
+get_address_family(const char* config_key)
+{
+  const String value = TheServiceParticipant->config_store()->get(
+    config_key, address_family_name(default_address_family()));
+  AddressFamily result;
+  return parse_address_family(value.c_str(), result) ? result :
+    ADDRESS_FAMILY_IPV4;
+}
+
+bool
+set_address_family(const char* config_key, AddressFamily value)
+{
+  if (!address_family_supported(value)) {
+    if (log_level >= LogLevel::Warning) {
+      ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: set_address_family: "
+                 "for %C, unsupported AddressFamily configuration: %C\n",
+                 config_key, address_family_name(value)));
+    }
+    return false;
+  }
+  TheServiceParticipant->config_store()->set(
+    config_key, address_family_name(value));
+  return true;
+}
+
+bool
+set_address_family(const char* config_key, const char* value)
+{
+  AddressFamily result;
+  if (parse_address_family(value, result)) {
+    return set_address_family(config_key, result);
+  }
+  if (log_level >= LogLevel::Warning) {
+    ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: set_address_family: "
+               "for %C, invalid AddressFamily configuration: %C\n",
+               config_key, value));
+  }
+  return false;
+}
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL

--- a/dds/DCPS/AddressFamily.h
+++ b/dds/DCPS/AddressFamily.h
@@ -1,0 +1,52 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_ADDRESSFAMILY_H
+#define OPENDDS_DCPS_ADDRESSFAMILY_H
+
+#include <dds/OpenDDSConfigWrapper.h>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+enum AddressFamily {
+  ADDRESS_FAMILY_IPV4,
+  ADDRESS_FAMILY_IPV6,
+  ADDRESS_FAMILY_DUAL
+};
+
+inline bool use_ipv4(AddressFamily value)
+{
+  return value != ADDRESS_FAMILY_IPV6;
+}
+
+inline bool use_ipv6(AddressFamily value)
+{
+#ifdef ACE_HAS_IPV6
+  return value != ADDRESS_FAMILY_IPV4;
+#else
+  (void) value;
+  return false;
+#endif
+}
+
+inline const char* address_family_name(AddressFamily value)
+{
+  switch (value) {
+  case ADDRESS_FAMILY_IPV4: return "ipv4";
+  case ADDRESS_FAMILY_IPV6: return "ipv6";
+  case ADDRESS_FAMILY_DUAL: return "dual";
+  }
+  return "unknown";
+}
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_DCPS_ADDRESSFAMILY_H */

--- a/dds/DCPS/AddressFamily.h
+++ b/dds/DCPS/AddressFamily.h
@@ -1,0 +1,98 @@
+/*
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef OPENDDS_DCPS_ADDRESSFAMILY_H
+#define OPENDDS_DCPS_ADDRESSFAMILY_H
+
+#include "dcps_export.h"
+
+#include <dds/OpenDDSConfigWrapper.h>
+
+#include <cstring>
+
+OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
+
+namespace OpenDDS {
+namespace DCPS {
+
+enum AddressFamily {
+  ADDRESS_FAMILY_IPV4,
+  ADDRESS_FAMILY_IPV6,
+  ADDRESS_FAMILY_DUAL
+};
+
+inline bool use_ipv4(AddressFamily value)
+{
+  return value != ADDRESS_FAMILY_IPV6;
+}
+
+inline bool use_ipv6(AddressFamily value)
+{
+#ifdef ACE_HAS_IPV6
+  return value != ADDRESS_FAMILY_IPV4;
+#else
+  (void) value;
+  return false;
+#endif
+}
+
+inline const char* address_family_name(AddressFamily value)
+{
+  switch (value) {
+  case ADDRESS_FAMILY_IPV4: return "ipv4";
+  case ADDRESS_FAMILY_IPV6: return "ipv6";
+  case ADDRESS_FAMILY_DUAL: return "dual";
+  }
+  return "unknown";
+}
+
+inline AddressFamily default_address_family()
+{
+#ifdef ACE_HAS_IPV6
+  return ADDRESS_FAMILY_DUAL;
+#else
+  return ADDRESS_FAMILY_IPV4;
+#endif
+}
+
+inline bool parse_address_family(const char* value, AddressFamily& result)
+{
+  if (std::strcmp(value, "ipv4") == 0) {
+    result = ADDRESS_FAMILY_IPV4;
+    return true;
+  } else if (std::strcmp(value, "ipv6") == 0) {
+    result = ADDRESS_FAMILY_IPV6;
+    return true;
+  } else if (std::strcmp(value, "dual") == 0) {
+    result = ADDRESS_FAMILY_DUAL;
+    return true;
+  }
+  return false;
+}
+
+inline bool address_family_supported(AddressFamily value)
+{
+#ifdef ACE_HAS_IPV6
+  (void) value;
+  return true;
+#else
+  return value != ADDRESS_FAMILY_IPV6;
+#endif
+}
+
+OpenDDS_Dcps_Export AddressFamily get_address_family(const char* config_key);
+
+OpenDDS_Dcps_Export bool set_address_family(const char* config_key,
+                                            AddressFamily value);
+
+OpenDDS_Dcps_Export bool set_address_family(const char* config_key,
+                                            const char* value);
+
+} // namespace DCPS
+} // namespace OpenDDS
+
+OPENDDS_END_VERSIONED_NAMESPACE_DECL
+
+#endif /* OPENDDS_DCPS_ADDRESSFAMILY_H */

--- a/dds/DCPS/MulticastManager.cpp
+++ b/dds/DCPS/MulticastManager.cpp
@@ -87,7 +87,8 @@ bool MulticastManager::join(const NetworkInterfaceAddress& nia,
 {
   bool joined = false;
 
-  if (joined_interfaces_.count(nia.name) == 0 && nia.is_ipv4()) {
+  if (multicast_group_address != NetworkAddress::default_IPV4 &&
+      joined_interfaces_.count(nia.name) == 0 && nia.is_ipv4()) {
     if (0 == multicast_socket.join(multicast_group_address.to_addr(), 1, nia.name.empty() ? 0 : ACE_TEXT_CHAR_TO_TCHAR(nia.name.c_str()))) {
       joined_interfaces_.insert(nia.name);
       if (log_level >= LogLevel::Info) {
@@ -126,7 +127,8 @@ bool MulticastManager::join(const NetworkInterfaceAddress& nia,
   }
 
 #ifdef ACE_HAS_IPV6
-  if (ipv6_joined_interfaces_.count(nia.name) == 0 && nia.is_ipv6()) {
+  if (ipv6_multicast_group_address != NetworkAddress::default_IPV6 &&
+      ipv6_joined_interfaces_.count(nia.name) == 0 && nia.is_ipv6()) {
     // Windows 7 has an issue with different threads concurrently calling join for ipv6
     static ACE_Thread_Mutex ipv6_static_lock;
     ACE_GUARD_RETURN(ACE_Thread_Mutex, g3, ipv6_static_lock, false);

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -64,6 +64,12 @@ RtpsDiscovery::Config::discovery_config()
     RtpsDiscovery_rch discovery = OpenDDS::DCPS::make_rch<RtpsDiscovery>(rtps_name);
     RtpsDiscoveryConfig_rch config = discovery->config();
 
+    if (config_store->has(config->config_key("ADDRESS_FAMILY").c_str()) &&
+        !config->address_family(config_store->get(
+          config->config_key("ADDRESS_FAMILY").c_str(), "").c_str())) {
+      return -1;
+    }
+
 #if OPENDDS_CONFIG_SECURITY
     if (config_store->has(config->config_key("IceTa").c_str())) {
       if (log_level >= DCPS::LogLevel::Warning) {

--- a/dds/DCPS/RTPS/RtpsDiscovery.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscovery.cpp
@@ -64,6 +64,13 @@ RtpsDiscovery::Config::discovery_config()
     RtpsDiscovery_rch discovery = OpenDDS::DCPS::make_rch<RtpsDiscovery>(rtps_name);
     RtpsDiscoveryConfig_rch config = discovery->config();
 
+    const String address_family_key = config->config_key("ADDRESS_FAMILY");
+    if (config_store->has(address_family_key.c_str()) &&
+        !config->address_family(config_store->get(
+          address_family_key.c_str(), "").c_str())) {
+      return -1;
+    }
+
 #if OPENDDS_CONFIG_SECURITY
     if (config_store->has(config->config_key("IceTa").c_str())) {
       if (log_level >= DCPS::LogLevel::Warning) {

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -26,6 +26,24 @@ RtpsDiscoveryConfig::config_key(const String& key) const
   return DCPS::ConfigPair::canonicalize(config_prefix_ + "_" + key);
 }
 
+DCPS::AddressFamily
+RtpsDiscoveryConfig::address_family() const
+{
+  return DCPS::get_address_family(config_key("ADDRESS_FAMILY").c_str());
+}
+
+bool
+RtpsDiscoveryConfig::address_family(DCPS::AddressFamily value)
+{
+  return DCPS::set_address_family(config_key("ADDRESS_FAMILY").c_str(), value);
+}
+
+bool
+RtpsDiscoveryConfig::address_family(const char* value)
+{
+  return DCPS::set_address_family(config_key("ADDRESS_FAMILY").c_str(), value);
+}
+
 DCPS::TimeDuration
 RtpsDiscoveryConfig::resend_period() const
 {
@@ -759,7 +777,7 @@ RtpsDiscoveryConfig::spdp_rtps_relay_address() const
   return TheServiceParticipant->config_store()->get(config_key("SPDP_RTPS_RELAY_ADDRESS").c_str(),
                                                     DCPS::NetworkAddress::default_IPV4,
                                                     DCPS::ConfigStoreImpl::Format_Required_Port,
-                                                    DCPS::ConfigStoreImpl::Kind_IPV4);
+                                                    DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -768,7 +786,7 @@ RtpsDiscoveryConfig::spdp_rtps_relay_address(const DCPS::NetworkAddress& address
   TheServiceParticipant->config_store()->set(config_key("SPDP_RTPS_RELAY_ADDRESS").c_str(),
                                              address,
                                              DCPS::ConfigStoreImpl::Format_Required_Port,
-                                             DCPS::ConfigStoreImpl::Kind_IPV4);
+                                             DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 DCPS::TimeDuration
@@ -793,7 +811,7 @@ RtpsDiscoveryConfig::sedp_rtps_relay_address() const
   return TheServiceParticipant->config_store()->get(config_key("SEDP_RTPS_RELAY_ADDRESS").c_str(),
                                                     DCPS::NetworkAddress::default_IPV4,
                                                     DCPS::ConfigStoreImpl::Format_Required_Port,
-                                                    DCPS::ConfigStoreImpl::Kind_IPV4);
+                                                    DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -802,7 +820,7 @@ RtpsDiscoveryConfig::sedp_rtps_relay_address(const DCPS::NetworkAddress& address
   TheServiceParticipant->config_store()->set(config_key("SEDP_RTPS_RELAY_ADDRESS").c_str(),
                                              address,
                                              DCPS::ConfigStoreImpl::Format_Required_Port,
-                                             DCPS::ConfigStoreImpl::Kind_IPV4);
+                                             DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 bool
@@ -839,7 +857,7 @@ RtpsDiscoveryConfig::spdp_stun_server_address() const
   return TheServiceParticipant->config_store()->get(config_key("SPDP_STUN_SERVER_ADDRESS").c_str(),
                                                     DCPS::NetworkAddress::default_IPV4,
                                                     DCPS::ConfigStoreImpl::Format_Required_Port,
-                                                    DCPS::ConfigStoreImpl::Kind_IPV4);
+                                                    DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -848,7 +866,7 @@ RtpsDiscoveryConfig::spdp_stun_server_address(const DCPS::NetworkAddress& addres
   TheServiceParticipant->config_store()->set(config_key("SPDP_STUN_SERVER_ADDRESS").c_str(),
                                              address,
                                              DCPS::ConfigStoreImpl::Format_Required_Port,
-                                             DCPS::ConfigStoreImpl::Kind_IPV4);
+                                             DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 DCPS::NetworkAddress
@@ -857,7 +875,7 @@ RtpsDiscoveryConfig::sedp_stun_server_address() const
   return TheServiceParticipant->config_store()->get(config_key("SEDP_STUN_SERVER_ADDRESS").c_str(),
                                                     DCPS::NetworkAddress::default_IPV4,
                                                     DCPS::ConfigStoreImpl::Format_Required_Port,
-                                                    DCPS::ConfigStoreImpl::Kind_IPV4);
+                                                    DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -866,7 +884,7 @@ RtpsDiscoveryConfig::sedp_stun_server_address(const DCPS::NetworkAddress& addres
   TheServiceParticipant->config_store()->set(config_key("SEDP_STUN_SERVER_ADDRESS").c_str(),
                                              address,
                                              DCPS::ConfigStoreImpl::Format_Required_Port,
-                                             DCPS::ConfigStoreImpl::Kind_IPV4);
+                                             DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 #if OPENDDS_CONFIG_SECURITY

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -9,6 +9,8 @@
 
 #include <dds/OpenDDSConfigWrapper.h>
 
+#include <cstring>
+
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
 namespace OpenDDS {
@@ -24,6 +26,61 @@ String
 RtpsDiscoveryConfig::config_key(const String& key) const
 {
   return DCPS::ConfigPair::canonicalize(config_prefix_ + "_" + key);
+}
+
+DCPS::AddressFamily
+RtpsDiscoveryConfig::address_family() const
+{
+#ifdef ACE_HAS_IPV6
+  const String value = TheServiceParticipant->config_store()->get(
+    config_key("ADDRESS_FAMILY").c_str(), "dual");
+#else
+  const String value = TheServiceParticipant->config_store()->get(
+    config_key("ADDRESS_FAMILY").c_str(), "ipv4");
+#endif
+  if (value == "ipv6") {
+    return DCPS::ADDRESS_FAMILY_IPV6;
+  }
+  if (value == "dual") {
+    return DCPS::ADDRESS_FAMILY_DUAL;
+  }
+  return DCPS::ADDRESS_FAMILY_IPV4;
+}
+
+bool
+RtpsDiscoveryConfig::address_family(DCPS::AddressFamily value)
+{
+#ifndef ACE_HAS_IPV6
+  if (value == DCPS::ADDRESS_FAMILY_IPV6) {
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RtpsDiscoveryConfig::address_family: "
+                 "IPv6 support is not available in this build\n"));
+    }
+    return false;
+  }
+#endif
+  TheServiceParticipant->config_store()->set(
+    config_key("ADDRESS_FAMILY").c_str(), DCPS::address_family_name(value));
+  return true;
+}
+
+bool
+RtpsDiscoveryConfig::address_family(const char* value)
+{
+  if (std::strcmp(value, "ipv4") == 0) {
+    return address_family(DCPS::ADDRESS_FAMILY_IPV4);
+  }
+  if (std::strcmp(value, "ipv6") == 0) {
+    return address_family(DCPS::ADDRESS_FAMILY_IPV6);
+  }
+  if (std::strcmp(value, "dual") == 0) {
+    return address_family(DCPS::ADDRESS_FAMILY_DUAL);
+  }
+  if (log_level >= LogLevel::Warning) {
+    ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: RtpsDiscoveryConfig::address_family: "
+               "invalid AddressFamily configuration: %C\n", value));
+  }
+  return false;
 }
 
 DCPS::TimeDuration
@@ -759,7 +816,7 @@ RtpsDiscoveryConfig::spdp_rtps_relay_address() const
   return TheServiceParticipant->config_store()->get(config_key("SPDP_RTPS_RELAY_ADDRESS").c_str(),
                                                     DCPS::NetworkAddress::default_IPV4,
                                                     DCPS::ConfigStoreImpl::Format_Required_Port,
-                                                    DCPS::ConfigStoreImpl::Kind_IPV4);
+                                                    DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -768,7 +825,7 @@ RtpsDiscoveryConfig::spdp_rtps_relay_address(const DCPS::NetworkAddress& address
   TheServiceParticipant->config_store()->set(config_key("SPDP_RTPS_RELAY_ADDRESS").c_str(),
                                              address,
                                              DCPS::ConfigStoreImpl::Format_Required_Port,
-                                             DCPS::ConfigStoreImpl::Kind_IPV4);
+                                             DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 DCPS::TimeDuration
@@ -793,7 +850,7 @@ RtpsDiscoveryConfig::sedp_rtps_relay_address() const
   return TheServiceParticipant->config_store()->get(config_key("SEDP_RTPS_RELAY_ADDRESS").c_str(),
                                                     DCPS::NetworkAddress::default_IPV4,
                                                     DCPS::ConfigStoreImpl::Format_Required_Port,
-                                                    DCPS::ConfigStoreImpl::Kind_IPV4);
+                                                    DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -802,7 +859,7 @@ RtpsDiscoveryConfig::sedp_rtps_relay_address(const DCPS::NetworkAddress& address
   TheServiceParticipant->config_store()->set(config_key("SEDP_RTPS_RELAY_ADDRESS").c_str(),
                                              address,
                                              DCPS::ConfigStoreImpl::Format_Required_Port,
-                                             DCPS::ConfigStoreImpl::Kind_IPV4);
+                                             DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 bool
@@ -839,7 +896,7 @@ RtpsDiscoveryConfig::spdp_stun_server_address() const
   return TheServiceParticipant->config_store()->get(config_key("SPDP_STUN_SERVER_ADDRESS").c_str(),
                                                     DCPS::NetworkAddress::default_IPV4,
                                                     DCPS::ConfigStoreImpl::Format_Required_Port,
-                                                    DCPS::ConfigStoreImpl::Kind_IPV4);
+                                                    DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -848,7 +905,7 @@ RtpsDiscoveryConfig::spdp_stun_server_address(const DCPS::NetworkAddress& addres
   TheServiceParticipant->config_store()->set(config_key("SPDP_STUN_SERVER_ADDRESS").c_str(),
                                              address,
                                              DCPS::ConfigStoreImpl::Format_Required_Port,
-                                             DCPS::ConfigStoreImpl::Kind_IPV4);
+                                             DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 DCPS::NetworkAddress
@@ -857,7 +914,7 @@ RtpsDiscoveryConfig::sedp_stun_server_address() const
   return TheServiceParticipant->config_store()->get(config_key("SEDP_STUN_SERVER_ADDRESS").c_str(),
                                                     DCPS::NetworkAddress::default_IPV4,
                                                     DCPS::ConfigStoreImpl::Format_Required_Port,
-                                                    DCPS::ConfigStoreImpl::Kind_IPV4);
+                                                    DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -866,7 +923,7 @@ RtpsDiscoveryConfig::sedp_stun_server_address(const DCPS::NetworkAddress& addres
   TheServiceParticipant->config_store()->set(config_key("SEDP_STUN_SERVER_ADDRESS").c_str(),
                                              address,
                                              DCPS::ConfigStoreImpl::Format_Required_Port,
-                                             DCPS::ConfigStoreImpl::Kind_IPV4);
+                                             DCPS::ConfigStoreImpl::Kind_ANY);
 }
 
 #if OPENDDS_CONFIG_SECURITY

--- a/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
+++ b/dds/DCPS/RTPS/RtpsDiscoveryConfig.h
@@ -8,6 +8,7 @@
 
 #include "Spdp.h"
 
+#include <dds/DCPS/AddressFamily.h>
 #include <dds/DCPS/AtomicBool.h>
 #include <dds/DCPS/debug.h>
 
@@ -31,6 +32,10 @@ public:
   };
 
   RtpsDiscoveryConfig(const String& name);
+
+  DCPS::AddressFamily address_family() const;
+  bool address_family(DCPS::AddressFamily value);
+  bool address_family(const char* value);
 
   const String& config_prefix() const { return config_prefix_; }
   String config_key(const String& key) const;

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -472,6 +472,8 @@ Sedp::init(const GUID_t& guid,
                            disco.config()->recv_buffer_size());
   transport_inst_->receive_preallocated_message_blocks(disco.config()->sedp_receive_preallocated_message_blocks());
   transport_inst_->receive_preallocated_data_blocks(disco.config()->sedp_receive_preallocated_data_blocks());
+  config_store_->set(transport_inst_->config_key("ADDRESS_FAMILY").c_str(),
+                     DCPS::address_family_name(disco.config()->address_family()));
 
   set_port_mode(transport_inst_->config_key("PORT_MODE").c_str(), disco.config()->sedp_port_mode());
   config_store_->set_int32(transport_inst_->config_key("PB").c_str(), disco.config()->pb());
@@ -528,13 +530,13 @@ Sedp::init(const GUID_t& guid,
   config_store_->set(transport_inst_->config_key("DATA_RTPS_RELAY_ADDRESS").c_str(),
                      disco.config()->sedp_rtps_relay_address(),
                      ConfigStoreImpl::Format_Required_Port,
-                     ConfigStoreImpl::Kind_IPV4);
+                     ConfigStoreImpl::Kind_ANY);
   config_store_->set_boolean(transport_inst_->config_key("USE_RTPS_RELAY").c_str(), disco.config()->use_rtps_relay());
   config_store_->set_boolean(transport_inst_->config_key("RTPS_RELAY_ONLY").c_str(), disco.config()->rtps_relay_only());
   config_store_->set(transport_inst_->config_key("DATA_STUN_SERVER_ADDRESS").c_str(),
                      disco.config()->sedp_stun_server_address(),
                      ConfigStoreImpl::Format_Required_Port,
-                     ConfigStoreImpl::Kind_IPV4);
+                     ConfigStoreImpl::Kind_ANY);
 #if OPENDDS_CONFIG_SECURITY
   config_store_->set_boolean(transport_inst_->config_key("USE_ICE").c_str(), disco.config()->use_ice());
 #endif
@@ -6273,7 +6275,7 @@ Sedp::rtps_relay_address(const NetworkAddress& address)
   config_store_->set(transport_inst_->config_key("DATA_RTPS_RELAY_ADDRESS").c_str(),
                      address,
                      ConfigStoreImpl::Format_Required_Port,
-                     ConfigStoreImpl::Kind_IPV4);
+                     ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -6282,7 +6284,7 @@ Sedp::stun_server_address(const NetworkAddress& address)
   config_store_->set(transport_inst_->config_key("DATA_STUN_SERVER_ADDRESS").c_str(),
                      address,
                      ConfigStoreImpl::Format_Required_Port,
-                     ConfigStoreImpl::Kind_IPV4);
+                     ConfigStoreImpl::Kind_ANY);
 }
 
 void

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -472,6 +472,8 @@ Sedp::init(const GUID_t& guid,
                            disco.config()->recv_buffer_size());
   transport_inst_->receive_preallocated_message_blocks(disco.config()->sedp_receive_preallocated_message_blocks());
   transport_inst_->receive_preallocated_data_blocks(disco.config()->sedp_receive_preallocated_data_blocks());
+  config_store_->set(transport_inst_->config_key("ADDRESS_FAMILY").c_str(),
+                     DCPS::address_family_name(disco.config()->address_family()));
 
   set_port_mode(transport_inst_->config_key("PORT_MODE").c_str(), disco.config()->sedp_port_mode());
   config_store_->set_int32(transport_inst_->config_key("PB").c_str(), disco.config()->pb());
@@ -528,13 +530,13 @@ Sedp::init(const GUID_t& guid,
   config_store_->set(transport_inst_->config_key("DATA_RTPS_RELAY_ADDRESS").c_str(),
                      disco.config()->sedp_rtps_relay_address(),
                      ConfigStoreImpl::Format_Required_Port,
-                     ConfigStoreImpl::Kind_IPV4);
+                     ConfigStoreImpl::Kind_ANY);
   config_store_->set_boolean(transport_inst_->config_key("USE_RTPS_RELAY").c_str(), disco.config()->use_rtps_relay());
   config_store_->set_boolean(transport_inst_->config_key("RTPS_RELAY_ONLY").c_str(), disco.config()->rtps_relay_only());
   config_store_->set(transport_inst_->config_key("DATA_STUN_SERVER_ADDRESS").c_str(),
                      disco.config()->sedp_stun_server_address(),
                      ConfigStoreImpl::Format_Required_Port,
-                     ConfigStoreImpl::Kind_IPV4);
+                     ConfigStoreImpl::Kind_ANY);
 #if OPENDDS_CONFIG_SECURITY
   config_store_->set_boolean(transport_inst_->config_key("USE_ICE").c_str(), disco.config()->use_ice());
 #endif
@@ -6271,7 +6273,7 @@ Sedp::rtps_relay_address(const NetworkAddress& address)
   config_store_->set(transport_inst_->config_key("DATA_RTPS_RELAY_ADDRESS").c_str(),
                      address,
                      ConfigStoreImpl::Format_Required_Port,
-                     ConfigStoreImpl::Kind_IPV4);
+                     ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -6280,7 +6282,7 @@ Sedp::stun_server_address(const NetworkAddress& address)
   config_store_->set(transport_inst_->config_key("DATA_STUN_SERVER_ADDRESS").c_str(),
                      address,
                      ConfigStoreImpl::Format_Required_Port,
-                     ConfigStoreImpl::Kind_IPV4);
+                     ConfigStoreImpl::Kind_ANY);
 }
 
 void

--- a/dds/DCPS/RTPS/Spdp.cpp
+++ b/dds/DCPS/RTPS/Spdp.cpp
@@ -2296,12 +2296,11 @@ ParticipantData_t Spdp::build_local_pdata(
   // The OpenDDS publication/subscription data will have locators included.
   DCPS::LocatorSeq nonEmptyList(1);
   nonEmptyList.length(1);
-  nonEmptyList[0].kind = LOCATOR_KIND_UDPv4;
+  const bool ipv4 = DCPS::use_ipv4(config_->address_family());
+  nonEmptyList[0].kind = ipv4 ? LOCATOR_KIND_UDPv4 : LOCATOR_KIND_UDPv6;
   nonEmptyList[0].port = 12345;
-  std::memset(nonEmptyList[0].address, 0, 12);
-  nonEmptyList[0].address[12] = 127;
-  nonEmptyList[0].address[13] = 0;
-  nonEmptyList[0].address[14] = 0;
+  std::memset(nonEmptyList[0].address, 0, 16);
+  nonEmptyList[0].address[12] = ipv4 ? 127 : 0;
   nonEmptyList[0].address[15] = 1;
 
   const GuidPrefix_t& gp = guid_.guidPrefix;
@@ -2427,23 +2426,37 @@ Spdp::SpdpTransport::SpdpTransport(DCPS::RcHandle<Spdp> outer)
 
   multicast_interface_ = outer->disco_->multicast_interface();
 
-  if (!outer->config_->spdp_multicast_address(multicast_address_, outer->domain_)) {
-    throw std::runtime_error("failed to get valid multicast IPv4 address for SPDP");
+  const DCPS::AddressFamily address_family = outer->config_->address_family();
+  if (DCPS::use_ipv4(address_family)) {
+    if (!outer->config_->spdp_multicast_address(multicast_address_, outer->domain_)) {
+      throw std::runtime_error("failed to get valid multicast IPv4 address for SPDP");
+    }
+    send_addrs_.insert(multicast_address_);
   }
-  send_addrs_.insert(multicast_address_);
 #ifdef ACE_HAS_IPV6
-  if (!outer->config_->ipv6_spdp_multicast_address(multicast_ipv6_address_, outer->domain_)) {
-    throw std::runtime_error("failed to get valid multicast IPv4 address for SPDP");
+  if (DCPS::use_ipv6(address_family)) {
+    if (!outer->config_->ipv6_spdp_multicast_address(multicast_ipv6_address_, outer->domain_)) {
+      throw std::runtime_error("failed to get valid multicast IPv6 address for SPDP");
+    }
+    send_addrs_.insert(multicast_ipv6_address_);
   }
-  send_addrs_.insert(multicast_ipv6_address_);
 #endif
 
   const DCPS::NetworkAddressSet addrs = outer->config_->spdp_send_addrs();
-  send_addrs_.insert(addrs.begin(), addrs.end());
+  for (DCPS::NetworkAddressSet::const_iterator pos = addrs.begin(); pos != addrs.end(); ++pos) {
+    const int type = pos->to_addr().get_type();
+    if ((type == AF_INET && DCPS::use_ipv4(address_family))
+#ifdef ACE_HAS_IPV6
+        || (type == AF_INET6 && DCPS::use_ipv6(address_family))
+#endif
+        ) {
+      send_addrs_.insert(*pos);
+    }
+  }
 
   const DDS::UInt16 startingParticipantId = outer->ipv4_participant_port_id_;
   const DDS::UInt16 max_part_id = 119; // RTPS 2.5 9.6.2.3
-  while (!open_unicast_socket(outer->ipv4_participant_port_id_)) {
+  while (DCPS::use_ipv4(address_family) && !open_unicast_socket(outer->ipv4_participant_port_id_)) {
     if (outer->ipv4_participant_port_id_ == max_part_id && log_level >= LogLevel::Warning) {
       ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: Spdp::SpdpTransport: "
         "participant id is going above max %u allowed by RTPS spec\n", max_part_id));
@@ -2459,8 +2472,10 @@ Spdp::SpdpTransport::SpdpTransport(DCPS::RcHandle<Spdp> outer)
   }
 
 #ifdef ACE_HAS_IPV6
-  outer->ipv6_participant_port_id_ = outer->ipv4_participant_port_id_;
-  while (!open_unicast_ipv6_socket(outer->ipv6_participant_port_id_)) {
+  outer->ipv6_participant_port_id_ = DCPS::use_ipv4(address_family) ?
+    outer->ipv4_participant_port_id_ : startingParticipantId;
+  while (DCPS::use_ipv6(address_family) &&
+         !open_unicast_ipv6_socket(outer->ipv6_participant_port_id_)) {
     ++outer->ipv6_participant_port_id_;
     if (outer->ipv4_participant_port_id_ == outer->ipv6_participant_port_id_) {
       throw std::runtime_error("could not find a free IPv6 unicast port for SPDP");
@@ -2469,13 +2484,19 @@ Spdp::SpdpTransport::SpdpTransport(DCPS::RcHandle<Spdp> outer)
 #endif
 
 #ifdef OPENDDS_SAFETY_PROFILE
-  if (outer->ipv4_participant_port_id_ > startingParticipantId && ACE_OS::getpid() == -1) {
+#ifdef ACE_HAS_IPV6
+  const DDS::UInt16 selected_participant_id = DCPS::use_ipv4(address_family) ?
+    outer->ipv4_participant_port_id_ : outer->ipv6_participant_port_id_;
+#else
+  const DDS::UInt16 selected_participant_id = outer->ipv4_participant_port_id_;
+#endif
+  if (selected_participant_id > startingParticipantId && ACE_OS::getpid() == -1) {
     // Since pids are not available, use the fact that we had to increment
     // participantId to modify the GUID's pid bytes.  This avoids GUID conflicts
     // between processes on the same host which start at the same time
     // (resulting in the same seed value for the random number generator).
-    hdr_.guidPrefix[8] = static_cast<CORBA::Octet>(outer->ipv4_participant_port_id_ >> 8);
-    hdr_.guidPrefix[9] = static_cast<CORBA::Octet>(outer->ipv4_participant_port_id_ & 0xFF);
+    hdr_.guidPrefix[8] = static_cast<CORBA::Octet>(selected_participant_id >> 8);
+    hdr_.guidPrefix[9] = static_cast<CORBA::Octet>(selected_participant_id & 0xFF);
     outer->guid_.guidPrefix[8] = hdr_.guidPrefix[8];
     outer->guid_.guidPrefix[9] = hdr_.guidPrefix[9];
   }
@@ -2648,9 +2669,13 @@ void Spdp::SpdpTransport::register_handlers(DCPS::ReactorWrapper& reactor_wrappe
     return;
   }
 
-  register_unicast_socket(reactor_wrapper, unicast_socket_, "IPV4");
+  if (unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+    register_unicast_socket(reactor_wrapper, unicast_socket_, "IPV4");
+  }
 #ifdef ACE_HAS_IPV6
-  register_unicast_socket(reactor_wrapper, unicast_ipv6_socket_, "IPV6");
+  if (unicast_ipv6_socket_.get_handle() != ACE_INVALID_HANDLE) {
+    register_unicast_socket(reactor_wrapper, unicast_ipv6_socket_, "IPV6");
+  }
 #endif
 }
 
@@ -2763,11 +2788,19 @@ Spdp::SpdpTransport::close(const DCPS::ReactorTask_rch& reactor_task)
   ACE_Reactor* reactor = reactor_task->get_reactor();
   const ACE_Reactor_Mask mask =
     ACE_Event_Handler::READ_MASK | ACE_Event_Handler::DONT_CALL;
-  reactor->remove_handler(multicast_socket_.get_handle(), mask);
-  reactor->remove_handler(unicast_socket_.get_handle(), mask);
+  if (multicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+    reactor->remove_handler(multicast_socket_.get_handle(), mask);
+  }
+  if (unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+    reactor->remove_handler(unicast_socket_.get_handle(), mask);
+  }
 #ifdef ACE_HAS_IPV6
-  reactor->remove_handler(multicast_ipv6_socket_.get_handle(), mask);
-  reactor->remove_handler(unicast_ipv6_socket_.get_handle(), mask);
+  if (multicast_ipv6_socket_.get_handle() != ACE_INVALID_HANDLE) {
+    reactor->remove_handler(multicast_ipv6_socket_.get_handle(), mask);
+  }
+  if (unicast_ipv6_socket_.get_handle() != ACE_INVALID_HANDLE) {
+    reactor->remove_handler(unicast_ipv6_socket_.get_handle(), mask);
+  }
 #endif
 
   if (config_reader_) {
@@ -3420,8 +3453,8 @@ Spdp::SpdpTransport::host_addresses() const
   ICE::AddressListType addresses;
   ACE_INET_Addr addr;
 
-  unicast_socket_.get_local_addr(addr);
-  if (addr != ACE_INET_Addr()) {
+  if (unicast_socket_.get_handle() != ACE_INVALID_HANDLE &&
+      unicast_socket_.get_local_addr(addr) == 0 && addr != ACE_INET_Addr()) {
     if (addr.is_any()) {
       ICE::AddressListType addrs;
       DCPS::get_interface_addrs(addrs);
@@ -3437,8 +3470,9 @@ Spdp::SpdpTransport::host_addresses() const
   }
 
 #ifdef ACE_HAS_IPV6
-  unicast_ipv6_socket_.get_local_addr(addr);
-  if (addr != ACE_INET_Addr()) {
+  if (unicast_ipv6_socket_.get_handle() != ACE_INVALID_HANDLE &&
+      unicast_ipv6_socket_.get_local_addr(addr) == 0 &&
+      addr != ACE_INET_Addr()) {
     if (addr.is_any()) {
       ICE::AddressListType addrs;
       DCPS::get_interface_addrs(addrs);
@@ -3720,10 +3754,12 @@ void Spdp::SpdpTransport::handle_network_interface_updates()
                                  multicast_interface_,
                                  reactor(),
                                  this,
-                                 multicast_address_,
+                                 DCPS::use_ipv4(outer->config_->address_family()) ?
+                                   multicast_address_ : DCPS::NetworkAddress::default_IPV4,
                                  multicast_socket_
 #ifdef ACE_HAS_IPV6
-                                 , multicast_ipv6_address_,
+                                 , DCPS::use_ipv6(outer->config_->address_family()) ?
+                                   multicast_ipv6_address_ : DCPS::NetworkAddress::default_IPV6,
                                  multicast_ipv6_socket_
 #endif
                                  )) {

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpDataLink.cpp
@@ -320,7 +320,8 @@ RtpsUdpDataLink::open(const ACE_SOCK_Dgram& unicast_socket
   }
 
   if (cfg->use_multicast()) {
-    if (!set_socket_multicast_ttl(unicast_socket_, cfg->ttl())) {
+    if (unicast_socket_.get_handle() != ACE_INVALID_HANDLE &&
+        !set_socket_multicast_ttl(unicast_socket_, cfg->ttl())) {
       if (DCPS_debug_level > 0) {
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("(%P|%t) ERROR: ")
@@ -331,7 +332,8 @@ RtpsUdpDataLink::open(const ACE_SOCK_Dgram& unicast_socket
       return false;
     }
 #ifdef ACE_HAS_IPV6
-    if (!set_socket_multicast_ttl(ipv6_unicast_socket_, cfg->ttl())) {
+    if (ipv6_unicast_socket_.get_handle() != ACE_INVALID_HANDLE &&
+        !set_socket_multicast_ttl(ipv6_unicast_socket_, cfg->ttl())) {
       if (DCPS_debug_level > 0) {
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("(%P|%t) ERROR: ")
@@ -346,7 +348,7 @@ RtpsUdpDataLink::open(const ACE_SOCK_Dgram& unicast_socket
 
   if (cfg->send_buffer_size() > 0) {
     int snd_size = cfg->send_buffer_size();
-    if (unicast_socket_.set_option(SOL_SOCKET,
+    if (unicast_socket_.get_handle() != ACE_INVALID_HANDLE && unicast_socket_.set_option(SOL_SOCKET,
                                 SO_SNDBUF,
                                 &snd_size,
                                 sizeof(snd_size)) < 0
@@ -360,7 +362,8 @@ RtpsUdpDataLink::open(const ACE_SOCK_Dgram& unicast_socket
       return false;
     }
 #ifdef ACE_HAS_IPV6
-    if (ipv6_unicast_socket_.set_option(SOL_SOCKET,
+    if (ipv6_unicast_socket_.get_handle() != ACE_INVALID_HANDLE &&
+        ipv6_unicast_socket_.set_option(SOL_SOCKET,
                                         SO_SNDBUF,
                                         (void *) &snd_size,
                                         sizeof(snd_size)) < 0
@@ -378,7 +381,7 @@ RtpsUdpDataLink::open(const ACE_SOCK_Dgram& unicast_socket
 
   if (cfg->rcv_buffer_size() > 0) {
     int rcv_size = cfg->rcv_buffer_size();
-    if (unicast_socket_.set_option(SOL_SOCKET,
+    if (unicast_socket_.get_handle() != ACE_INVALID_HANDLE && unicast_socket_.set_option(SOL_SOCKET,
                                 SO_RCVBUF,
                                 &rcv_size,
                                 sizeof(int)) < 0
@@ -392,7 +395,8 @@ RtpsUdpDataLink::open(const ACE_SOCK_Dgram& unicast_socket
       return false;
     }
 #ifdef ACE_HAS_IPV6
-    if (ipv6_unicast_socket_.set_option(SOL_SOCKET,
+    if (ipv6_unicast_socket_.get_handle() != ACE_INVALID_HANDLE &&
+        ipv6_unicast_socket_.set_option(SOL_SOCKET,
                                         SO_RCVBUF,
                                         (void *) &rcv_size,
                                         sizeof(int)) < 0
@@ -463,10 +467,14 @@ void RtpsUdpDataLink::handle_network_interface_updates()
                              cfg->multicast_interface(),
                              get_reactor(),
                              receive_strategy().in(),
-                             cfg->multicast_group_address(tport->domain()),
+                             use_ipv4(cfg->address_family()) ?
+                               cfg->multicast_group_address(tport->domain()) :
+                               NetworkAddress::default_IPV4,
                              multicast_socket_
 #ifdef ACE_HAS_IPV6
-                             , cfg->ipv6_multicast_group_address(tport->domain()),
+                             , use_ipv6(cfg->address_family()) ?
+                               cfg->ipv6_multicast_group_address(tport->domain()) :
+                               NetworkAddress::default_IPV6,
                              ipv6_multicast_socket_
 #endif
                              );

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -44,6 +44,24 @@ RtpsUdpInst::RtpsUdpInst(const OPENDDS_STRING& name,
   , opendds_discovery_guid_(GUID_UNKNOWN)
 {}
 
+AddressFamily
+RtpsUdpInst::address_family() const
+{
+  return get_address_family(config_key("ADDRESS_FAMILY").c_str());
+}
+
+bool
+RtpsUdpInst::address_family(AddressFamily value)
+{
+  return set_address_family(config_key("ADDRESS_FAMILY").c_str(), value);
+}
+
+bool
+RtpsUdpInst::address_family(const char* value)
+{
+  return set_address_family(config_key("ADDRESS_FAMILY").c_str(), value);
+}
+
 void
 RtpsUdpInst::send_buffer_size(ACE_INT32 sbs)
 {
@@ -577,7 +595,7 @@ RtpsUdpInst::rtps_relay_address(const NetworkAddress& address)
   TheServiceParticipant->config_store()->set(config_key("DATA_RTPS_RELAY_ADDRESS").c_str(),
                                              address,
                                              ConfigStoreImpl::Format_Required_Port,
-                                             ConfigStoreImpl::Kind_IPV4);
+                                             ConfigStoreImpl::Kind_ANY);
 }
 
 NetworkAddress
@@ -586,7 +604,7 @@ RtpsUdpInst::rtps_relay_address() const
   return TheServiceParticipant->config_store()->get(config_key("DATA_RTPS_RELAY_ADDRESS").c_str(),
                                                     NetworkAddress::default_IPV4,
                                                     ConfigStoreImpl::Format_Required_Port,
-                                                    ConfigStoreImpl::Kind_IPV4);
+                                                    ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -607,7 +625,7 @@ RtpsUdpInst::stun_server_address(const NetworkAddress& address)
   TheServiceParticipant->config_store()->set(config_key("DATA_STUN_SERVER_ADDRESS").c_str(),
                                              address,
                                              ConfigStoreImpl::Format_Required_Port,
-                                             ConfigStoreImpl::Kind_IPV4);
+                                             ConfigStoreImpl::Kind_ANY);
 }
 
 NetworkAddress
@@ -616,7 +634,7 @@ RtpsUdpInst::stun_server_address() const
   return TheServiceParticipant->config_store()->get(config_key("DATA_STUN_SERVER_ADDRESS").c_str(),
                                                     NetworkAddress::default_IPV4,
                                                     ConfigStoreImpl::Format_Required_Port,
-                                                    ConfigStoreImpl::Kind_IPV4);
+                                                    ConfigStoreImpl::Kind_ANY);
 }
 
 TransportImpl_rch
@@ -632,6 +650,7 @@ RtpsUdpInst::dump_to_str(DDS::DomainId_t domain) const
   ret += formatNameForDump("send_buffer_size") + to_dds_string(send_buffer_size()) + '\n';
   ret += formatNameForDump("rcv_buffer_size") + to_dds_string(rcv_buffer_size()) + '\n';
   ret += formatNameForDump("use_multicast") + (use_multicast() ? "true" : "false") + '\n';
+  ret += formatNameForDump("address_family") + address_family_name(address_family()) + '\n';
   ret += formatNameForDump("ttl") + to_dds_string(ttl()) + '\n';
   ret += formatNameForDump("multicast_interface") + multicast_interface() + '\n';
   ret += formatNameForDump("anticipated_fragments") + to_dds_string(unsigned(anticipated_fragments())) + '\n';
@@ -664,13 +683,16 @@ RtpsUdpInst::populate_locator(TransportLocator& info,
 
   // multicast first so it's preferred by remote peers
   const NetworkAddress multicast_group_addr = multicast_group_address(domain);
-  if ((flags & CONNINFO_MULTICAST) && use_multicast() && multicast_group_addr != NetworkAddress::default_IPV4) {
+  if (use_ipv4(address_family()) && (flags & CONNINFO_MULTICAST) &&
+      use_multicast() && multicast_group_addr != NetworkAddress::default_IPV4) {
     grow(locators);
     address_to_locator(locators[idx++], multicast_group_addr.to_addr());
   }
 #ifdef ACE_HAS_IPV6
   const NetworkAddress ipv6_multicast_group_addr = ipv6_multicast_group_address(domain);
-  if ((flags & CONNINFO_MULTICAST) && use_multicast() && ipv6_multicast_group_addr != NetworkAddress::default_IPV6) {
+  if (use_ipv6(address_family()) && (flags & CONNINFO_MULTICAST) &&
+      use_multicast() &&
+      ipv6_multicast_group_addr != NetworkAddress::default_IPV6) {
     grow(locators);
     address_to_locator(locators[idx++], ipv6_multicast_group_addr.to_addr());
   }
@@ -681,7 +703,7 @@ RtpsUdpInst::populate_locator(TransportLocator& info,
   NetworkAddress my_ipv6_actual_local_address = ipv6_actual_local_address(domain, participant);
 #endif
 
-  if (flags & CONNINFO_UNICAST) {
+  if ((flags & CONNINFO_UNICAST) && use_ipv4(address_family())) {
     const NetworkAddress addr = (my_actual_local_address == NetworkAddress::default_IPV4) ? local_address() : my_actual_local_address;
     if (addr != NetworkAddress::default_IPV4) {
       if (advertised_address() != NetworkAddress::default_IPV4) {
@@ -708,7 +730,9 @@ RtpsUdpInst::populate_locator(TransportLocator& info,
         address_to_locator(locators[idx++], addr.to_addr());
       }
     }
+  }
 #ifdef ACE_HAS_IPV6
+  if ((flags & CONNINFO_UNICAST) && use_ipv6(address_family())) {
     const NetworkAddress addr6 = (my_ipv6_actual_local_address == NetworkAddress::default_IPV6) ? ipv6_local_address() : my_ipv6_actual_local_address;
     if (addr6 != NetworkAddress::default_IPV6) {
       if (ipv6_advertised_address() != NetworkAddress::default_IPV6) {
@@ -735,8 +759,8 @@ RtpsUdpInst::populate_locator(TransportLocator& info,
         address_to_locator(locators[idx++], addr6.to_addr());
       }
     }
-#endif
   }
+#endif
 
   info.transport_type = "rtps_udp";
   RTPS::locators_to_blob(locators, VENDORID_OPENDDS, info.data);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -44,6 +44,61 @@ RtpsUdpInst::RtpsUdpInst(const OPENDDS_STRING& name,
   , opendds_discovery_guid_(GUID_UNKNOWN)
 {}
 
+AddressFamily
+RtpsUdpInst::address_family() const
+{
+#ifdef ACE_HAS_IPV6
+  const String value = TheServiceParticipant->config_store()->get(
+    config_key("ADDRESS_FAMILY").c_str(), "dual");
+#else
+  const String value = TheServiceParticipant->config_store()->get(
+    config_key("ADDRESS_FAMILY").c_str(), "ipv4");
+#endif
+  if (value == "ipv6") {
+    return ADDRESS_FAMILY_IPV6;
+  }
+  if (value == "dual") {
+    return ADDRESS_FAMILY_DUAL;
+  }
+  return ADDRESS_FAMILY_IPV4;
+}
+
+bool
+RtpsUdpInst::address_family(AddressFamily value)
+{
+#ifndef ACE_HAS_IPV6
+  if (value == ADDRESS_FAMILY_IPV6) {
+    if (log_level >= LogLevel::Error) {
+      ACE_ERROR((LM_ERROR, "(%P|%t) ERROR: RtpsUdpInst::address_family: "
+                 "IPv6 support is not available in this build\n"));
+    }
+    return false;
+  }
+#endif
+  TheServiceParticipant->config_store()->set(
+    config_key("ADDRESS_FAMILY").c_str(), address_family_name(value));
+  return true;
+}
+
+bool
+RtpsUdpInst::address_family(const char* value)
+{
+  if (std::strcmp(value, "ipv4") == 0) {
+    return address_family(ADDRESS_FAMILY_IPV4);
+  }
+  if (std::strcmp(value, "ipv6") == 0) {
+    return address_family(ADDRESS_FAMILY_IPV6);
+  }
+  if (std::strcmp(value, "dual") == 0) {
+    return address_family(ADDRESS_FAMILY_DUAL);
+  }
+  if (log_level >= LogLevel::Warning) {
+    ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: RtpsUdpInst::address_family: "
+               "invalid AddressFamily configuration: %C\n", value));
+  }
+  return false;
+}
+
 void
 RtpsUdpInst::send_buffer_size(ACE_INT32 sbs)
 {
@@ -577,7 +632,7 @@ RtpsUdpInst::rtps_relay_address(const NetworkAddress& address)
   TheServiceParticipant->config_store()->set(config_key("DATA_RTPS_RELAY_ADDRESS").c_str(),
                                              address,
                                              ConfigStoreImpl::Format_Required_Port,
-                                             ConfigStoreImpl::Kind_IPV4);
+                                             ConfigStoreImpl::Kind_ANY);
 }
 
 NetworkAddress
@@ -586,7 +641,7 @@ RtpsUdpInst::rtps_relay_address() const
   return TheServiceParticipant->config_store()->get(config_key("DATA_RTPS_RELAY_ADDRESS").c_str(),
                                                     NetworkAddress::default_IPV4,
                                                     ConfigStoreImpl::Format_Required_Port,
-                                                    ConfigStoreImpl::Kind_IPV4);
+                                                    ConfigStoreImpl::Kind_ANY);
 }
 
 void
@@ -607,7 +662,7 @@ RtpsUdpInst::stun_server_address(const NetworkAddress& address)
   TheServiceParticipant->config_store()->set(config_key("DATA_STUN_SERVER_ADDRESS").c_str(),
                                              address,
                                              ConfigStoreImpl::Format_Required_Port,
-                                             ConfigStoreImpl::Kind_IPV4);
+                                             ConfigStoreImpl::Kind_ANY);
 }
 
 NetworkAddress
@@ -616,7 +671,7 @@ RtpsUdpInst::stun_server_address() const
   return TheServiceParticipant->config_store()->get(config_key("DATA_STUN_SERVER_ADDRESS").c_str(),
                                                     NetworkAddress::default_IPV4,
                                                     ConfigStoreImpl::Format_Required_Port,
-                                                    ConfigStoreImpl::Kind_IPV4);
+                                                    ConfigStoreImpl::Kind_ANY);
 }
 
 TransportImpl_rch
@@ -632,6 +687,7 @@ RtpsUdpInst::dump_to_str(DDS::DomainId_t domain) const
   ret += formatNameForDump("send_buffer_size") + to_dds_string(send_buffer_size()) + '\n';
   ret += formatNameForDump("rcv_buffer_size") + to_dds_string(rcv_buffer_size()) + '\n';
   ret += formatNameForDump("use_multicast") + (use_multicast() ? "true" : "false") + '\n';
+  ret += formatNameForDump("address_family") + address_family_name(address_family()) + '\n';
   ret += formatNameForDump("ttl") + to_dds_string(ttl()) + '\n';
   ret += formatNameForDump("multicast_interface") + multicast_interface() + '\n';
   ret += formatNameForDump("anticipated_fragments") + to_dds_string(unsigned(anticipated_fragments())) + '\n';
@@ -664,13 +720,16 @@ RtpsUdpInst::populate_locator(TransportLocator& info,
 
   // multicast first so it's preferred by remote peers
   const NetworkAddress multicast_group_addr = multicast_group_address(domain);
-  if ((flags & CONNINFO_MULTICAST) && use_multicast() && multicast_group_addr != NetworkAddress::default_IPV4) {
+  if (use_ipv4(address_family()) && (flags & CONNINFO_MULTICAST) &&
+      use_multicast() && multicast_group_addr != NetworkAddress::default_IPV4) {
     grow(locators);
     address_to_locator(locators[idx++], multicast_group_addr.to_addr());
   }
 #ifdef ACE_HAS_IPV6
   const NetworkAddress ipv6_multicast_group_addr = ipv6_multicast_group_address(domain);
-  if ((flags & CONNINFO_MULTICAST) && use_multicast() && ipv6_multicast_group_addr != NetworkAddress::default_IPV6) {
+  if (use_ipv6(address_family()) && (flags & CONNINFO_MULTICAST) &&
+      use_multicast() &&
+      ipv6_multicast_group_addr != NetworkAddress::default_IPV6) {
     grow(locators);
     address_to_locator(locators[idx++], ipv6_multicast_group_addr.to_addr());
   }
@@ -681,7 +740,7 @@ RtpsUdpInst::populate_locator(TransportLocator& info,
   NetworkAddress my_ipv6_actual_local_address = ipv6_actual_local_address(domain, participant);
 #endif
 
-  if (flags & CONNINFO_UNICAST) {
+  if ((flags & CONNINFO_UNICAST) && use_ipv4(address_family())) {
     const NetworkAddress addr = (my_actual_local_address == NetworkAddress::default_IPV4) ? local_address() : my_actual_local_address;
     if (addr != NetworkAddress::default_IPV4) {
       if (advertised_address() != NetworkAddress::default_IPV4) {
@@ -708,7 +767,9 @@ RtpsUdpInst::populate_locator(TransportLocator& info,
         address_to_locator(locators[idx++], addr.to_addr());
       }
     }
+  }
 #ifdef ACE_HAS_IPV6
+  if ((flags & CONNINFO_UNICAST) && use_ipv6(address_family())) {
     const NetworkAddress addr6 = (my_ipv6_actual_local_address == NetworkAddress::default_IPV6) ? ipv6_local_address() : my_ipv6_actual_local_address;
     if (addr6 != NetworkAddress::default_IPV6) {
       if (ipv6_advertised_address() != NetworkAddress::default_IPV6) {
@@ -735,8 +796,8 @@ RtpsUdpInst::populate_locator(TransportLocator& info,
         address_to_locator(locators[idx++], addr6.to_addr());
       }
     }
-#endif
   }
+#endif
 
   info.transport_type = "rtps_udp";
   RTPS::locators_to_blob(locators, VENDORID_OPENDDS, info.data);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpInst.h
@@ -9,10 +9,11 @@
 #include "Rtps_Udp_Export.h"
 #include "RtpsUdpTransport_rch.h"
 
+#include <dds/DCPS/AddressFamily.h>
 #include <dds/DCPS/NetworkAddress.h>
-#include <dds/DCPS/SafetyProfileStreams.h>
 #include <dds/DCPS/RTPS/ICE/Ice.h>
 #include <dds/DCPS/RTPS/MessageUtils.h>
+#include <dds/DCPS/SafetyProfileStreams.h>
 #include <dds/DCPS/transport/framework/TransportInst.h>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -32,6 +33,10 @@ public:
 
   static const suseconds_t DEFAULT_NAK_RESPONSE_DELAY_USEC = 200000; // default from RTPS
   static const time_t DEFAULT_HEARTBEAT_PERIOD_SEC = 1; // no default in RTPS spec
+
+  AddressFamily address_family() const;
+  bool address_family(AddressFamily value);
+  bool address_family(const char* value);
 
   ConfigValue<RtpsUdpInst, ACE_INT32> send_buffer_size_;
   void send_buffer_size(ACE_INT32 sbs);

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpReceiveStrategy.cpp
@@ -1005,9 +1005,17 @@ int
 RtpsUdpReceiveStrategy::start_i()
 {
   ReactorTask_rch ri = link_->get_reactor_task();
-  ri->execute_or_enqueue(make_rch<RegisterHandler>(link_->unicast_socket().get_handle(), this, static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+  if (link_->unicast_socket().get_handle() != ACE_INVALID_HANDLE) {
+    ri->execute_or_enqueue(make_rch<RegisterHandler>(
+      link_->unicast_socket().get_handle(), this,
+      static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+  }
 #ifdef ACE_HAS_IPV6
-  ri->execute_or_enqueue(make_rch<RegisterHandler>(link_->ipv6_unicast_socket().get_handle(), this, static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+  if (link_->ipv6_unicast_socket().get_handle() != ACE_INVALID_HANDLE) {
+    ri->execute_or_enqueue(make_rch<RegisterHandler>(
+      link_->ipv6_unicast_socket().get_handle(), this,
+      static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+  }
 #endif
 
   return 0;
@@ -1017,16 +1025,32 @@ void
 RtpsUdpReceiveStrategy::stop_i()
 {
   ReactorTask_rch ri = link_->get_reactor_task();
-  ri->execute_or_enqueue(make_rch<RemoveHandler>(link_->unicast_socket().get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+  if (link_->unicast_socket().get_handle() != ACE_INVALID_HANDLE) {
+    ri->execute_or_enqueue(make_rch<RemoveHandler>(
+      link_->unicast_socket().get_handle(),
+      static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+  }
 #ifdef ACE_HAS_IPV6
-  ri->execute_or_enqueue(make_rch<RemoveHandler>(link_->ipv6_unicast_socket().get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+  if (link_->ipv6_unicast_socket().get_handle() != ACE_INVALID_HANDLE) {
+    ri->execute_or_enqueue(make_rch<RemoveHandler>(
+      link_->ipv6_unicast_socket().get_handle(),
+      static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+  }
 #endif
 
   RtpsUdpInst_rch cfg = link_->config();
   if (cfg && cfg->use_multicast()) {
-    ri->execute_or_enqueue(make_rch<RemoveHandler>(link_->multicast_socket().get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    if (link_->multicast_socket().get_handle() != ACE_INVALID_HANDLE) {
+      ri->execute_or_enqueue(make_rch<RemoveHandler>(
+        link_->multicast_socket().get_handle(),
+        static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    }
 #ifdef ACE_HAS_IPV6
-    ri->execute_or_enqueue(make_rch<RemoveHandler>(link_->ipv6_multicast_socket().get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    if (link_->ipv6_multicast_socket().get_handle() != ACE_INVALID_HANDLE) {
+      ri->execute_or_enqueue(make_rch<RemoveHandler>(
+        link_->ipv6_multicast_socket().get_handle(),
+        static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    }
 #endif
   }
 }

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -128,9 +128,17 @@ RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
   {
     if (core_.use_ice()) {
       ReactorTask_rch ri = reactor_task();
-      ri->execute_or_enqueue(make_rch<RemoveHandler>(unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+      if (unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+        ri->execute_or_enqueue(make_rch<RemoveHandler>(
+          unicast_socket_.get_handle(),
+          static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+      }
 #ifdef ACE_HAS_IPV6
-      ri->execute_or_enqueue(make_rch<RemoveHandler>(ipv6_unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+      if (ipv6_unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+        ri->execute_or_enqueue(make_rch<RemoveHandler>(
+          ipv6_unicast_socket_.get_handle(),
+          static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+      }
 #endif
     }
   }
@@ -356,8 +364,15 @@ RtpsUdpTransport::get_connection_addrs(const TransportBLOB& remote,
     ACE_INET_Addr addr;
     // If conversion was successful
     if (locator_to_address(addr, locators[i], false) == 0) {
+      const RtpsUdpInst_rch cfg = config();
+      if (!cfg || (addr.get_type() == AF_INET && !use_ipv4(cfg->address_family()))
+#ifdef ACE_HAS_IPV6
+          || (addr.get_type() == AF_INET6 && !use_ipv6(cfg->address_family()))
+#endif
+          ) {
+        continue;
+      }
       if (addr.is_multicast()) {
-        RtpsUdpInst_rch cfg = config();
         if (cfg && cfg->use_multicast() && mc_addrs) {
           mc_addrs->insert(NetworkAddress(addr));
         }
@@ -658,28 +673,41 @@ RtpsUdpTransport::configure_i(const RtpsUdpInst_rch& config)
     return false;
   }
 
+  if (TheServiceParticipant->config_store()->has(
+        config->config_key("ADDRESS_FAMILY").c_str())) {
+    const String value = TheServiceParticipant->config_store()->get(
+      config->config_key("ADDRESS_FAMILY").c_str(), "");
+    if (!config->address_family(value.c_str())) {
+      return false;
+    }
+  }
+
   // Open the socket here so that any addresses/ports left
   // unspecified in the RtpsUdpInst are known by the time we get to
   // connection_info_i().  Opening the sockets here also allows us to
   // detect and report errors during DataReader/Writer setup instead
   // of during association.
 
-  ACE_INET_Addr actual4;
-  if (!open_socket(config, unicast_socket_, PF_INET, actual4)) {
-    return false;
+  if (use_ipv4(config->address_family())) {
+    ACE_INET_Addr actual4;
+    if (!open_socket(config, unicast_socket_, PF_INET, actual4)) {
+      return false;
+    }
+    core_.actual_local_address(NetworkAddress(actual4));
   }
-  core_.actual_local_address(NetworkAddress(actual4));
 
 #ifdef ACE_HAS_IPV6
-  ACE_INET_Addr actual6;
-  if (!open_socket(config, ipv6_unicast_socket_, PF_INET6, actual6)) {
-    return false;
+  if (use_ipv6(config->address_family())) {
+    ACE_INET_Addr actual6;
+    if (!open_socket(config, ipv6_unicast_socket_, PF_INET6, actual6)) {
+      return false;
+    }
+    NetworkAddress temp(actual6);
+    if (actual6.is_ipv4_mapped_ipv6() && temp.is_any()) {
+      temp = NetworkAddress(actual6.get_port_number(), "::");
+    }
+    core_.ipv6_actual_local_address(temp);
   }
-  NetworkAddress temp(actual6);
-  if (actual6.is_ipv4_mapped_ipv6() && temp.is_any()) {
-    temp = NetworkAddress(actual6.get_port_number(), "::");
-  }
-  core_.ipv6_actual_local_address(temp);
 #endif
 
   create_reactor_task(false, "RtpsUdpTransport" + config->name());
@@ -1051,9 +1079,17 @@ RtpsUdpTransport::start_ice()
 
   if (!link_) {
     ReactorTask_rch ri = reactor_task();
-    ri->execute_or_enqueue(make_rch<RegisterHandler>(unicast_socket_.get_handle(), ice_endpoint_.get(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    if (unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+      ri->execute_or_enqueue(make_rch<RegisterHandler>(
+        unicast_socket_.get_handle(), ice_endpoint_.get(),
+        static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    }
 #ifdef ACE_HAS_IPV6
-    ri->execute_or_enqueue(make_rch<RegisterHandler>(ipv6_unicast_socket_.get_handle(), ice_endpoint_.get(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    if (ipv6_unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+      ri->execute_or_enqueue(make_rch<RegisterHandler>(
+        ipv6_unicast_socket_.get_handle(), ice_endpoint_.get(),
+        static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    }
 #endif
   }
 }
@@ -1069,9 +1105,17 @@ RtpsUdpTransport::stop_ice()
 
   if (!link_) {
     ReactorTask_rch ri = reactor_task();
-    ri->execute_or_enqueue(make_rch<RemoveHandler>(unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    if (unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+      ri->execute_or_enqueue(make_rch<RemoveHandler>(
+        unicast_socket_.get_handle(),
+        static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    }
 #ifdef ACE_HAS_IPV6
-    ri->execute_or_enqueue(make_rch<RemoveHandler>(ipv6_unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    if (ipv6_unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+      ri->execute_or_enqueue(make_rch<RemoveHandler>(
+        ipv6_unicast_socket_.get_handle(),
+        static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    }
 #endif
   }
 

--- a/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
+++ b/dds/DCPS/transport/rtps_udp/RtpsUdpTransport.cpp
@@ -128,9 +128,17 @@ RtpsUdpTransport::make_datalink(const GuidPrefix_t& local_prefix)
   {
     if (core_.use_ice()) {
       ReactorTask_rch ri = reactor_task();
-      ri->execute_or_enqueue(make_rch<RemoveHandler>(unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+      if (unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+        ri->execute_or_enqueue(make_rch<RemoveHandler>(
+          unicast_socket_.get_handle(),
+          static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+      }
 #ifdef ACE_HAS_IPV6
-      ri->execute_or_enqueue(make_rch<RemoveHandler>(ipv6_unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+      if (ipv6_unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+        ri->execute_or_enqueue(make_rch<RemoveHandler>(
+          ipv6_unicast_socket_.get_handle(),
+          static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+      }
 #endif
     }
   }
@@ -356,8 +364,15 @@ RtpsUdpTransport::get_connection_addrs(const TransportBLOB& remote,
     ACE_INET_Addr addr;
     // If conversion was successful
     if (locator_to_address(addr, locators[i], false) == 0) {
+      const RtpsUdpInst_rch cfg = config();
+      if (!cfg || (addr.get_type() == AF_INET && !use_ipv4(cfg->address_family()))
+#ifdef ACE_HAS_IPV6
+          || (addr.get_type() == AF_INET6 && !use_ipv6(cfg->address_family()))
+#endif
+          ) {
+        continue;
+      }
       if (addr.is_multicast()) {
-        RtpsUdpInst_rch cfg = config();
         if (cfg && cfg->use_multicast() && mc_addrs) {
           mc_addrs->insert(NetworkAddress(addr));
         }
@@ -658,28 +673,41 @@ RtpsUdpTransport::configure_i(const RtpsUdpInst_rch& config)
     return false;
   }
 
+  const String address_family_key = config->config_key("ADDRESS_FAMILY");
+  if (TheServiceParticipant->config_store()->has(address_family_key.c_str())) {
+    const String value = TheServiceParticipant->config_store()->get(
+      address_family_key.c_str(), "");
+    if (!config->address_family(value.c_str())) {
+      return false;
+    }
+  }
+
   // Open the socket here so that any addresses/ports left
   // unspecified in the RtpsUdpInst are known by the time we get to
   // connection_info_i().  Opening the sockets here also allows us to
   // detect and report errors during DataReader/Writer setup instead
   // of during association.
 
-  ACE_INET_Addr actual4;
-  if (!open_socket(config, unicast_socket_, PF_INET, actual4)) {
-    return false;
+  if (use_ipv4(config->address_family())) {
+    ACE_INET_Addr actual4;
+    if (!open_socket(config, unicast_socket_, PF_INET, actual4)) {
+      return false;
+    }
+    core_.actual_local_address(NetworkAddress(actual4));
   }
-  core_.actual_local_address(NetworkAddress(actual4));
 
 #ifdef ACE_HAS_IPV6
-  ACE_INET_Addr actual6;
-  if (!open_socket(config, ipv6_unicast_socket_, PF_INET6, actual6)) {
-    return false;
+  if (use_ipv6(config->address_family())) {
+    ACE_INET_Addr actual6;
+    if (!open_socket(config, ipv6_unicast_socket_, PF_INET6, actual6)) {
+      return false;
+    }
+    NetworkAddress temp(actual6);
+    if (actual6.is_ipv4_mapped_ipv6() && temp.is_any()) {
+      temp = NetworkAddress(actual6.get_port_number(), "::");
+    }
+    core_.ipv6_actual_local_address(temp);
   }
-  NetworkAddress temp(actual6);
-  if (actual6.is_ipv4_mapped_ipv6() && temp.is_any()) {
-    temp = NetworkAddress(actual6.get_port_number(), "::");
-  }
-  core_.ipv6_actual_local_address(temp);
 #endif
 
   create_reactor_task(false, "RtpsUdpTransport" + config->name());
@@ -1051,9 +1079,17 @@ RtpsUdpTransport::start_ice()
 
   if (!link_) {
     ReactorTask_rch ri = reactor_task();
-    ri->execute_or_enqueue(make_rch<RegisterHandler>(unicast_socket_.get_handle(), ice_endpoint_.get(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    if (unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+      ri->execute_or_enqueue(make_rch<RegisterHandler>(
+        unicast_socket_.get_handle(), ice_endpoint_.get(),
+        static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    }
 #ifdef ACE_HAS_IPV6
-    ri->execute_or_enqueue(make_rch<RegisterHandler>(ipv6_unicast_socket_.get_handle(), ice_endpoint_.get(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    if (ipv6_unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+      ri->execute_or_enqueue(make_rch<RegisterHandler>(
+        ipv6_unicast_socket_.get_handle(), ice_endpoint_.get(),
+        static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    }
 #endif
   }
 }
@@ -1069,9 +1105,17 @@ RtpsUdpTransport::stop_ice()
 
   if (!link_) {
     ReactorTask_rch ri = reactor_task();
-    ri->execute_or_enqueue(make_rch<RemoveHandler>(unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    if (unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+      ri->execute_or_enqueue(make_rch<RemoveHandler>(
+        unicast_socket_.get_handle(),
+        static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    }
 #ifdef ACE_HAS_IPV6
-    ri->execute_or_enqueue(make_rch<RemoveHandler>(ipv6_unicast_socket_.get_handle(), static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    if (ipv6_unicast_socket_.get_handle() != ACE_INVALID_HANDLE) {
+      ri->execute_or_enqueue(make_rch<RemoveHandler>(
+        ipv6_unicast_socket_.get_handle(),
+        static_cast<ACE_Reactor_Mask>(ACE_Event_Handler::READ_MASK)));
+    }
 #endif
   }
 

--- a/docs/devguide/run_time_configuration.rst
+++ b/docs/devguide/run_time_configuration.rst
@@ -1174,6 +1174,14 @@ Those properties, along with options specific to OpenDDS's RTPS discovery implem
 
 .. sec:: rtps_discovery/<inst_name>
 
+  .. prop:: AddressFamily=ipv4|ipv6|dual
+    :default: ``dual`` when IPv6 support is built, otherwise ``ipv4``
+
+    Selects the network address families used by SPDP and SEDP.  ``ipv4`` and
+    ``ipv6`` restrict discovery sockets and advertised locators to that family.
+    ``dual`` enables every address family available in the build.  Selecting
+    ``ipv6`` in a build without IPv6 support is an error.
+
   .. prop:: ResendPeriod=<sec>
     :default: ``30``
 
@@ -2867,6 +2875,15 @@ Some implementation notes related to using the ``rtps_udp`` transport protocol a
 #. Transport auto-selection (negotiation) is partially supported with RTPS such that the ``rtps_udp`` transport goes through a handshaking phase only in reliable mode.
 
 .. sec:: transport@rtps_udp/<inst_name>
+
+  .. prop:: AddressFamily=ipv4|ipv6|dual
+    :default: ``dual`` when IPv6 support is built, otherwise ``ipv4``
+
+    Selects the network address families used by this transport instance.
+    ``ipv4`` and ``ipv6`` restrict sockets, multicast membership, and advertised
+    and accepted locators to that family.  ``dual`` enables every address family
+    available in the build.  Selecting ``ipv6`` in a build without IPv6 support
+    is an error.  This property is applied when the transport is initialized.
 
   .. prop:: use_multicast=<boolean>
     :default: ``1`` (enabled)

--- a/docs/news.d/5258.rst
+++ b/docs/news.d/5258.rst
@@ -1,0 +1,7 @@
+.. news-prs: 5261
+
+.. news-start-section: Additions
+- RTPS discovery and UDP transports can be restricted to IPv4 or IPv6 using
+  :cfg:prop:`[rtps_discovery]AddressFamily` and
+  :cfg:prop:`[transport@rtps_udp]AddressFamily`.
+.. news-end-section

--- a/docs/news.d/rtps-address-family-selection.rst
+++ b/docs/news.d/rtps-address-family-selection.rst
@@ -1,0 +1,7 @@
+.. news-prs: 5261
+
+.. news-start-section: Additions
+- RTPS discovery and UDP transports can be restricted to IPv4 or IPv6 using
+  :cfg:prop:`[rtps_discovery]AddressFamily` and
+  :cfg:prop:`[transport@rtps_udp]AddressFamily`.
+.. news-end-section

--- a/tests/unit-tests/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
+++ b/tests/unit-tests/dds/DCPS/RTPS/RtpsDiscoveryConfig.cpp
@@ -49,6 +49,31 @@ TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, use_rtps_duration_fraction)
   EXPECT_EQ(0u, t.rtps.participant_flags() & PFLAGS_RTPS_DURATION_FRACTION);
 }
 
+TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, address_family)
+{
+  AddressTest t;
+#ifdef ACE_HAS_IPV6
+  EXPECT_EQ(ADDRESS_FAMILY_DUAL, t.rtps.address_family());
+#else
+  EXPECT_EQ(ADDRESS_FAMILY_IPV4, t.rtps.address_family());
+#endif
+  EXPECT_TRUE(t.rtps.address_family("ipv4"));
+  EXPECT_EQ(ADDRESS_FAMILY_IPV4, t.rtps.address_family());
+#ifdef ACE_HAS_IPV6
+  EXPECT_TRUE(t.rtps.address_family("ipv6"));
+  EXPECT_EQ(ADDRESS_FAMILY_IPV6, t.rtps.address_family());
+#else
+  {
+    LogRestore lr;
+    log_level.set(LogLevel::None);
+    EXPECT_FALSE(t.rtps.address_family("ipv6"));
+  }
+#endif
+  EXPECT_TRUE(t.rtps.address_family("dual"));
+  EXPECT_EQ(ADDRESS_FAMILY_DUAL, t.rtps.address_family());
+  EXPECT_FALSE(t.rtps.address_family("invalid"));
+}
+
 TEST(dds_DCPS_RTPS_RtpsDiscoveryConfig, spdp_unicast_address)
 {
   const char* const default_addr = "0.0.0.0";

--- a/tests/unit-tests/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
+++ b/tests/unit-tests/dds/DCPS/transport/rtps_udp/RtpsUdpInst.cpp
@@ -6,24 +6,24 @@ using namespace OpenDDS::RTPS;
 using namespace OpenDDS::DCPS;
 
 namespace {
-  struct RtpsUdpType {
+  struct RtpsUdpTestContext {
     RcHandle<ConfigStoreImpl> store;
     RcHandle<RtpsUdpInst> rtps_udp;
 
-    RtpsUdpType()
+    RtpsUdpTestContext()
     : store(make_rch<ConfigStoreImpl>(TheServiceParticipant->config_topic(), TheServiceParticipant->time_source()))
     , rtps_udp(make_rch<RtpsUdpInst>("RTPS_UDP_INST_UNIT_TEST", true))
     {
       store->unset_section(rtps_udp->config_prefix());
     }
 
-    ~RtpsUdpType()
+    ~RtpsUdpTestContext()
     {
       store->unset_section(rtps_udp->config_prefix());
     }
   };
 
-  struct AddressTest : public RtpsUdpType {
+  struct AddressTest : public RtpsUdpTestContext {
     NetworkAddress addr;
     bool fixed;
 
@@ -39,6 +39,56 @@ namespace {
   const NetworkAddress fake_ipv6_addr(1234, "::1:2:3:4");
 #endif
 }
+
+TEST(dds_DCPS_RTPS_RtpsUdpInst, address_family)
+{
+  RtpsUdpTestContext t;
+#ifdef ACE_HAS_IPV6
+  EXPECT_EQ(ADDRESS_FAMILY_DUAL, t.rtps_udp->address_family());
+#else
+  EXPECT_EQ(ADDRESS_FAMILY_IPV4, t.rtps_udp->address_family());
+#endif
+  EXPECT_TRUE(t.rtps_udp->address_family("ipv4"));
+  EXPECT_EQ(ADDRESS_FAMILY_IPV4, t.rtps_udp->address_family());
+#ifdef ACE_HAS_IPV6
+  EXPECT_TRUE(t.rtps_udp->address_family("ipv6"));
+  EXPECT_EQ(ADDRESS_FAMILY_IPV6, t.rtps_udp->address_family());
+#else
+  {
+    LogRestore lr;
+    log_level.set(LogLevel::None);
+    EXPECT_FALSE(t.rtps_udp->address_family("ipv6"));
+  }
+#endif
+  EXPECT_TRUE(t.rtps_udp->address_family("dual"));
+  EXPECT_EQ(ADDRESS_FAMILY_DUAL, t.rtps_udp->address_family());
+  EXPECT_FALSE(t.rtps_udp->address_family("invalid"));
+}
+
+#ifdef ACE_HAS_IPV6
+TEST(dds_DCPS_RTPS_RtpsUdpInst, address_family_locators)
+{
+  RtpsUdpTestContext t;
+  TransportLocator info;
+  LocatorSeq locators;
+  VendorId_t vendor;
+
+  ASSERT_TRUE(t.rtps_udp->address_family("ipv4"));
+  EXPECT_EQ(1u, t.rtps_udp->populate_locator(info, CONNINFO_MULTICAST, 0, GUID_UNKNOWN));
+  ASSERT_EQ(DDS::RETCODE_OK, blob_to_locators(info.data, locators, vendor));
+  ASSERT_EQ(1u, locators.length());
+  EXPECT_EQ(OpenDDS::RTPS::LOCATOR_KIND_UDPv4, locators[0].kind);
+
+  ASSERT_TRUE(t.rtps_udp->address_family("ipv6"));
+  EXPECT_EQ(1u, t.rtps_udp->populate_locator(info, CONNINFO_MULTICAST, 0, GUID_UNKNOWN));
+  ASSERT_EQ(DDS::RETCODE_OK, blob_to_locators(info.data, locators, vendor));
+  ASSERT_EQ(1u, locators.length());
+  EXPECT_EQ(OpenDDS::RTPS::LOCATOR_KIND_UDPv6, locators[0].kind);
+
+  ASSERT_TRUE(t.rtps_udp->address_family("dual"));
+  EXPECT_EQ(2u, t.rtps_udp->populate_locator(info, CONNINFO_MULTICAST, 0, GUID_UNKNOWN));
+}
+#endif
 
 TEST(dds_DCPS_RTPS_RtpsUdpInst, multicast_address)
 {


### PR DESCRIPTION
Fixes: #5258

Changes:
- AddressFamily=ipv4|ipv6|dual for RTPS discovery and rtps_udp
- Family-specific socket creation, multicast, locator advertisement, and remote-locator filtering
- SEDP inheritance from discovery configuration
- SPDP family selection
- ICE/reactor handling for inactive sockets
- IPv6 relay, STUN, and SpdpSendAddrs parsing
- Invalid-value and non-IPv6-build validation
- Documentation and news fragment
- Unit tests covering defaults, parsing, and locator families
