### PR TITLE
Adding Reader Cache Lifespan Eviction

### DIFF
--- a/dds/DCPS/DataReaderImpl.cpp
+++ b/dds/DCPS/DataReaderImpl.cpp
@@ -79,6 +79,10 @@ DataReaderImpl::DataReaderImpl()
   , last_deadline_missed_total_count_(0)
   , deadline_queue_enabled_(false)
   , deadline_task_(make_rch<SporadicEvent>(TheServiceParticipant->event_dispatcher(), make_rch<DRIEvent>(rchandle_from(this), &DataReaderImpl::deadline_task)))
+  , next_lifespan_expiration_(MonotonicTimePoint::zero_value)
+  , lifespan_task_(make_rch<SporadicEvent>(TheServiceParticipant->event_dispatcher(),
+                                           make_rch<DRIEvent>(rchandle_from(this),
+                                                              &DataReaderImpl::lifespan_task)))
   , is_bit_(false)
   , always_get_history_(false)
   , statistics_enabled_(false)
@@ -136,6 +140,7 @@ DataReaderImpl::~DataReaderImpl()
   DBG_ENTRY_LVL("DataReaderImpl", "~DataReaderImpl", 6);
 
   deadline_task_->cancel();
+  lifespan_task_->cancel();
 
 #ifndef OPENDDS_SAFETY_PROFILE
   RcHandle<DomainParticipantImpl> participant = participant_servant_.lock();
@@ -1374,7 +1379,39 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
     SubscriptionInstance_rch instance;
     if (!check_historic(sample)) break;
 
-    DataSampleHeader const & header = sample.header_;
+    const ReceivedDataSample* sample_for_processing = &sample;
+    ReceivedDataSample sample_with_lifespan;
+
+    // RTPS communicates Lifespan as writer QoS.  It is not required to be
+    // repeated as inline QoS on every DATA submessage, so attach the
+    // discovered writer's policy to the internal per-sample header.
+    if (!is_bit()
+        && sample.header_.message_id_ == SAMPLE_DATA
+        && !sample.header_.lifespan_duration_) {
+      WriterInfo_rch writer;
+      {
+        ACE_READ_GUARD(ACE_RW_Thread_Mutex, read_guard, writers_lock_);
+        const WriterMapType::const_iterator pos =
+          writers_.find(sample.header_.publication_id_);
+        if (pos != writers_.end()) {
+          writer = pos->second;
+        }
+      }
+      if (writer) {
+        const DDS::Duration_t lifespan =
+          writer->writer_qos_lifespan().duration;
+        if (!is_infinite(lifespan)) {
+          sample_with_lifespan = sample;
+          DataSampleHeader& header = sample_with_lifespan.header_;
+          header.lifespan_duration_ = true;
+          header.lifespan_duration_sec_ = lifespan.sec;
+          header.lifespan_duration_nanosec_ = lifespan.nanosec;
+          sample_for_processing = &sample_with_lifespan;
+        }
+      }
+    }
+
+    const DataSampleHeader& header = sample_for_processing->header_;
 
     this->writer_activity(header);
 
@@ -1397,7 +1434,7 @@ DataReaderImpl::data_received(const ReceivedDataSample& sample)
 
     bool is_new_instance = false;
     bool filtered = false;
-    dds_demarshal(sample, publication_handle, instance, is_new_instance, filtered,
+    dds_demarshal(*sample_for_processing, publication_handle, instance, is_new_instance, filtered,
                   sample.header_.key_fields_only_ ? KEY_ONLY_MARSHALING : FULL_MARSHALING);
 
     // Per sample logging
@@ -2645,6 +2682,70 @@ void DataReaderImpl::post_read_or_take()
   if (subscriber) {
     subscriber->set_status_changed_flag(
       DDS::DATA_ON_READERS_STATUS, false);
+  }
+}
+
+void DataReaderImpl::schedule_lifespan(const ReceivedDataElement* sample)
+{
+  // sample_lock_ must be held.
+  const MonotonicTimePoint expiration = sample->expiration_time_;
+  if (expiration == MonotonicTimePoint::zero_value) {
+    return;
+  }
+
+  if (next_lifespan_expiration_ == MonotonicTimePoint::zero_value
+      || expiration < next_lifespan_expiration_) {
+    next_lifespan_expiration_ = expiration;
+    lifespan_task_->cancel();
+    const MonotonicTimePoint now = MonotonicTimePoint::now();
+    lifespan_task_->schedule(expiration > now
+      ? expiration - now : TimeDuration::zero_value);
+  }
+}
+
+void DataReaderImpl::lifespan_task(const MonotonicTimePoint& now)
+{
+  ThreadStatusManager::Event ev(TheServiceParticipant->get_thread_status_manager());
+
+  ACE_GUARD(ACE_Recursive_Thread_Mutex, guard, sample_lock_);
+  next_lifespan_expiration_ = MonotonicTimePoint::zero_value;
+
+  {
+    ACE_GUARD(ACE_Recursive_Thread_Mutex, instance_guard, instances_lock_);
+    for (SubscriptionInstanceMapType::iterator iter = instances_.begin();
+         iter != instances_.end();) {
+      const SubscriptionInstance_rch instance = iter->second;
+      // Removing the last sample can release and erase this instance.
+      ++iter;
+      ReceivedDataElementList& samples = instance->rcvd_samples_;
+
+      for (ReceivedDataElement* item = samples.get_next(0); item;) {
+        ReceivedDataElement* const next = samples.get_next(item);
+        const MonotonicTimePoint expiration = item->expiration_time_;
+        if (expiration != MonotonicTimePoint::zero_value) {
+          if (expiration <= now) {
+            const bool instance_released = samples.remove(item);
+            item->dec_ref();
+            if (instance_released) {
+              break;
+            }
+          } else if (next_lifespan_expiration_ == MonotonicTimePoint::zero_value
+                     || expiration < next_lifespan_expiration_) {
+            next_lifespan_expiration_ = expiration;
+          }
+        }
+        item = next;
+      }
+    }
+  }
+
+  if (!have_sample_states(DDS::ANY_SAMPLE_STATE)) {
+    post_read_or_take();
+  }
+
+  if (next_lifespan_expiration_ != MonotonicTimePoint::zero_value) {
+    lifespan_task_->schedule(next_lifespan_expiration_ > now
+      ? next_lifespan_expiration_ - now : TimeDuration::zero_value);
   }
 }
 

--- a/dds/DCPS/DataReaderImpl.h
+++ b/dds/DCPS/DataReaderImpl.h
@@ -626,6 +626,10 @@ protected:
 
   void post_read_or_take();
 
+  /// Arrange for a finite-Lifespan sample to be removed from the reader cache.
+  /// sample_lock_ must be held.
+  void schedule_lifespan(const ReceivedDataElement* sample);
+
   // type specific DataReader's part of enable.
   virtual DDS::ReturnCode_t enable_specific() = 0;
 
@@ -841,6 +845,11 @@ private:
   bool deadline_queue_enabled_;
   typedef PmfNowEvent<DataReaderImpl> DRIEvent;
   SporadicEvent_rch deadline_task_;
+
+  MonotonicTimePoint next_lifespan_expiration_;
+  SporadicEvent_rch lifespan_task_;
+
+  void lifespan_task(const MonotonicTimePoint& now);
 
   void schedule_deadline(SubscriptionInstance_rch instance,
                          bool timer_called);

--- a/dds/DCPS/DataReaderImpl_T.h
+++ b/dds/DCPS/DataReaderImpl_T.h
@@ -2133,6 +2133,7 @@ void finish_store_instance_data(unique_ptr<MessageTypeWithAllocator> instance_da
   // release it while status notifications temporarily release sample_lock_.
   ptr->inc_ref();
   instance_ptr->rcvd_strategy_->add(ptr);
+  schedule_lifespan(ptr);
 
   if (! is_dispose_msg  && ! is_unregister_msg
       && instance_ptr->rcvd_samples_.size() > get_depth())

--- a/dds/DCPS/ReceivedDataElementList.cpp
+++ b/dds/DCPS/ReceivedDataElementList.cpp
@@ -215,6 +215,13 @@ OpenDDS::DCPS::ReceivedDataElementList::matches(CORBA::ULong sample_states) cons
 }
 
 OpenDDS::DCPS::ReceivedDataElement*
+OpenDDS::DCPS::ReceivedDataElementList::get_next(ReceivedDataElement* prev)
+{
+  OPENDDS_ASSERT(sanity_check(prev));
+  return prev ? prev->next_data_sample_ : head_;
+}
+
+OpenDDS::DCPS::ReceivedDataElement*
 OpenDDS::DCPS::ReceivedDataElementList::get_next_match(CORBA::ULong sample_states, ReceivedDataElement* prev)
 {
   OPENDDS_ASSERT(sanity_check(prev));
@@ -222,8 +229,11 @@ OpenDDS::DCPS::ReceivedDataElementList::get_next_match(CORBA::ULong sample_state
     return 0;
   }
   ReceivedDataElement* item = prev ? prev->next_data_sample_ : head_;
+  const MonotonicTimePoint now = MonotonicTimePoint::now();
   for (; item != 0; item = item->next_data_sample_) {
     if ((item->sample_state_ & sample_states)
+      && (item->expiration_time_ == MonotonicTimePoint::zero_value
+        || item->expiration_time_ > now)
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
       && !item->coherent_change_
 #endif

--- a/dds/DCPS/ReceivedDataElementList.h
+++ b/dds/DCPS/ReceivedDataElementList.h
@@ -37,6 +37,7 @@ public:
       registered_data_(received_data),
       sample_state_(DDS::NOT_READ_SAMPLE_STATE),
       destination_timestamp_(SystemTimePoint::now().to_idl_struct()),
+      expiration_time_(MonotonicTimePoint::zero_value),
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
       coherent_change_(header.coherent_change_),
       group_coherent_(header.group_coherent_),
@@ -54,6 +55,17 @@ public:
   {
     source_timestamp_.sec = header.source_timestamp_sec_;
     source_timestamp_.nanosec = header.source_timestamp_nanosec_;
+
+    if (header.lifespan_duration_) {
+      const DDS::Duration_t lifespan = {
+        header.lifespan_duration_sec_,
+        header.lifespan_duration_nanosec_
+      };
+      const SystemTimePoint expiration =
+        SystemTimePoint(source_timestamp_) + TimeDuration(lifespan);
+      expiration_time_ = MonotonicTimePoint::now()
+        + (expiration - SystemTimePoint::now());
+    }
 
     /*
      * In some situations, we will not have data to give to the user and
@@ -100,6 +112,10 @@ public:
 
   /// Reception time stamp for this data sample
   DDS::Time_t destination_timestamp_;
+
+  /// Monotonic deadline after which this sample must not be delivered.
+  /// A zero value indicates an infinite Lifespan.
+  MonotonicTimePoint expiration_time_;
 
 #ifndef OPENDDS_NO_OBJECT_MODEL_PROFILE
   /// Sample belongs to an active coherent change set
@@ -213,6 +229,7 @@ public:
 
   bool has_zero_copies() const;
   bool matches(CORBA::ULong sample_states) const;
+  ReceivedDataElement* get_next(ReceivedDataElement* prev);
   ReceivedDataElement* get_next_match(CORBA::ULong sample_states, ReceivedDataElement* prev);
 
   void mark_read(ReceivedDataElement* item);

--- a/dds/DCPS/WriterInfo.h
+++ b/dds/DCPS/WriterInfo.h
@@ -127,6 +127,12 @@ public:
     writer_qos_.ownership_strength.value = writer_qos_ownership_strength;
   }
 
+  DDS::LifespanQosPolicy writer_qos_lifespan() const
+  {
+    ACE_Guard<ACE_Thread_Mutex> guard(mutex_);
+    return writer_qos_.lifespan;
+  }
+
   bool waiting_for_end_historic_samples() const
   {
     ACE_Guard<ACE_Thread_Mutex> guard(mutex_);

--- a/tests/DCPS/Lifespan/DataReaderListener.cpp
+++ b/tests/DCPS/Lifespan/DataReaderListener.cpp
@@ -21,7 +21,14 @@ DataReaderListenerImpl::~DataReaderListenerImpl ()
 
 void DataReaderListenerImpl::on_data_available(DDS::DataReader_ptr reader)
 {
-  ++num_reads_;
+  const long callback = ++num_reads_;
+
+  // Take the unexpired historical sample as the legacy test has always done.
+  // Leave the post-association sample in the reader cache so the test can
+  // verify that Lifespan evicts it.
+  if (callback != 1) {
+    return;
+  }
 
   try {
     MessageDataReader_var message_dr = MessageDataReader::_narrow(reader);

--- a/tests/DCPS/Lifespan/DataReaderListener.h
+++ b/tests/DCPS/Lifespan/DataReaderListener.h
@@ -4,6 +4,7 @@
 #define DATAREADER_LISTENER_IMPL
 
 #include <dds/DdsDcpsSubscriptionExtC.h>
+#include <dds/DCPS/Atomic.h>
 #include <dds/DCPS/LocalObject.h>
 
 #if !defined (ACE_LACKS_PRAGMA_ONCE)
@@ -62,13 +63,13 @@ public:
     const ::OpenDDS::DCPS::BudgetExceededStatus& status);
 
   long num_reads() const {
-    return num_reads_;
+    return num_reads_.load();
   }
 
 private:
 
   DDS::DataReader_var reader_;
-  long                  num_reads_;
+  OpenDDS::DCPS::Atomic<long> num_reads_;
 };
 
 #endif /* DATAREADER_LISTENER_IMPL  */

--- a/tests/DCPS/Lifespan/README
+++ b/tests/DCPS/Lifespan/README
@@ -1,4 +1,6 @@
 This test confirms that LIFESPAN support in OpenDDS functions
 according to the OMG DDS specification.  It does so by configuring a
-finite lifespan QoS policy value, and purposely writing data with a
-timestamp that forces the data to be considered expired.
+finite lifespan QoS policy value and purposely writing data with a
+timestamp that forces the data to be considered expired.  It also leaves
+a fresh sample unread until its lifespan expires, verifying that the
+sample is evicted from the reader cache.

--- a/tests/DCPS/Lifespan/Writer.cpp
+++ b/tests/DCPS/Lifespan/Writer.cpp
@@ -103,9 +103,9 @@ Writer::svc ()
     Messenger::MessageDataWriter::_narrow(writer_.in());
   Messenger::Message message;
   message.subject_id = 99;
-  message.from = CORBA::string_dup("Comic Book Guy");
-  message.subject = CORBA::string_dup("Review");
-  message.text = CORBA::string_dup("Cached until Lifespan expires.");
+  message.from = "Comic Book Guy";
+  message.subject = "Review";
+  message.text = "Cached until Lifespan expires.";
   message.count = ++count_;
   const DDS::InstanceHandle_t handle = message_dw->register_instance(message);
   if (message_dw->write(message, handle) != DDS::RETCODE_OK)

--- a/tests/DCPS/Lifespan/Writer.cpp
+++ b/tests/DCPS/Lifespan/Writer.cpp
@@ -97,6 +97,22 @@ Writer::svc ()
       ACE_OS::sleep(1);
     }
 
+  // Cache a fresh sample at the reader after association.  The listener
+  // deliberately leaves this sample unread so its Lifespan can expire.
+  Messenger::MessageDataWriter_var message_dw =
+    Messenger::MessageDataWriter::_narrow(writer_.in());
+  Messenger::Message message;
+  message.subject_id = 99;
+  message.from = CORBA::string_dup("Comic Book Guy");
+  message.subject = CORBA::string_dup("Review");
+  message.text = CORBA::string_dup("Cached until Lifespan expires.");
+  message.count = ++count_;
+  const DDS::InstanceHandle_t handle = message_dw->register_instance(message);
+  if (message_dw->write(message, handle) != DDS::RETCODE_OK)
+    {
+      ACE_ERROR_RETURN((LM_ERROR, "(%P|%t) ERROR: post-match write failed\n"), 1);
+    }
+
   this->start_ = true;
 
   // wait for datareader finish.

--- a/tests/DCPS/Lifespan/publisher.cpp
+++ b/tests/DCPS/Lifespan/publisher.cpp
@@ -108,7 +108,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         writer->start ();
         while ( !writer->is_finished())
         {
-          ACE_Time_Value small_time(30,0);
+          ACE_Time_Value small_time(1, 0);
           ACE_OS::sleep (small_time);
         }
 

--- a/tests/DCPS/Lifespan/subscriber.cpp
+++ b/tests/DCPS/Lifespan/subscriber.cpp
@@ -111,14 +111,33 @@ int ACE_TMAIN(int argc, ACE_TCHAR *argv[])
         cerr << "create_datareader failed." << endl;
         exit(1);
       }
-
-      ACE_OS::sleep (10);
-      if (listener_servant->num_reads () != 1)
+      // The first callback consumes the one valid historical sample.  The
+      // second corresponds to a post-association sample which the listener
+      // intentionally leaves in the reader cache.
+      for (int i = 0; i < 300 && listener_servant->num_reads() < 2; ++i) {
+        ACE_OS::sleep(ACE_Time_Value(0, 100000));
+      }
+      if (listener_servant->num_reads() != 2)
         {
           cerr << "ERROR: Incorrect number of samples received." << endl
                << "       Expired data was probably read." << endl;
           exit (1);
         }
+
+      // The writer Lifespan is 20 seconds.  After it expires, the unread
+      // sample must no longer be available from the reader cache.
+      ACE_OS::sleep(21);
+      Messenger::MessageDataReader_var message_dr =
+        Messenger::MessageDataReader::_narrow(dr.in());
+      Messenger::Message message;
+      DDS::SampleInfo sample_info;
+      const DDS::ReturnCode_t take_status =
+        message_dr->take_next_sample(message, sample_info);
+      if (take_status != DDS::RETCODE_NO_DATA) {
+        cerr << "ERROR: Lifespan-expired sample remained readable (status "
+             << take_status << ")." << endl;
+        exit(1);
+      }
 
       if (!CORBA::is_nil (participant.in ())) {
         participant->delete_contained_entities();


### PR DESCRIPTION
## Motivation

DDS v1.4, §2.2.3.16 LIFESPAN specifies that expired samples must no longer be delivered and are removed from DataReader caches. OpenDDS retained these samples in violation of the spec (and causing Lifespan self-interoperability failures in the omg-dds/dds-rtps tests).

## Description of Changes

Track sample expiration using monotonic time, schedule reader-cache eviction, and defensively exclude expired samples from read/take operations. Extend the legacy Lifespan test to verify that unread samples become unavailable after expiration.