### PR TITLE
Fix for flakey shared ownership test

### DIFF
--- a/tests/DCPS/Ownership/publisher.cpp
+++ b/tests/DCPS/Ownership/publisher.cpp
@@ -13,6 +13,8 @@
 #include <dds/DCPS/PublisherImpl.h>
 #include <dds/DCPS/Service_Participant.h>
 
+#include <tests/Utils/DistributedConditionSet.h>
+
 #include "dds/DCPS/StaticIncludes.h"
 #ifdef ACE_AS_STATIC_LIBS
 #include <dds/DCPS/transport/udp/Udp.h>
@@ -36,13 +38,14 @@ ACE_CString ownership_dw_id = "OwnershipDataWriter";
 bool delay_reset = false;
 ACE_CString topic_name = "Movie Discussion List";
 int expected_readers = 2;
+bool wait_for_subscriber = false;
 
 namespace {
 
 int
 parse_args(int argc, ACE_TCHAR *argv[])
 {
-  ACE_Get_Opt get_opts(argc, argv, ACE_TEXT("s:i:r:d:y:l:cn:m:"));
+  ACE_Get_Opt get_opts(argc, argv, ACE_TEXT("s:i:r:d:y:l:cn:m:w"));
 
   int c;
   while ((c = get_opts()) != -1) {
@@ -76,13 +79,17 @@ parse_args(int argc, ACE_TCHAR *argv[])
     case 'm':
       expected_readers = ACE_OS::atoi(get_opts.opt_arg());
       break;
+    case 'w':
+      wait_for_subscriber = true;
+      break;
     case '?':
     default:
       ACE_ERROR_RETURN((LM_ERROR,
                         ACE_TEXT("usage: %C -s <ownership_strength> ")
                         ACE_TEXT("-i <ownership_dw_id> -r <reset_ownership_strength> ")
                         ACE_TEXT("-d <deadline> -y <delay> -l <liveliness> ")
-                        ACE_TEXT("-n <topic_name> -m <expected_readers>\n"),
+                        ACE_TEXT("-n <topic_name> -m <expected_readers> ")
+                        ACE_TEXT("-w\n"),
                         argv[0]),
                         -1);
     }
@@ -194,6 +201,12 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                         ACE_TEXT("%N:%l: main()")
                         ACE_TEXT(" ERROR: create_datawriter failed!\n")),
                        -1);
+    }
+
+    if (wait_for_subscriber) {
+      DistributedConditionSet_rch dcs =
+        OpenDDS::DCPS::make_rch<FileBasedDistributedConditionSet>();
+      dcs->wait_for(ownership_dw_id.c_str(), "subscriber", "ready");
     }
 
     // Start writing threads

--- a/tests/DCPS/Ownership/run_test.pl
+++ b/tests/DCPS/Ownership/run_test.pl
@@ -81,8 +81,8 @@ $test->setup_discovery("$debug_opts -ORBLogFile DCPSInfoRepo.log");
 
 $test->process('subscriber', 'subscriber', " $sub_opts -ORBLogFile sub.log $sub_deadline $sub_liveliness -t $testcase");
 if ($testcase == 4) {
-  $test->process('publisher1', 'publisher', "$pub_opts -ORBLogFile pub1.log -s 10 -i datawriter1 -m 1 -y 0");
-  $test->process('publisher2', 'publisher', "$pub_opts -ORBLogFile pub2.log -s 10 -i datawriter2 -m 1 -y 0 -n Movie_Discussion_List_2");
+  $test->process('publisher1', 'publisher', "$pub_opts -ORBLogFile pub1.log -s 10 -i datawriter1 -m 1 -y 0 -w");
+  $test->process('publisher2', 'publisher', "$pub_opts -ORBLogFile pub2.log -s 10 -i datawriter2 -m 1 -y 0 -w -n Movie_Discussion_List_2");
 }
 else {
   $test->process('publisher1', 'publisher', "$pub_opts -ORBLogFile pub1.log -s 10 -i datawriter1 $pub1_reset_strength $pub1_deadline $pub1_liveliness");

--- a/tests/DCPS/Ownership/subscriber.cpp
+++ b/tests/DCPS/Ownership/subscriber.cpp
@@ -16,6 +16,8 @@
 #include <dds/DCPS/SubscriberImpl.h>
 #include <dds/DCPS/WaitSet.h>
 
+#include <tests/Utils/DistributedConditionSet.h>
+
 #include "dds/DCPS/StaticIncludes.h"
 #ifdef ACE_AS_STATIC_LIBS
 #include <dds/DCPS/transport/udp/Udp.h>
@@ -205,6 +207,11 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
       DDS::ConditionSeq conditions;
       DDS::SubscriptionMatchedStatus matches1 = { 0, 0, 0, 0, 0 };
       DDS::SubscriptionMatchedStatus matches2 = { 0, 0, 0, 0, 0 };
+      bool readers_ready = testcase != shared_type;
+      DistributedConditionSet_rch dcs;
+      if (!readers_ready) {
+        dcs = OpenDDS::DCPS::make_rch<FileBasedDistributedConditionSet>();
+      }
       while (true) {
         if (reader1->get_subscription_matched_status(matches1) != DDS::RETCODE_OK) {
           ACE_ERROR_RETURN((LM_ERROR,
@@ -218,8 +225,21 @@ ACE_TMAIN(int argc, ACE_TCHAR *argv[])
                             ACE_TEXT(" ERROR: get_subscription_matched_status() failed!\n")), -1);
         }
 
-        if ((matches1.current_count == 0 && matches1.total_count > 0) ||
-            (matches2.current_count == 0 && matches2.total_count > 0)) {
+        if (!readers_ready &&
+            matches1.current_count > 0 &&
+            matches2.current_count > 0) {
+          dcs->post("subscriber", "ready");
+          readers_ready = true;
+        }
+
+        const bool reader1_done =
+          matches1.current_count == 0 && matches1.total_count > 0;
+        const bool reader2_done =
+          matches2.current_count == 0 && matches2.total_count > 0;
+        const bool readers_done = testcase == shared_type
+          ? reader1_done && reader2_done
+          : reader1_done || reader2_done;
+        if (readers_done) {
           break;
         }
         DDS::ReturnCode_t wait_status = ws->wait(conditions, timeout);


### PR DESCRIPTION
Problem:
- The test `tests/DCPS/Ownership/run_test.pl shared_type rtps` has historically been flakey and has, for whatever reason, becoming increasingly failure-prone lately

Solution:
- The test is not correctly having both publishers wait for the subscriber to be ready before writing, causing a race and likely failure. Have the publishers wait until the subscriber is ready.