### PR TITLE
Check CDR extraction results in UpdateManager (partial fix for #5232)

### DIFF
--- a/dds/InfoRepo/UpdateManager.cpp
+++ b/dds/InfoRepo/UpdateManager.cpp
@@ -12,7 +12,7 @@
 #include "DCPSInfo_i.h"
 
 #include "tao/CDR.h"
-
+#include "dds/DCPS/debug.h"
 #include <vector>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
@@ -143,7 +143,14 @@ Manager::pushImage(const DImage& image)
 
     DDS::DomainParticipantQos* qos;
     ACE_NEW_NORETURN(qos, DDS::DomainParticipantQos);
-    in_cdr >> *qos;
+    if (!(in_cdr >> *qos)) {
+      if (OpenDDS::DCPS::log_level >= OpenDDS::DCPS::LogLevel::Error) {
+        ACE_ERROR((LM_ERROR,
+          "(%P|%t) ERROR: UpdateManager::pushImage: failed to demarshal participant qos\n"));
+      }
+      delete qos;
+      continue;
+    }
     part_qos.push_back(qos);
 
     UParticipant* u_part;
@@ -173,7 +180,14 @@ Manager::pushImage(const DImage& image)
 
     DDS::TopicQos* qos;
     ACE_NEW_NORETURN(qos, DDS::TopicQos);
-    in_cdr >> *qos;
+    if (!(in_cdr >> *qos)) {
+      if (OpenDDS::DCPS::log_level >= OpenDDS::DCPS::LogLevel::Error) {
+        ACE_ERROR((LM_ERROR,
+          "(%P|%t) ERROR: UpdateManager::pushImage: failed to demarshal topic qos\n"));
+      }
+      delete qos;
+      continue;
+    }
     topics_qos.push_back(qos);
 
     UTopic* u_topic;
@@ -323,7 +337,13 @@ Manager::add(const DTopic& topic)
                       , topic.topicQos.second.first);
 
   DDS::TopicQos qos;
-  in_cdr >> qos;
+  if (!(in_cdr >> qos)) {
+    if (OpenDDS::DCPS::log_level >= OpenDDS::DCPS::LogLevel::Error) {
+      ACE_ERROR((LM_ERROR,
+        "(%P|%t) ERROR: UpdateManager::add: failed to demarshal topic qos\n"));
+    }
+    return;
+  }
 
   // Pass topic info to infoRepo.
   info_->add_topic(topic.topicId, topic.domainId
@@ -343,7 +363,13 @@ Manager::add(const DParticipant& participant)
                       , participant.participantQos.second.first);
 
   DDS::DomainParticipantQos qos;
-  in_cdr >> qos;
+  if (!(in_cdr >> qos)) {
+    if (OpenDDS::DCPS::log_level >= OpenDDS::DCPS::LogLevel::Error) {
+      ACE_ERROR((LM_ERROR,
+        "(%P|%t) ERROR: UpdateManager::add: failed to demarshal participant qos\n"));
+    }
+    return;
+  }
 
   // Pass participant info to infoRepo.
   info_->add_domain_participant(participant.domainId

--- a/dds/InfoRepo/UpdateManager.cpp
+++ b/dds/InfoRepo/UpdateManager.cpp
@@ -11,8 +11,10 @@
 #include "Updater.h"
 #include "DCPSInfo_i.h"
 
-#include "tao/CDR.h"
-#include "dds/DCPS/debug.h"
+#include <dds/DCPS/debug.h>
+
+#include <tao/CDR.h>
+
 #include <vector>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL


### PR DESCRIPTION
## Scope

This is a partial fix for #5232. The audit found 18 total unchecked operator>> sites in this file; the remaining 14 are either structural (a value is pushed into an owned sequence before extraction is validated,
requiring a reorder rather than a bare check) or live in Manager::add(const DActor&), which wasn't covered by the initial audit. Follow-up PR(s) will address those separately to keep this change reviewable.

## Testing

- Full solution build (Debug x64): 0 errors, 0 new warnings
- tools/scripts/lint.pl: no issues in the modified file
- DevGuideExamples/DCPS/Messenger integration test: test PASSED.