### PR TITLE
Fix classic C++ mapping code generation for maps with bounded string keys

### DIFF
--- a/dds/idl/dynamic_data_adapter_generator.cpp
+++ b/dds/idl/dynamic_data_adapter_generator.cpp
@@ -249,8 +249,8 @@ namespace {
         elem = scoped(map_node->key_type()->name());
       }
       const Classification key_cls = classify(map_node->key_type());
-      if ((key_cls & CL_STRING) && be_global->language_mapping() == BE_GlobalData::LANGMAP_CXX11) {
-        elem = (key_cls & CL_WIDE) ? "std::wstring" : "std::string";
+      if (key_cls & CL_STRING) {
+        elem = string_type(key_cls);
       }
       RefWrapper key(map_node->value_type(), elem, "key");
       be_global->impl_ <<

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -932,10 +932,13 @@ namespace {
     } else if (cls & CL_STRING) {
       be_global->impl_ << indent <<
         "primitive_serialized_size_ulong(encoding, size);\n";
+      const bool use_cxx11 = be_global->language_mapping() == BE_GlobalData::LANGMAP_CXX11;
+      const string get_size = use_cxx11 ? accessor + ".size()"
+        : "ACE_OS::strlen(" + accessor + ".in())";
       const string strlen_suffix = (cls & CL_WIDE)
         ? " * char16_cdr_size;\n" : " + 1;\n";
       be_global->impl_ << indent <<
-        "size += " << accessor << ".size()" << strlen_suffix;
+        "size += " << get_size << strlen_suffix;
     } else {
       RefWrapper elem_wrapper(type, cxx_elem, accessor);
       elem_wrapper.nested_key_only_ = nested_key_only;
@@ -968,6 +971,20 @@ namespace {
       be_global->impl_ <<
         streamAndCheck("<< " + member_wrapper.ref(), streamIndent);
     }
+  }
+
+  std::string generate_input_for_map(Classification member_cls, AST_Type* member_type,
+                                     const std::string& accessor, bool use_cxx11)
+  {
+    if (member_cls & CL_STRING) {
+      if (member_cls & CL_BOUNDED) {
+        const string args = accessor + (use_cxx11 ? ", " : ".out(), ")
+          + bounded_arg(member_type);
+        return getWrapper(args, member_type, WD_INPUT);
+      }
+      return accessor + (use_cxx11 ? "" : ".out()");
+    }
+    return accessor;
   }
 
   void gen_map_i(UTL_ScopedName* tdname, AST_Map* map, bool nested_key_only, const FieldInfo* anonymous = 0)
@@ -1010,11 +1027,11 @@ namespace {
       val_cxx_elem = scoped(val->name());
     }
     const bool use_cxx11 = be_global->language_mapping() == BE_GlobalData::LANGMAP_CXX11;
-    if ((key_cls & CL_STRING) && use_cxx11) {
-      key_cxx_elem = (key_cls & CL_WIDE) ? "std::wstring" : "std::string";
+    if (key_cls & CL_STRING) {
+      key_cxx_elem = string_type(key_cls);
     }
-    if ((val_cls & CL_STRING) && use_cxx11) {
-      val_cxx_elem = (val_cls & CL_WIDE) ? "std::wstring" : "std::string";
+    if (val_cls & CL_STRING) {
+      val_cxx_elem = string_type(val_cls);
     }
 
     RefWrapper(base_wrapper).done().generate_tag();
@@ -1140,14 +1157,16 @@ namespace {
       }
 
       static const size_t loopIndent = 4;
+      const std::string key_input = generate_input_for_map(key_cls, key, "key", use_cxx11);
+      const std::string val_input = generate_input_for_map(val_cls, val, "val", use_cxx11);
       be_global->impl_ <<
         "  " << wrapper.value_access() << ".clear();\n" <<
         (may_skip ? "  bool skip = false;\n" : "") <<
         "  for (DDS::UInt32 read = 0; read < size;) {\n"
         "    " << key_cxx_elem << " key;\n" <<
-        streamAndCheck(">> key", loopIndent) <<
+        streamAndCheck(">> " + key_input, loopIndent) <<
         "    " << val_cxx_elem << " val;\n" <<
-        streamAndCheck(">> val", loopIndent, valFailureHandler) <<
+        streamAndCheck(">> " + val_input, loopIndent, valFailureHandler) <<
         (may_skip ?
         "    if (!skip) {\n  "
         : "") <<

--- a/dds/idl/value_reader_generator.cpp
+++ b/dds/idl/value_reader_generator.cpp
@@ -145,7 +145,7 @@ namespace {
     const Classification clsKey = classify(actualKey);
     const std::string key_tk = type_kind(map->key_type()),
       value_tk = type_kind(map->value_type()),
-      localKeyType = (clsKey & CL_STRING) ? "String" : scoped(map->key_type()->name()),
+      localKeyType = (clsKey & CL_STRING) ? string_type(clsKey) : scoped(map->key_type()->name()),
       keyName = "key" + OpenDDS::DCPS::to_dds_string(level);
     be_global->impl_ <<
       indent << "if (!value_reader.begin_map(" << key_tk << ", " << value_tk << ")) return false;\n" <<

--- a/tests/DCPS/Compiler/maps/CMakeLists.txt
+++ b/tests/DCPS/Compiler/maps/CMakeLists.txt
@@ -20,5 +20,7 @@ target_link_libraries(${PROJECT_NAME}
   OpenDDS_TestUtils
 )
 
+add_subdirectory(classic)
+
 configure_file(run_test.pl . COPYONLY)
 opendds_add_test(COMMAND perl run_test.pl)

--- a/tests/DCPS/Compiler/maps/classic/CMakeLists.txt
+++ b/tests/DCPS/Compiler/maps/classic/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.8...4.0)
+project(opendds_compiler_maps_classic CXX)
+enable_testing()
+
+find_package(OpenDDS REQUIRED)
+include(opendds_testing)
+
+set(target_prefix "${PROJECT_NAME}_")
+
+set(idl "${target_prefix}idl")
+add_library(${idl})
+opendds_target_sources(${idl}
+  PUBLIC
+    test.idl
+  TAO_IDL_OPTIONS -St
+)
+target_link_libraries(${idl} PUBLIC OpenDDS::Dcps)
+
+set(exe "${target_prefix}exe")
+add_executable(${exe} main.cpp)
+set_target_properties(${exe} PROPERTIES OUTPUT_NAME maps_classic)
+target_link_libraries(${exe} OpenDDS::Dcps ${idl})
+
+opendds_add_test(
+  NAME roundtrip
+  COMMAND $<TARGET_FILE:${exe}>
+  EXTRA_LIB_DIRS "${CMAKE_CURRENT_BINARY_DIR}"
+)

--- a/tests/DCPS/Compiler/maps/classic/main.cpp
+++ b/tests/DCPS/Compiler/maps/classic/main.cpp
@@ -1,0 +1,45 @@
+#include <testTypeSupportImpl.h>
+
+#include <dds/DCPS/Message_Block_Ptr.h>
+#include <dds/DCPS/Serializer.h>
+
+#include <ace/OS_main.h>
+
+#include <cstring>
+#include <iostream>
+
+using namespace OpenDDS::DCPS;
+
+int ACE_TMAIN(int, ACE_TCHAR*[])
+{
+  test::ClassicMapStringKey value;
+  value.map_probe["alpha"] = 42;
+
+  const Encoding encoding(Encoding::KIND_XCDR2);
+  Message_Block_Ptr buffer(new ACE_Message_Block(serialized_size(encoding, value)));
+  Serializer writer(buffer.get(), encoding);
+  if (!(writer << value)) {
+    std::cerr << "serialize failed\n";
+    return 1;
+  }
+
+  test::ClassicMapStringKey roundtrip;
+  Serializer reader(buffer.get(), encoding);
+  if (!(reader >> roundtrip)) {
+    std::cerr << "deserialize failed\n";
+    return 1;
+  }
+
+  if (roundtrip.map_probe.size() != 1) {
+    std::cerr << "unexpected map size\n";
+    return 1;
+  }
+
+  const test::ClassicMapStringKey::_map_probe_map::const_iterator it = roundtrip.map_probe.find("alpha");
+  if (it == roundtrip.map_probe.end() || std::strcmp(it->first.in(), "alpha") != 0 || it->second != 42) {
+    std::cerr << "roundtrip mismatch\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/tests/DCPS/Compiler/maps/classic/test.idl
+++ b/tests/DCPS/Compiler/maps/classic/test.idl
@@ -1,0 +1,5 @@
+module test {
+  struct ClassicMapStringKey {
+    map<string<8>, long, 4> map_probe;
+  };
+};


### PR DESCRIPTION
Title:
Fix classic C++ mapping code generation for maps with bounded string keys
Fixes #5263
Summary:
This fixes OpenDDS IDL code generation for classic C++ mapping when a map uses a bounded string as its key, for example:

```idl
module test {
  struct ClassicMapStringKey {
    map<string<8>, long, 4> map_probe;
  };
};
```
Before this change, generated TypeSupport code used C++11/string-style assumptions in classic mapping code paths. This caused generated C++ to fail to compile due to mismatches between OpenDDS::DCPS::String, raw string expressions, and the actual TAO classic mapping type TAO::String_Manager.
Fixes:
Use string_type() for map string key/value temporary types so classic mapping uses TAO::String_Manager / TAO::WString_Manager.
Use .in() for classic string serialized-size calculations instead of .size().
Use .out() with ACE CDR bounded string extraction for classic map string keys/values.
Fix DynamicData adapter map key helper generation for classic string keys.
Add a classic mapping regression test for map<string<8>, long, 4>.
Verification:
Rebuilt opendds_idl.
Regenerated TypeSupport for the new classic map test.
Confirmed generated code now uses TAO::String_Manager and ACE_InputCDR::to_string(key.out(), 8).
Compiled the generated TypeSupport and regression main.
Ran the round-trip regression executable successfully.
Also regenerated and compiled the existing C++11 maps TypeSupport to check for regression.
Note:
The regression test uses TAO_IDL_OPTIONS -St to avoid an independent TAO TypeCode generation issue for IDL maps. This PR is scoped to OpenDDS TypeSupport/codegen for classic map string keys.