### PR TITLE
Add reproducer for intermittent SHM post-match delivery failure

### DIFF
--- a/tests/DCPS/ShmemWakeupRace/.gitignore
+++ b/tests/DCPS/ShmemWakeupRace/.gitignore
@@ -1,0 +1,17 @@
+/GNUmakefile.ShmemWakeupRace_Publisher
+/GNUmakefile.ShmemWakeupRace_Subscriber
+/ShmemWakeupRaceC.cpp
+/ShmemWakeupRaceC.h
+/ShmemWakeupRaceC.inl
+/ShmemWakeupRaceS.cpp
+/ShmemWakeupRaceS.h
+/ShmemWakeupRaceTypeSupport.idl
+/ShmemWakeupRaceTypeSupportC.cpp
+/ShmemWakeupRaceTypeSupportC.h
+/ShmemWakeupRaceTypeSupportC.inl
+/ShmemWakeupRaceTypeSupportImpl.cpp
+/ShmemWakeupRaceTypeSupportImpl.h
+/ShmemWakeupRaceTypeSupportS.cpp
+/ShmemWakeupRaceTypeSupportS.h
+/publisher
+/subscriber

--- a/tests/DCPS/ShmemWakeupRace/MatchBarrier.h
+++ b/tests/DCPS/ShmemWakeupRace/MatchBarrier.h
@@ -1,0 +1,81 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#ifndef SHMEM_WAKEUP_RACE_MATCH_BARRIER_H
+#define SHMEM_WAKEUP_RACE_MATCH_BARRIER_H
+
+#include <dds/DCPS/WaitSet.h>
+
+#include <ace/OS_NS_unistd.h>
+#include <ace/Time_Value.h>
+
+namespace ShmemWakeupRace {
+
+inline bool wait_for_match(DDS::DataWriter_ptr writer)
+{
+  DDS::PublicationMatchedStatus match_status;
+  if (writer->get_publication_matched_status(match_status) != DDS::RETCODE_OK) {
+    return false;
+  }
+  if (match_status.current_count >= 1) {
+    return true;
+  }
+
+  DDS::StatusCondition_var condition = writer->get_statuscondition();
+  if (condition->set_enabled_statuses(DDS::PUBLICATION_MATCHED_STATUS) != DDS::RETCODE_OK) {
+    return false;
+  }
+  DDS::WaitSet_var wait_set = new DDS::WaitSet;
+  if (wait_set->attach_condition(condition.in()) != DDS::RETCODE_OK) {
+    return false;
+  }
+
+  DDS::ConditionSeq active;
+  const DDS::Duration_t timeout = { 5, 0 };
+  const DDS::ReturnCode_t wait_result = wait_set->wait(active, timeout);
+  const DDS::ReturnCode_t detach_result = wait_set->detach_condition(condition.in());
+  return wait_result == DDS::RETCODE_OK && detach_result == DDS::RETCODE_OK &&
+    writer->get_publication_matched_status(match_status) == DDS::RETCODE_OK &&
+    match_status.current_count >= 1;
+}
+
+inline bool wait_for_match(DDS::DataReader_ptr reader)
+{
+  DDS::SubscriptionMatchedStatus match_status;
+  if (reader->get_subscription_matched_status(match_status) != DDS::RETCODE_OK) {
+    return false;
+  }
+  if (match_status.current_count >= 1) {
+    return true;
+  }
+
+  DDS::StatusCondition_var condition = reader->get_statuscondition();
+  if (condition->set_enabled_statuses(DDS::SUBSCRIPTION_MATCHED_STATUS) != DDS::RETCODE_OK) {
+    return false;
+  }
+  DDS::WaitSet_var wait_set = new DDS::WaitSet;
+  if (wait_set->attach_condition(condition.in()) != DDS::RETCODE_OK) {
+    return false;
+  }
+
+  DDS::ConditionSeq active;
+  const DDS::Duration_t timeout = { 5, 0 };
+  const DDS::ReturnCode_t wait_result = wait_set->wait(active, timeout);
+  const DDS::ReturnCode_t detach_result = wait_set->detach_condition(condition.in());
+  return wait_result == DDS::RETCODE_OK && detach_result == DDS::RETCODE_OK &&
+    reader->get_subscription_matched_status(match_status) == DDS::RETCODE_OK &&
+    match_status.current_count >= 1;
+}
+
+inline void settle_after_matches()
+{
+  ACE_OS::sleep(ACE_Time_Value(1, 200000));
+}
+
+}
+
+#endif

--- a/tests/DCPS/ShmemWakeupRace/README.rst
+++ b/tests/DCPS/ShmemWakeupRace/README.rst
@@ -1,17 +1,24 @@
-######################
-SHM Wakeup Race MWE
-######################
+###########################
+SHM Post-Match Delivery MWE
+###########################
 
 This is a two-process minimum working example for an OpenDDS shared-memory
-transport wakeup race. It uses only public DDS APIs, RTPS discovery, and
-best-effort writers and readers. An RTPS/UDP control uses the same executable,
-discovery configuration, QoS, and timing.
+transport delivery failure after endpoint matching. It uses only public DDS
+APIs, RTPS discovery, and best-effort writers and readers. An RTPS/UDP control
+uses the same executable, discovery configuration, QoS, and timing.
 
 The ping process creates a writer for the ping topic and a reader for the pong
 topic. The pong process creates a reader for ping and a writer for pong. Both
-processes wait for their writer and reader matches, followed by a fixed settle
-interval. Ping then writes exactly one sample and waits a bounded time for its
-echo. A missing request or reply makes the test fail.
+processes wait for their writer and reader matches, followed by a 1.2-second
+settle interval. Ping then writes exactly one sample and waits a bounded time
+for its echo. A missing request or reply makes the test fail.
+
+Generate and build the test from this directory with::
+
+  source ../../../setenv.sh
+  "$MPC_ROOT/mpc.pl" -type gnuace ShmemWakeupRace.mpc
+  make -f GNUmakefile.ShmemWakeupRace_Publisher
+  make -f GNUmakefile.ShmemWakeupRace_Subscriber
 
 Run one trial with::
 
@@ -25,14 +32,19 @@ Run the transport control with::
 
   perl run_test.pl transport=rtps_udp trials=20
 
+On Linux, repeated SHM trials may leave detached System V shared-memory
+segments. After running many trials, inspect them with ``ipcs -m`` and remove
+only segments known to belong to this test. Other applications on the same
+host may also be using System V shared memory.
+
 A healthy control reports ``failed trials: 0/N`` and exits with status zero.
 The SHM defect is reproduced when one or more fresh process pairs time out
 after both directions report matched endpoints. The launcher reports the
 number of failed trials and exits nonzero in that case.
 
-The test deliberately sends no second application sample. In the investigated
-failure mode, a later SHM notification can make an earlier stranded sample
-visible and hide the problem.
+The test deliberately sends no second application sample. A later SHM
+notification could make an earlier stranded sample visible and hide the
+observed timeout.
 
 This MWE is not a deterministic CI regression test. Public DDS APIs do not
 control the internal ordering between a remote SHM notification and local

--- a/tests/DCPS/ShmemWakeupRace/README.rst
+++ b/tests/DCPS/ShmemWakeupRace/README.rst
@@ -3,22 +3,32 @@ SHM Wakeup Race MWE
 ######################
 
 This is a two-process minimum working example for an OpenDDS shared-memory
-transport wakeup race. It uses only public DDS APIs, RTPS discovery, and a
-best-effort writer and reader.
+transport wakeup race. It uses only public DDS APIs, RTPS discovery, and
+best-effort writers and readers. An RTPS/UDP control uses the same executable,
+discovery configuration, QoS, and timing.
 
 The ping process creates a writer for the ping topic and a reader for the pong
-topic. The pong process creates a reader for ping and a writer for pong. Ping
-waits until its writer observes one matched reader, writes exactly one sample,
-and waits a bounded time for its echo. A missing request or reply makes the
-test fail.
+topic. The pong process creates a reader for ping and a writer for pong. Both
+processes wait for their writer and reader matches, followed by a fixed settle
+interval. Ping then writes exactly one sample and waits a bounded time for its
+echo. A missing request or reply makes the test fail.
 
 Run one trial with::
 
-  perl run_test.pl
+  perl run_test.pl transport=shmem
 
 Run multiple fresh process pairs to measure the failure rate with::
 
-  perl run_test.pl trials=20
+  perl run_test.pl transport=shmem trials=20
+
+Run the transport control with::
+
+  perl run_test.pl transport=rtps_udp trials=20
+
+A healthy control reports ``failed trials: 0/N`` and exits with status zero.
+The SHM defect is reproduced when one or more fresh process pairs time out
+after both directions report matched endpoints. The launcher reports the
+number of failed trials and exits nonzero in that case.
 
 The test deliberately sends no second application sample. In the investigated
 failure mode, a later SHM notification can make an earlier stranded sample
@@ -32,4 +42,6 @@ evidence that the transport is fixed.
 Best-effort QoS does not guarantee delivery, so this test alone does not claim
 an OMG DDS reliability-contract violation. It demonstrates an association-
 adjacent missing request or reply in a same-host SHM ping/pong exchange after
-the request writer has observed a match and accepted its write.
+both directions have observed endpoint matches and the request writer has
+accepted its write. The RTPS/UDP control distinguishes this from a generic
+startup or bidirectional-association failure.

--- a/tests/DCPS/ShmemWakeupRace/README.rst
+++ b/tests/DCPS/ShmemWakeupRace/README.rst
@@ -1,0 +1,35 @@
+######################
+SHM Wakeup Race MWE
+######################
+
+This is a two-process minimum working example for an OpenDDS shared-memory
+transport wakeup race. It uses only public DDS APIs, RTPS discovery, and a
+best-effort writer and reader.
+
+The ping process creates a writer for the ping topic and a reader for the pong
+topic. The pong process creates a reader for ping and a writer for pong. Ping
+waits until its writer observes one matched reader, writes exactly one sample,
+and waits a bounded time for its echo. A missing request or reply makes the
+test fail.
+
+Run one trial with::
+
+  perl run_test.pl
+
+Run multiple fresh process pairs to measure the failure rate with::
+
+  perl run_test.pl trials=20
+
+The test deliberately sends no second application sample. In the investigated
+failure mode, a later SHM notification can make an earlier stranded sample
+visible and hide the problem.
+
+This MWE is not a deterministic CI regression test. Public DDS APIs do not
+control the internal ordering between a remote SHM notification and local
+DataLink registration, so a passing trial is a non-reproduction rather than
+evidence that the transport is fixed.
+
+Best-effort QoS does not guarantee delivery, so this test alone does not claim
+an OMG DDS reliability-contract violation. It demonstrates an association-
+adjacent missing request or reply in a same-host SHM ping/pong exchange after
+the request writer has observed a match and accepted its write.

--- a/tests/DCPS/ShmemWakeupRace/ShmemWakeupRace.idl
+++ b/tests/DCPS/ShmemWakeupRace/ShmemWakeupRace.idl
@@ -1,0 +1,19 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+module ShmemWakeupRace {
+
+  const long DOMAIN = 113;
+
+  @topic
+  struct Sample {
+    long sample_id;
+  };
+
+  const string PING_TOPIC_NAME = "ShmemWakeupRacePing";
+  const string PONG_TOPIC_NAME = "ShmemWakeupRacePong";
+};

--- a/tests/DCPS/ShmemWakeupRace/ShmemWakeupRace.idl
+++ b/tests/DCPS/ShmemWakeupRace/ShmemWakeupRace.idl
@@ -7,7 +7,7 @@
 
 module ShmemWakeupRace {
 
-  const long DOMAIN = 113;
+  const long DOMAIN_ID = 228;
 
   @topic
   struct Sample {

--- a/tests/DCPS/ShmemWakeupRace/ShmemWakeupRace.mpc
+++ b/tests/DCPS/ShmemWakeupRace/ShmemWakeupRace.mpc
@@ -1,0 +1,24 @@
+project(*Publisher) : dcpsexe, dcps_test, dcps_rtps_udp, dcps_shmem {
+  exename = publisher
+
+  TypeSupport_Files {
+    ShmemWakeupRace.idl
+  }
+
+  Source_Files {
+    publisher.cpp
+  }
+}
+
+project(*Subscriber) : dcpsexe, dcps_test, dcps_rtps_udp, dcps_shmem {
+  exename = subscriber
+  after += *Publisher
+
+  TypeSupport_Files {
+    ShmemWakeupRace.idl
+  }
+
+  Source_Files {
+    subscriber.cpp
+  }
+}

--- a/tests/DCPS/ShmemWakeupRace/publisher.cpp
+++ b/tests/DCPS/ShmemWakeupRace/publisher.cpp
@@ -25,7 +25,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   DDS::DomainParticipantFactory_var domain_participant_factory =
     TheParticipantFactoryWithArgs(argc, argv);
   DDS::DomainParticipant_var participant =
-    domain_participant_factory->create_participant(ShmemWakeupRace::DOMAIN,
+    domain_participant_factory->create_participant(ShmemWakeupRace::DOMAIN_ID,
                                                    PARTICIPANT_QOS_DEFAULT,
                                                    0,
                                                    0);
@@ -90,8 +90,13 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
               std::cout << "Ping: wrote sample 1" << std::endl;
               DDS::ConditionSeq conditions;
               const DDS::Duration_t timeout = { 5, 0 };
-              if (wait_set->wait(conditions, timeout) != DDS::RETCODE_OK) {
+              const DDS::ReturnCode_t wait_result = wait_set->wait(conditions, timeout);
+              if (wait_result == DDS::RETCODE_TIMEOUT) {
                 std::cerr << "Ping: timed out waiting for pong" << std::endl;
+                status = 1;
+              } else if (wait_result != DDS::RETCODE_OK) {
+                std::cerr << "Ping: waiting for pong failed with return code "
+                          << static_cast<int>(wait_result) << std::endl;
                 status = 1;
               } else {
                 ShmemWakeupRace::SampleSeq samples;
@@ -123,7 +128,14 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
                 }
               }
             }
-            wait_set->detach_condition(read_condition.in());
+            if (wait_set->detach_condition(read_condition.in()) != DDS::RETCODE_OK) {
+              std::cerr << "Ping: detach_condition failed" << std::endl;
+              status = 1;
+            }
+          }
+          if (reader->delete_readcondition(read_condition.in()) != DDS::RETCODE_OK) {
+            std::cerr << "Ping: delete_readcondition failed" << std::endl;
+            status = 1;
           }
         }
       }

--- a/tests/DCPS/ShmemWakeupRace/publisher.cpp
+++ b/tests/DCPS/ShmemWakeupRace/publisher.cpp
@@ -1,0 +1,170 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "ShmemWakeupRaceTypeSupportImpl.h"
+
+#include <dds/DCPS/Marked_Default_Qos.h>
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/StaticIncludes.h>
+#include <dds/DCPS/WaitSet.h>
+#ifdef ACE_AS_STATIC_LIBS
+#  include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
+
+#include <iostream>
+
+namespace {
+
+bool wait_for_match(DDS::DataWriter_ptr writer)
+{
+  DDS::PublicationMatchedStatus match_status;
+  if (writer->get_publication_matched_status(match_status) != DDS::RETCODE_OK) {
+    return false;
+  }
+  if (match_status.current_count >= 1) {
+    return true;
+  }
+
+  DDS::StatusCondition_var status_condition = writer->get_statuscondition();
+  if (status_condition->set_enabled_statuses(DDS::PUBLICATION_MATCHED_STATUS) != DDS::RETCODE_OK) {
+    return false;
+  }
+  DDS::WaitSet_var wait_set = new DDS::WaitSet;
+  if (wait_set->attach_condition(status_condition.in()) != DDS::RETCODE_OK) {
+    return false;
+  }
+
+  DDS::ConditionSeq conditions;
+  const DDS::Duration_t timeout = { 5, 0 };
+  const DDS::ReturnCode_t wait_result = wait_set->wait(conditions, timeout);
+  const DDS::ReturnCode_t detach_result = wait_set->detach_condition(status_condition.in());
+  if (wait_result != DDS::RETCODE_OK || detach_result != DDS::RETCODE_OK ||
+      writer->get_publication_matched_status(match_status) != DDS::RETCODE_OK) {
+    return false;
+  }
+  return match_status.current_count >= 1;
+}
+
+}
+
+int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
+{
+  int status = 0;
+  DDS::DomainParticipantFactory_var domain_participant_factory =
+    TheParticipantFactoryWithArgs(argc, argv);
+  DDS::DomainParticipant_var participant =
+    domain_participant_factory->create_participant(ShmemWakeupRace::DOMAIN,
+                                                   PARTICIPANT_QOS_DEFAULT,
+                                                   0,
+                                                   0);
+
+  if (CORBA::is_nil(participant.in())) {
+    std::cerr << "Ping: create_participant failed" << std::endl;
+    status = 1;
+  } else {
+    ShmemWakeupRace::SampleTypeSupport_var type_support =
+      new ShmemWakeupRace::SampleTypeSupportImpl;
+    if (type_support->register_type(participant.in(), "") != DDS::RETCODE_OK) {
+      std::cerr << "Ping: register_type failed" << std::endl;
+      status = 1;
+    } else {
+      CORBA::String_var type_name = type_support->get_type_name();
+      DDS::Topic_var ping_topic = participant->create_topic(
+        ShmemWakeupRace::PING_TOPIC_NAME, type_name.in(), TOPIC_QOS_DEFAULT, 0, 0);
+      DDS::Topic_var pong_topic = participant->create_topic(
+        ShmemWakeupRace::PONG_TOPIC_NAME, type_name.in(), TOPIC_QOS_DEFAULT, 0, 0);
+      DDS::Publisher_var publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT, 0, 0);
+      DDS::Subscriber_var subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, 0, 0);
+      if (CORBA::is_nil(ping_topic.in()) || CORBA::is_nil(pong_topic.in()) ||
+          CORBA::is_nil(publisher.in()) || CORBA::is_nil(subscriber.in())) {
+        std::cerr << "Ping: topic, publisher, or subscriber creation failed" << std::endl;
+        status = 1;
+      } else {
+        DDS::DataWriterQos writer_qos;
+        publisher->get_default_datawriter_qos(writer_qos);
+        writer_qos.reliability.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
+        DDS::DataReaderQos reader_qos;
+        subscriber->get_default_datareader_qos(reader_qos);
+        reader_qos.reliability.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
+        DDS::DataWriter_var writer = publisher->create_datawriter(ping_topic.in(), writer_qos, 0, 0);
+        DDS::DataReader_var reader = subscriber->create_datareader(pong_topic.in(), reader_qos, 0, 0);
+        ShmemWakeupRace::SampleDataWriter_var sample_writer =
+          ShmemWakeupRace::SampleDataWriter::_narrow(writer.in());
+        ShmemWakeupRace::SampleDataReader_var sample_reader =
+          ShmemWakeupRace::SampleDataReader::_narrow(reader.in());
+        if (CORBA::is_nil(sample_writer.in()) || CORBA::is_nil(sample_reader.in())) {
+          std::cerr << "Ping: create_datawriter or create_datareader failed" << std::endl;
+          status = 1;
+        } else if (!wait_for_match(writer.in())) {
+          std::cerr << "Ping: waiting for pong match failed" << std::endl;
+          status = 1;
+        } else {
+          std::cout << "Ping: matched pong reader" << std::endl;
+          DDS::ReadCondition_var read_condition = reader->create_readcondition(
+            DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
+          DDS::WaitSet_var wait_set = new DDS::WaitSet;
+          if (wait_set->attach_condition(read_condition.in()) != DDS::RETCODE_OK) {
+            std::cerr << "Ping: attach_condition failed" << std::endl;
+            status = 1;
+          } else {
+            ShmemWakeupRace::Sample sample;
+            sample.sample_id = 1;
+            if (sample_writer->write(sample, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
+              std::cerr << "Ping: write failed" << std::endl;
+              status = 1;
+            } else {
+              std::cout << "Ping: wrote sample 1" << std::endl;
+              DDS::ConditionSeq conditions;
+              const DDS::Duration_t timeout = { 5, 0 };
+              if (wait_set->wait(conditions, timeout) != DDS::RETCODE_OK) {
+                std::cerr << "Ping: timed out waiting for pong" << std::endl;
+                status = 1;
+              } else {
+                ShmemWakeupRace::SampleSeq samples;
+                DDS::SampleInfoSeq sample_infos;
+                const DDS::ReturnCode_t take_result = sample_reader->take(
+                  samples, sample_infos, DDS::LENGTH_UNLIMITED,
+                  DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
+                bool received = false;
+                bool return_loan_failed = false;
+                if (take_result == DDS::RETCODE_OK) {
+                  for (CORBA::ULong i = 0; i < samples.length(); ++i) {
+                    if (sample_infos[i].valid_data && samples[i].sample_id == 1) {
+                      received = true;
+                      break;
+                    }
+                  }
+                  if (sample_reader->return_loan(samples, sample_infos) != DDS::RETCODE_OK) {
+                    std::cerr << "Ping: return_loan failed" << std::endl;
+                    return_loan_failed = true;
+                  }
+                }
+                if (return_loan_failed) {
+                  status = 1;
+                } else if (!received) {
+                  std::cerr << "Ping: did not receive pong sample 1" << std::endl;
+                  status = 1;
+                } else {
+                  std::cout << "Ping: received pong sample 1" << std::endl;
+                }
+              }
+            }
+            wait_set->detach_condition(read_condition.in());
+          }
+        }
+      }
+    }
+  }
+
+  if (!CORBA::is_nil(participant.in())) {
+    participant->delete_contained_entities();
+    domain_participant_factory->delete_participant(participant.in());
+  }
+  TheServiceParticipant->shutdown();
+  return status;
+}

--- a/tests/DCPS/ShmemWakeupRace/publisher.cpp
+++ b/tests/DCPS/ShmemWakeupRace/publisher.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "ShmemWakeupRaceTypeSupportImpl.h"
+#include "MatchBarrier.h"
 
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/Service_Participant.h>
@@ -17,40 +18,6 @@
 #endif
 
 #include <iostream>
-
-namespace {
-
-bool wait_for_match(DDS::DataWriter_ptr writer)
-{
-  DDS::PublicationMatchedStatus match_status;
-  if (writer->get_publication_matched_status(match_status) != DDS::RETCODE_OK) {
-    return false;
-  }
-  if (match_status.current_count >= 1) {
-    return true;
-  }
-
-  DDS::StatusCondition_var status_condition = writer->get_statuscondition();
-  if (status_condition->set_enabled_statuses(DDS::PUBLICATION_MATCHED_STATUS) != DDS::RETCODE_OK) {
-    return false;
-  }
-  DDS::WaitSet_var wait_set = new DDS::WaitSet;
-  if (wait_set->attach_condition(status_condition.in()) != DDS::RETCODE_OK) {
-    return false;
-  }
-
-  DDS::ConditionSeq conditions;
-  const DDS::Duration_t timeout = { 5, 0 };
-  const DDS::ReturnCode_t wait_result = wait_set->wait(conditions, timeout);
-  const DDS::ReturnCode_t detach_result = wait_set->detach_condition(status_condition.in());
-  if (wait_result != DDS::RETCODE_OK || detach_result != DDS::RETCODE_OK ||
-      writer->get_publication_matched_status(match_status) != DDS::RETCODE_OK) {
-    return false;
-  }
-  return match_status.current_count >= 1;
-}
-
-}
 
 int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
 {
@@ -100,11 +67,13 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
         if (CORBA::is_nil(sample_writer.in()) || CORBA::is_nil(sample_reader.in())) {
           std::cerr << "Ping: create_datawriter or create_datareader failed" << std::endl;
           status = 1;
-        } else if (!wait_for_match(writer.in())) {
-          std::cerr << "Ping: waiting for pong match failed" << std::endl;
+        } else if (!ShmemWakeupRace::wait_for_match(writer.in()) ||
+                   !ShmemWakeupRace::wait_for_match(reader.in())) {
+          std::cerr << "Ping: waiting for endpoint matches failed" << std::endl;
           status = 1;
         } else {
-          std::cout << "Ping: matched pong reader" << std::endl;
+          std::cout << "Ping: matched pong reader and writer" << std::endl;
+          ShmemWakeupRace::settle_after_matches();
           DDS::ReadCondition_var read_condition = reader->create_readcondition(
             DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
           DDS::WaitSet_var wait_set = new DDS::WaitSet;

--- a/tests/DCPS/ShmemWakeupRace/rtps_udp.ini
+++ b/tests/DCPS/ShmemWakeupRace/rtps_udp.ini
@@ -1,7 +1,7 @@
 [common]
 DCPSGlobalTransportConfig=$file
 
-[domain/113]
+[domain/228]
 DiscoveryConfig=uni_rtps
 
 [rtps_discovery/uni_rtps]

--- a/tests/DCPS/ShmemWakeupRace/rtps_udp.ini
+++ b/tests/DCPS/ShmemWakeupRace/rtps_udp.ini
@@ -1,0 +1,14 @@
+[common]
+DCPSGlobalTransportConfig=$file
+
+[domain/113]
+DiscoveryConfig=uni_rtps
+
+[rtps_discovery/uni_rtps]
+SedpMulticast=0
+ResendPeriod=2
+
+[transport/rtps_udp]
+transport_type=rtps_udp
+rcv_buffer_size=16777216
+send_buffer_size=16777216

--- a/tests/DCPS/ShmemWakeupRace/run_test.pl
+++ b/tests/DCPS/ShmemWakeupRace/run_test.pl
@@ -1,0 +1,42 @@
+eval '(exit $?0)' && eval 'exec perl -S $0 ${1+"$@"}'
+    & eval 'exec perl -S $0 $argv:q'
+    if 0;
+
+# -*- perl -*-
+
+use Env (ACE_ROOT, DDS_ROOT);
+use lib "$ACE_ROOT/bin";
+use lib "$DDS_ROOT/bin";
+use PerlDDS::Run_Test;
+use strict;
+use warnings;
+
+my $trials = 1;
+for my $arg (@ARGV) {
+  if ($arg =~ /^trials=(\d+)$/ && $1 > 0) {
+    $trials = $1;
+  } else {
+    die "Usage: $0 [trials=<positive integer>]\n";
+  }
+}
+
+my $failed = 0;
+for my $trial (1 .. $trials) {
+  print "ShmemWakeupRace trial $trial of $trials\n";
+
+  my $test = new PerlDDS::TestFramework();
+  $test->process('subscriber', 'subscriber',
+                 '-DCPSConfigFile shmem_rtps.ini -DCPSDebugLevel 0 -DCPSTransportDebugLevel 0');
+  $test->process('publisher', 'publisher',
+                 '-DCPSConfigFile shmem_rtps.ini -DCPSDebugLevel 0 -DCPSTransportDebugLevel 0');
+
+  $test->start_process('subscriber');
+  $test->start_process('publisher');
+
+  if ($test->finish(15)) {
+    ++$failed;
+  }
+}
+
+print "ShmemWakeupRace failed trials: $failed/$trials\n";
+exit($failed ? 1 : 0);

--- a/tests/DCPS/ShmemWakeupRace/run_test.pl
+++ b/tests/DCPS/ShmemWakeupRace/run_test.pl
@@ -12,31 +12,35 @@ use strict;
 use warnings;
 
 my $trials = 1;
+my $transport = 'shmem';
 for my $arg (@ARGV) {
   if ($arg =~ /^trials=(\d+)$/ && $1 > 0) {
     $trials = $1;
+  } elsif ($arg =~ /^transport=(shmem|rtps_udp)$/) {
+    $transport = $1;
   } else {
-    die "Usage: $0 [trials=<positive integer>]\n";
+    die "Usage: $0 [trials=<positive integer>] [transport=shmem|rtps_udp]\n";
   }
 }
 
+my $config = $transport eq 'shmem' ? 'shmem_rtps.ini' : 'rtps_udp.ini';
 my $failed = 0;
 for my $trial (1 .. $trials) {
-  print "ShmemWakeupRace trial $trial of $trials\n";
+  print "ShmemWakeupRace transport=$transport trial $trial of $trials\n";
 
   my $test = new PerlDDS::TestFramework();
   $test->process('subscriber', 'subscriber',
-                 '-DCPSConfigFile shmem_rtps.ini -DCPSDebugLevel 0 -DCPSTransportDebugLevel 0');
+                 "-DCPSConfigFile $config -DCPSDebugLevel 0 -DCPSTransportDebugLevel 0");
   $test->process('publisher', 'publisher',
-                 '-DCPSConfigFile shmem_rtps.ini -DCPSDebugLevel 0 -DCPSTransportDebugLevel 0');
+                 "-DCPSConfigFile $config -DCPSDebugLevel 0 -DCPSTransportDebugLevel 0");
 
   $test->start_process('subscriber');
   $test->start_process('publisher');
 
-  if ($test->finish(15)) {
+  if ($test->finish(20)) {
     ++$failed;
   }
 }
 
-print "ShmemWakeupRace failed trials: $failed/$trials\n";
+print "ShmemWakeupRace transport=$transport failed trials: $failed/$trials\n";
 exit($failed ? 1 : 0);

--- a/tests/DCPS/ShmemWakeupRace/shmem_rtps.ini
+++ b/tests/DCPS/ShmemWakeupRace/shmem_rtps.ini
@@ -1,7 +1,7 @@
 [common]
 DCPSGlobalTransportConfig=$file
 
-[domain/113]
+[domain/228]
 DiscoveryConfig=uni_rtps
 
 [rtps_discovery/uni_rtps]

--- a/tests/DCPS/ShmemWakeupRace/shmem_rtps.ini
+++ b/tests/DCPS/ShmemWakeupRace/shmem_rtps.ini
@@ -1,0 +1,13 @@
+[common]
+DCPSGlobalTransportConfig=$file
+
+[domain/113]
+DiscoveryConfig=uni_rtps
+
+[rtps_discovery/uni_rtps]
+SedpMulticast=0
+ResendPeriod=2
+
+[transport/shmem]
+transport_type=shmem
+datalink_control_size=8192

--- a/tests/DCPS/ShmemWakeupRace/subscriber.cpp
+++ b/tests/DCPS/ShmemWakeupRace/subscriber.cpp
@@ -1,0 +1,129 @@
+/*
+ *
+ *
+ * Distributed under the OpenDDS License.
+ * See: http://www.opendds.org/license.html
+ */
+
+#include "ShmemWakeupRaceTypeSupportImpl.h"
+
+#include <dds/DCPS/Marked_Default_Qos.h>
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/StaticIncludes.h>
+#include <dds/DCPS/WaitSet.h>
+#ifdef ACE_AS_STATIC_LIBS
+#  include <dds/DCPS/RTPS/RtpsDiscovery.h>
+#  include <dds/DCPS/transport/rtps_udp/RtpsUdp.h>
+#endif
+
+#include <iostream>
+
+int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
+{
+  int status = 0;
+  DDS::DomainParticipantFactory_var domain_participant_factory =
+    TheParticipantFactoryWithArgs(argc, argv);
+  DDS::DomainParticipant_var participant =
+    domain_participant_factory->create_participant(ShmemWakeupRace::DOMAIN,
+                                                   PARTICIPANT_QOS_DEFAULT,
+                                                   0,
+                                                   0);
+
+  if (CORBA::is_nil(participant.in())) {
+    std::cerr << "Pong: create_participant failed" << std::endl;
+    status = 1;
+  } else {
+    ShmemWakeupRace::SampleTypeSupport_var type_support =
+      new ShmemWakeupRace::SampleTypeSupportImpl;
+    if (type_support->register_type(participant.in(), "") != DDS::RETCODE_OK) {
+      std::cerr << "Pong: register_type failed" << std::endl;
+      status = 1;
+    } else {
+      CORBA::String_var type_name = type_support->get_type_name();
+      DDS::Topic_var ping_topic = participant->create_topic(
+        ShmemWakeupRace::PING_TOPIC_NAME, type_name.in(), TOPIC_QOS_DEFAULT, 0, 0);
+      DDS::Topic_var pong_topic = participant->create_topic(
+        ShmemWakeupRace::PONG_TOPIC_NAME, type_name.in(), TOPIC_QOS_DEFAULT, 0, 0);
+      DDS::Publisher_var publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT, 0, 0);
+      DDS::Subscriber_var subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT, 0, 0);
+      if (CORBA::is_nil(ping_topic.in()) || CORBA::is_nil(pong_topic.in()) ||
+          CORBA::is_nil(publisher.in()) || CORBA::is_nil(subscriber.in())) {
+        std::cerr << "Pong: topic, publisher, or subscriber creation failed" << std::endl;
+        status = 1;
+      } else {
+        DDS::DataWriterQos writer_qos;
+        publisher->get_default_datawriter_qos(writer_qos);
+        writer_qos.reliability.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
+        DDS::DataReaderQos reader_qos;
+        subscriber->get_default_datareader_qos(reader_qos);
+        reader_qos.reliability.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
+        DDS::DataReader_var reader = subscriber->create_datareader(ping_topic.in(), reader_qos, 0, 0);
+        DDS::DataWriter_var writer = publisher->create_datawriter(pong_topic.in(), writer_qos, 0, 0);
+        ShmemWakeupRace::SampleDataReader_var sample_reader =
+          ShmemWakeupRace::SampleDataReader::_narrow(reader.in());
+        ShmemWakeupRace::SampleDataWriter_var sample_writer =
+          ShmemWakeupRace::SampleDataWriter::_narrow(writer.in());
+        if (CORBA::is_nil(sample_reader.in()) || CORBA::is_nil(sample_writer.in())) {
+          std::cerr << "Pong: create_datareader or create_datawriter failed" << std::endl;
+          status = 1;
+        } else {
+          DDS::ReadCondition_var read_condition = reader->create_readcondition(
+            DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
+          DDS::WaitSet_var wait_set = new DDS::WaitSet;
+          if (wait_set->attach_condition(read_condition.in()) != DDS::RETCODE_OK) {
+            std::cerr << "Pong: attach_condition failed" << std::endl;
+            status = 1;
+          } else {
+            DDS::ConditionSeq conditions;
+            const DDS::Duration_t timeout = { 5, 0 };
+            if (wait_set->wait(conditions, timeout) != DDS::RETCODE_OK) {
+              std::cerr << "Pong: timed out waiting for ping" << std::endl;
+              status = 1;
+            } else {
+              ShmemWakeupRace::SampleSeq samples;
+              DDS::SampleInfoSeq sample_infos;
+              const DDS::ReturnCode_t take_result = sample_reader->take(
+                samples, sample_infos, DDS::LENGTH_UNLIMITED,
+                DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
+              bool received = false;
+              bool return_loan_failed = false;
+              ShmemWakeupRace::Sample sample;
+              if (take_result == DDS::RETCODE_OK) {
+                for (CORBA::ULong i = 0; i < samples.length(); ++i) {
+                  if (sample_infos[i].valid_data && samples[i].sample_id == 1) {
+                    sample = samples[i];
+                    received = true;
+                    break;
+                  }
+                }
+                if (sample_reader->return_loan(samples, sample_infos) != DDS::RETCODE_OK) {
+                  std::cerr << "Pong: return_loan failed" << std::endl;
+                  return_loan_failed = true;
+                }
+              }
+              if (return_loan_failed) {
+                status = 1;
+              } else if (!received) {
+                std::cerr << "Pong: did not receive ping sample 1" << std::endl;
+                status = 1;
+              } else if (sample_writer->write(sample, DDS::HANDLE_NIL) != DDS::RETCODE_OK) {
+                std::cerr << "Pong: write failed" << std::endl;
+                status = 1;
+              } else {
+                std::cout << "Pong: echoed sample 1" << std::endl;
+              }
+            }
+            wait_set->detach_condition(read_condition.in());
+          }
+        }
+      }
+    }
+  }
+
+  if (!CORBA::is_nil(participant.in())) {
+    participant->delete_contained_entities();
+    domain_participant_factory->delete_participant(participant.in());
+  }
+  TheServiceParticipant->shutdown();
+  return status;
+}

--- a/tests/DCPS/ShmemWakeupRace/subscriber.cpp
+++ b/tests/DCPS/ShmemWakeupRace/subscriber.cpp
@@ -25,7 +25,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
   DDS::DomainParticipantFactory_var domain_participant_factory =
     TheParticipantFactoryWithArgs(argc, argv);
   DDS::DomainParticipant_var participant =
-    domain_participant_factory->create_participant(ShmemWakeupRace::DOMAIN,
+    domain_participant_factory->create_participant(ShmemWakeupRace::DOMAIN_ID,
                                                    PARTICIPANT_QOS_DEFAULT,
                                                    0,
                                                    0);
@@ -83,8 +83,13 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
           } else {
             DDS::ConditionSeq conditions;
             const DDS::Duration_t timeout = { 5, 0 };
-            if (wait_set->wait(conditions, timeout) != DDS::RETCODE_OK) {
+            const DDS::ReturnCode_t wait_result = wait_set->wait(conditions, timeout);
+            if (wait_result == DDS::RETCODE_TIMEOUT) {
               std::cerr << "Pong: timed out waiting for ping" << std::endl;
+              status = 1;
+            } else if (wait_result != DDS::RETCODE_OK) {
+              std::cerr << "Pong: waiting for ping failed with return code "
+                        << static_cast<int>(wait_result) << std::endl;
               status = 1;
             } else {
               ShmemWakeupRace::SampleSeq samples;
@@ -120,7 +125,14 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
                 std::cout << "Pong: echoed sample 1" << std::endl;
               }
             }
-            wait_set->detach_condition(read_condition.in());
+            if (wait_set->detach_condition(read_condition.in()) != DDS::RETCODE_OK) {
+              std::cerr << "Pong: detach_condition failed" << std::endl;
+              status = 1;
+            }
+          }
+          if (reader->delete_readcondition(read_condition.in()) != DDS::RETCODE_OK) {
+            std::cerr << "Pong: delete_readcondition failed" << std::endl;
+            status = 1;
           }
         }
       }

--- a/tests/DCPS/ShmemWakeupRace/subscriber.cpp
+++ b/tests/DCPS/ShmemWakeupRace/subscriber.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "ShmemWakeupRaceTypeSupportImpl.h"
+#include "MatchBarrier.h"
 
 #include <dds/DCPS/Marked_Default_Qos.h>
 #include <dds/DCPS/Service_Participant.h>
@@ -66,7 +67,13 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
         if (CORBA::is_nil(sample_reader.in()) || CORBA::is_nil(sample_writer.in())) {
           std::cerr << "Pong: create_datareader or create_datawriter failed" << std::endl;
           status = 1;
+        } else if (!ShmemWakeupRace::wait_for_match(writer.in()) ||
+                   !ShmemWakeupRace::wait_for_match(reader.in())) {
+          std::cerr << "Pong: waiting for endpoint matches failed" << std::endl;
+          status = 1;
         } else {
+          std::cout << "Pong: matched ping reader and writer" << std::endl;
+          ShmemWakeupRace::settle_after_matches();
           DDS::ReadCondition_var read_condition = reader->create_readcondition(
             DDS::ANY_SAMPLE_STATE, DDS::ANY_VIEW_STATE, DDS::ANY_INSTANCE_STATE);
           DDS::WaitSet_var wait_set = new DDS::WaitSet;


### PR DESCRIPTION
## Problem Report

Related issue: #5274

**OpenDDS version:** 3.35.0-dev, `ac227d5028a64c2250585a28097f49b8912e6985`

**Host and target:** Ubuntu 22.04.5 LTS, Linux 6.8.0-136-generic, x86_64 (same host)

**Compiler:** g++ 12.3.0

**ACE/TAO:** ACE 6.5.24 / TAO 2.5.24, configured with `ace/config-linux.h` and `include/makeinclude/platform_linux.GNU`; OpenDDS configured with `--no-debug --optimize`.

**Urgency:** Medium

**Area affected:** `dds/DCPS/transport/shmem`, association-adjacent delivery with RTPS discovery and best-effort QoS.

**Affects:** Execution of an application using the OpenDDS shared-memory transport.

### Synopsis

After both directions observe matched reader and writer endpoints and a short settle interval completes, a same-host best-effort SHM ping/pong exchange can fail to deliver the request or its echo. The same MWE is stable with RTPS/UDP.

### Description

This PR adds `tests/DCPS/ShmemWakeupRace`, a two-process MWE using only public DDS/OpenDDS application APIs. Ping creates a writer for the ping topic and a reader for the pong topic. Pong creates the inverse pair. Each process waits for its local writer and reader to observe a match, then waits 1.2 seconds before Ping writes exactly one best-effort sample and waits five seconds for the echo.

The runner selects `shmem` or `rtps_udp`; the executable, RTPS discovery configuration, QoS, domain, timing, and process topology are otherwise the same. This eliminates the earlier one-direction-only match barrier as a generic startup confounder.

### Controlled Comparison

One fresh-process 50-trial run on the environment above produced:

| Transport | Trials | Failed |
|---|---:|---:|
| shmem | 50 | 38 |
| rtps_udp | 50 | 0 |

All 50 trials in both arms reported successful bidirectional endpoint matches. Of the 38 SHM failures, Pong timed out before receiving the request in 21 trials. In the remaining 17 failures, Pong echoed the request but Ping did not receive the reply.

A later independent rerun produced 29/50 SHM failures and 0/50 RTPS/UDP failures. All trials again reported successful bidirectional endpoint matches. The exact SHM failure rate varies, but the transport-specific separation was reproduced.

This MWE is intentionally probabilistic and is not presented as a deterministic CI regression test. It also does **not** claim an OMG DDS reliability-contract violation: best-effort QoS does not guarantee delivery.

Related history: #3549 handled an earlier SHM association race. This MWE shows a remaining SHM-specific post-match delivery failure. Separate investigation suggests a wakeup/registration ordering window, but that internal cause is a hypothesis beyond what this public-API MWE alone proves.

### Repeat By

```sh
cd tests/DCPS/ShmemWakeupRace
source ../../../setenv.sh
"$MPC_ROOT/mpc.pl" -type gnuace ShmemWakeupRace.mpc
make -f GNUmakefile.ShmemWakeupRace_Publisher
make -f GNUmakefile.ShmemWakeupRace_Subscriber

perl run_test.pl transport=rtps_udp trials=50
perl run_test.pl transport=shmem trials=50
```

### Expected Result

A healthy trial prints:

```text
Ping: matched pong reader and writer
Pong: matched ping reader and writer
Ping: wrote sample 1
Pong: echoed sample 1
Ping: received pong sample 1
```

The RTPS/UDP control reports `failed trials: 0/N` and exits with status zero.

### Actual Result

On the affected host, SHM intermittently times out after both directions have reported endpoint matches. The runner reports one or more failed trials and exits nonzero.

### Sample Fix/Workaround

No production fix is included in this PR. The MWE is provided to establish the transport-specific failure mode and request guidance on an appropriate transport-level regression strategy.
