### PR TITLE
Add read_encapsulation_header to tighten encapsulation validity checks

### DIFF
--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -930,8 +930,9 @@ namespace OpenDDS {
       static_cast<Endianness>(sample.header_.byte_order_));
 
     if (encapsulated) {
-      EncapsulationHeader encap;
-      if (!(ser >> encap)) {
+      const EncapsulationReadStatus::Value read_status =
+        read_encapsulation_header(ser, type_support_->base_extensibility());
+      if (read_status == EncapsulationReadStatus::HeaderError) {
         if (DCPS_debug_level > 0) {
           ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR ")
             ACE_TEXT("%CDataReaderImpl::lookup_instance: ")
@@ -939,18 +940,18 @@ namespace OpenDDS {
             TraitsType::type_name()));
         }
         return;
-      }
-      Encoding encoding;
-      if (!to_encoding(encoding, encap, type_support_->base_extensibility())) {
+      } else if (read_status == EncapsulationReadStatus::ExtensibilityMismatch) {
         if (log_level >= LogLevel::Error) {
           ACE_ERROR((LM_ERROR,
                      "(%P|%t) ERROR: %CDataReaderImpl::lookup_instance: "
                      "to_encoding failed writer %C reader %C\n",
+                     TraitsType::type_name(),
                      LogGuid(sample.header_.publication_id_).c_str(),
                      LogGuid(subscription_id()).c_str()));
         }
         return;
       }
+      const Encoding& encoding = ser.encoding();
 
       if (decoding_modes_.find(encoding.kind()) == decoding_modes_.end()) {
         if (DCPS_debug_level >= 1) {
@@ -970,8 +971,6 @@ namespace OpenDDS {
           TraitsType::type_name(),
           Encoding::kind_to_string(encoding.kind()).c_str()));
       }
-
-      ser.encoding(encoding);
     }
 
     bool ser_ret = true;
@@ -1106,8 +1105,9 @@ protected:
       static_cast<Endianness>(sample.header_.byte_order_));
 
     if (encapsulated) {
-      EncapsulationHeader encap;
-      if (!(ser >> encap)) {
+      const EncapsulationReadStatus::Value read_status =
+        read_encapsulation_header(ser, type_support_->base_extensibility());
+      if (read_status == EncapsulationReadStatus::HeaderError) {
         if (DCPS_debug_level > 0) {
           ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR ")
             ACE_TEXT("%CDataReaderImpl::dds_demarshal: ")
@@ -1115,18 +1115,18 @@ protected:
             TraitsType::type_name()));
         }
         return;
-      }
-      Encoding encoding;
-      if (!to_encoding(encoding, encap, type_support_->base_extensibility())) {
+      } else if (read_status == EncapsulationReadStatus::ExtensibilityMismatch) {
         if (log_level >= LogLevel::Error) {
           ACE_ERROR((LM_ERROR,
                      "(%P|%t) ERROR: %CDataReaderImpl::dds_demarshal: "
                      "to_encoding failed writer %C reader %C\n",
+                     TraitsType::type_name(),
                      LogGuid(sample.header_.publication_id_).c_str(),
                      LogGuid(subscription_id()).c_str()));
         }
         return;
       }
+      const Encoding& encoding = ser.encoding();
 
       if (decoding_modes_.find(encoding.kind()) == decoding_modes_.end()) {
         if (DCPS_debug_level >= 1) {
@@ -1146,8 +1146,6 @@ protected:
           TraitsType::type_name(),
           Encoding::kind_to_string(encoding.kind()).c_str()));
       }
-
-      ser.encoding(encoding);
     }
 
     const bool key_only_marshaling =

--- a/dds/DCPS/EncapsulationHeader.cpp
+++ b/dds/DCPS/EncapsulationHeader.cpp
@@ -263,6 +263,30 @@ to_any_encoding(Encoding& encoding,
   return to_encoding_i(encoding, header, 0);
 }
 
+EncapsulationReadStatus::Value
+read_encapsulation_header(Serializer& s,
+                          EncapsulationHeader& header,
+                          Extensibility expected_extensibility)
+{
+  if (!(s >> header)) {
+    return EncapsulationReadStatus::HeaderError;
+  }
+  Encoding encoding;
+  if (!to_encoding(encoding, header, expected_extensibility)) {
+    return EncapsulationReadStatus::ExtensibilityMismatch;
+  }
+  s.encoding(encoding);
+  return EncapsulationReadStatus::Ok;
+}
+
+EncapsulationReadStatus::Value
+read_encapsulation_header(Serializer& s,
+                          Extensibility expected_extensibility)
+{
+  EncapsulationHeader header;
+  return read_encapsulation_header(s, header, expected_extensibility);
+}
+
 }
 }
 

--- a/dds/DCPS/EncapsulationHeader.h
+++ b/dds/DCPS/EncapsulationHeader.h
@@ -134,7 +134,7 @@ struct EncapsulationReadStatus {
     /// The 4-byte header itself could not be deserialized, e.g. a truncated buffer.
     HeaderError,
     /// The header was read, but its representation doesn't match expected_extensibility.
-    ExtensibilityMismatch
+    ExtensibilityMismatch,
   };
 };
 

--- a/dds/DCPS/EncapsulationHeader.h
+++ b/dds/DCPS/EncapsulationHeader.h
@@ -128,6 +128,35 @@ OpenDDS_Dcps_Export
 bool to_any_encoding(Encoding& encoding,
                      const EncapsulationHeader& header);
 
+struct EncapsulationReadStatus {
+  enum Value {
+    Ok,
+    /// The 4-byte header itself could not be deserialized, e.g. a truncated buffer.
+    HeaderError,
+    /// The header was read, but its representation doesn't match expected_extensibility.
+    ExtensibilityMismatch
+  };
+};
+
+/**
+ * Read encapsulation header from Serializer, validate representation against
+ * expected extensibility, and set the stream's encoding. Leaves the stream's
+ * encoding unchanged unless EncapsulationReadStatus::Ok is returned.
+ */
+OpenDDS_Dcps_Export
+EncapsulationReadStatus::Value read_encapsulation_header(
+  Serializer& s,
+  EncapsulationHeader& header,
+  Extensibility expected_extensibility);
+
+/**
+ * Like the above, for callers that don't need the parsed header.
+ */
+OpenDDS_Dcps_Export
+EncapsulationReadStatus::Value read_encapsulation_header(
+  Serializer& s,
+  Extensibility expected_extensibility);
+
 } // namespace DCPS
 } // namespace OpenDDS
 

--- a/dds/DCPS/FilterEvaluator.cpp
+++ b/dds/DCPS/FilterEvaluator.cpp
@@ -140,23 +140,20 @@ FilterEvaluator::SerializedForEval::lookup(const char* field) const
   Message_Block_Ptr mb(serialized_->duplicate());
   Serializer ser(mb.get(), encoding_);
   if (encoding_.is_encapsulated()) {
-    EncapsulationHeader encap;
-    if (!(ser >> encap)) {
+    const EncapsulationReadStatus::Value read_status = read_encapsulation_header(ser, exten_);
+    if (read_status == EncapsulationReadStatus::HeaderError) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR ")
         ACE_TEXT("FilterEvaluator::SerializedForEval::lookup: ")
         ACE_TEXT("deserialization of encapsulation header failed.\n")));
       throw std::runtime_error("FilterEvaluator::SerializedForEval::lookup:"
         "deserialization of encapsulation header failed.\n");
-    }
-    Encoding encoding;
-    if (!to_encoding(encoding, encap, exten_)) {
+    } else if (read_status == EncapsulationReadStatus::ExtensibilityMismatch) {
       ACE_ERROR((LM_ERROR, ACE_TEXT("(%P|%t) ERROR ")
         ACE_TEXT("FilterEvaluator::SerializedForEval::lookup: ")
         ACE_TEXT("failed to convert encapsulation header to encoding.\n")));
       throw std::runtime_error("FilterEvaluator::SerializedForEval::lookup:"
         "failed to convert encapsulation header to encoding.\n");
     }
-    ser.encoding(encoding);
   }
   const Value v = meta_.getValue(ser, field, &type_support_);
   cache_.insert(std::make_pair(OPENDDS_STRING(field), v));

--- a/dds/DCPS/RTPS/Sedp.cpp
+++ b/dds/DCPS/RTPS/Sedp.cpp
@@ -4322,15 +4322,14 @@ Sedp::Reader::data_received(const DCPS::ReceivedDataSample& sample)
     Encoding encoding;
     DCPS::Message_Block_Ptr payload(sample.data(&mb_alloc_));
     Serializer ser(payload.get(), encoding);
-    DCPS::EncapsulationHeader encap;
-    if (!(ser >> encap)) {
+    const DCPS::EncapsulationReadStatus::Value read_status = read_encapsulation_header(ser, extensibility);
+    if (read_status == DCPS::EncapsulationReadStatus::HeaderError) {
       if (log_level >= LogLevel::Warning) {
         ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: Sedp::Reader::data_received: "
                    "failed to deserialize encapsulation header\n"));
       }
       return;
-    }
-    if (!to_encoding(encoding, encap, extensibility)) {
+    } else if (read_status == DCPS::EncapsulationReadStatus::ExtensibilityMismatch) {
       if (log_level >= DCPS::LogLevel::Error) {
         ACE_ERROR((LM_ERROR,
                    "(%P|%t) ERROR: Sedp::Reader::data_received: "
@@ -4339,7 +4338,6 @@ Sedp::Reader::data_received(const DCPS::ReceivedDataSample& sample)
       }
       return;
     }
-    ser.encoding(encoding);
 
     data_received_i(sample, entity_id, ser, extensibility);
     break;

--- a/tests/unit-tests/dds/DCPS/EncapsulationHeader.cpp
+++ b/tests/unit-tests/dds/DCPS/EncapsulationHeader.cpp
@@ -221,3 +221,92 @@ TEST(dds_DCPS_EncapsulationHeader, to_encoding_INVALID)
   EXPECT_FALSE(to_encoding(enc, eh, FINAL));
   EXPECT_STREQ("Invalid", eh.to_string().c_str());
 }
+
+TEST(dds_DCPS_EncapsulationHeader, to_encoding_PL_CDR2_LE_APPENDABLE_mismatch)
+{
+  OpenDDS::DCPS::LogRestore restore;
+  OpenDDS::DCPS::log_level.set(OpenDDS::DCPS::LogLevel::None);
+  EncapsulationHeader eh;
+  eh.kind(EncapsulationHeader::KIND_PL_CDR2_LE);
+  Encoding enc;
+  EXPECT_FALSE(to_encoding(enc, eh, APPENDABLE));
+}
+
+TEST(dds_DCPS_EncapsulationHeader, to_encoding_PL_CDR2_BE_APPENDABLE_mismatch)
+{
+  OpenDDS::DCPS::LogRestore restore;
+  OpenDDS::DCPS::log_level.set(OpenDDS::DCPS::LogLevel::None);
+  EncapsulationHeader eh;
+  eh.kind(EncapsulationHeader::KIND_PL_CDR2_BE);
+  Encoding enc;
+  EXPECT_FALSE(to_encoding(enc, eh, APPENDABLE));
+}
+
+TEST(dds_DCPS_EncapsulationHeader, to_encoding_D_CDR2_LE_MUTABLE_mismatch)
+{
+  OpenDDS::DCPS::LogRestore restore;
+  OpenDDS::DCPS::log_level.set(OpenDDS::DCPS::LogLevel::None);
+  EncapsulationHeader eh;
+  eh.kind(EncapsulationHeader::KIND_D_CDR2_LE);
+  Encoding enc;
+  EXPECT_FALSE(to_encoding(enc, eh, MUTABLE));
+}
+
+TEST(dds_DCPS_EncapsulationHeader, to_encoding_CDR2_LE_APPENDABLE_mismatch)
+{
+  OpenDDS::DCPS::LogRestore restore;
+  OpenDDS::DCPS::log_level.set(OpenDDS::DCPS::LogLevel::None);
+  EncapsulationHeader eh;
+  eh.kind(EncapsulationHeader::KIND_CDR2_LE);
+  Encoding enc;
+  EXPECT_FALSE(to_encoding(enc, eh, APPENDABLE));
+}
+
+TEST(dds_DCPS_EncapsulationHeader, read_encapsulation_header_APPENDABLE_valid)
+{
+  ACE_Message_Block mb(4);
+  mb.wr_ptr()[0] = 0x00;
+  mb.wr_ptr()[1] = 0x09; // KIND_D_CDR2_LE
+  mb.wr_ptr()[2] = 0x00;
+  mb.wr_ptr()[3] = 0x00;
+  mb.wr_ptr(4);
+
+  Serializer ser(&mb, Encoding());
+  EncapsulationHeader encap;
+  EXPECT_EQ(EncapsulationReadStatus::Ok, read_encapsulation_header(ser, encap, APPENDABLE));
+  EXPECT_EQ(EncapsulationHeader::KIND_D_CDR2_LE, encap.kind());
+  EXPECT_EQ(Encoding::KIND_XCDR2, ser.encoding().kind());
+  EXPECT_EQ(ENDIAN_LITTLE, ser.encoding().endianness());
+}
+
+TEST(dds_DCPS_EncapsulationHeader, read_encapsulation_header_APPENDABLE_mismatch)
+{
+  OpenDDS::DCPS::LogRestore restore;
+  OpenDDS::DCPS::log_level.set(OpenDDS::DCPS::LogLevel::None);
+  ACE_Message_Block mb(4);
+  mb.wr_ptr()[0] = 0x00;
+  mb.wr_ptr()[1] = 0x0b; // KIND_PL_CDR2_LE (mismatch for APPENDABLE)
+  mb.wr_ptr()[2] = 0x00;
+  mb.wr_ptr()[3] = 0x00;
+  mb.wr_ptr(4);
+
+  Serializer ser(&mb, Encoding());
+  EncapsulationHeader encap;
+  EXPECT_EQ(EncapsulationReadStatus::ExtensibilityMismatch,
+            read_encapsulation_header(ser, encap, APPENDABLE));
+}
+
+TEST(dds_DCPS_EncapsulationHeader, read_encapsulation_header_short_read)
+{
+  OpenDDS::DCPS::LogRestore restore;
+  OpenDDS::DCPS::log_level.set(OpenDDS::DCPS::LogLevel::None);
+  ACE_Message_Block mb(2);
+  mb.wr_ptr()[0] = 0x00;
+  mb.wr_ptr()[1] = 0x09;
+  mb.wr_ptr(2); // Truncated: only 2 of the required 4 bytes are present.
+
+  Serializer ser(&mb, Encoding());
+  EncapsulationHeader encap;
+  EXPECT_EQ(EncapsulationReadStatus::HeaderError,
+            read_encapsulation_header(ser, encap, APPENDABLE));
+}


### PR DESCRIPTION
Motivation

read_encapsulation_header() collapses the previous three-step pattern (deserialize the 4-byte encapsulation header, validate its representation against the target type's expected extensibility via to_encoding(), then set the stream's Encoding) into a single call. Previously these were three independent steps a caller had to get right in order; skipping the validation step after reading the header is exactly the misuse pattern described in #5271. All of OpenDDS's actual deserialization paths already performed this validation correctly before this change (each call site already passed the target's expected extensibility into to_encoding()), so this isn't a fix for an observed acceptance of malformed payloads — it's hardening the API so that mistake can't be made by a future call site, and it removes duplicated boilerplate at the same time.

Description of Changes

- Added read_encapsulation_header() to dds/DCPS/EncapsulationHeader.h/.cpp, which reads the header, validates it against an expected extensibility, and sets the stream's encoding in one call. It returns an EncapsulationReadStatus (Ok / HeaderError / ExtensibilityMismatch) rather than bool so callers can still distinguish a truncated/malformed header from a representation mismatch and log accordingly.
- Updated DataReaderImpl_T.h, FilterEvaluator.cpp, and Sedp.cpp to use the new helper, removing the duplicated read/validate/set-encoding boilerplate at each site. Also fixed a pre-existing format-string argument mismatch in DataReaderImpl_T.h's error logging (a %C with no corresponding argument).
- Added regression tests in tests/unit-tests/dds/DCPS/EncapsulationHeader.cpp covering XCDR2 representation-mismatch rejection (e.g. PL_CDR2 header on an @appendable type) and both success/failure paths of read_encapsulation_header().