### PR TITLE
fix: invalid bool load in `to_boolean`

### DIFF
--- a/dds/DCPS/Serializer.inl
+++ b/dds/DCPS/Serializer.inl
@@ -1315,8 +1315,18 @@ operator>>(Serializer& s, long double& x)
 ACE_INLINE bool
 operator>>(Serializer& s, ACE_InputCDR::to_boolean x)
 {
+  ACE_CDR::Octet tmp = 0;
   s.buffer_read(reinterpret_cast<char*>(&x.ref_), boolean_cdr_size, s.swap_bytes());
-  return s.good_bit();
+  if (!s.good_bit()) {
+    return false;
+  }
+  if (tmp & ~ACE_CDR::Octet(1)) {
+    x.ref_ = tmp != 0;
+    s.set_construction_status(Serializer::ElementConstructionFailure);
+    return false;
+  }
+  x.ref_ = tmp != 0;
+  return true;
 }
 
 ACE_INLINE bool

--- a/dds/DCPS/Serializer.inl
+++ b/dds/DCPS/Serializer.inl
@@ -1316,7 +1316,7 @@ ACE_INLINE bool
 operator>>(Serializer& s, ACE_InputCDR::to_boolean x)
 {
   ACE_CDR::Octet tmp = 0;
-  s.buffer_read(reinterpret_cast<char*>(&x.ref_), boolean_cdr_size, s.swap_bytes());
+  s.buffer_read(reinterpret_cast<char*>(&tmp), boolean_cdr_size, s.swap_bytes());
   if (!s.good_bit()) {
     return false;
   }


### PR DESCRIPTION
This PR attempts to fix: [#5281](https://github.com/OpenDDS/OpenDDS/issues/5281#issue-5201714565)

## Problem

When OpenDDS deserializes an RTPS `Parameter` whose discriminator is `PID_EXPECTS_INLINE_QOS` (`0x0043`) and whose single boolean data byte is not `0` or `1` (e.g. `0xFF`), `operator>>(Serializer&, ACE_InputCDR::to_boolean)` (`dds/DCPS/Serializer.inl:1316`) copies the raw byte directly into a `bool` (`ACE_CDR::Boolean = bool`, `ace/CDR_Base.h:180`) with no validation:

```cpp
operator>>(Serializer& s, ACE_InputCDR::to_boolean x)
{
  s.buffer_read(reinterpret_cast<char*>(&x.ref_), boolean_cdr_size, s.swap_bytes());
  return s.good_bit();
}
```

`buffer_read` only fails on a short stream — it never inspects the byte value — so `0xFF` is loaded into a `bool`. The invalid load happens *inside the library*, unconditionally, before `good_bit()` is consulted. The generated caller (`RtpsCoreTypeSupportImpl.cpp:13828-13829`, and every boolean field emitted via `marshal_generator.cpp:746`) trusts `to_boolean` to either yield a valid `bool` or return `false`; it can do neither for `0xFF`, so the ill-formed `bool` flows into setters like `uni.expects_inline_qos(tmp)`.

This diverges from OpenDDS's own ACE parent. `ACE_InputCDR::read_boolean` (`ace/CDR_Stream.inl`) reads into an `Octet`, normalizes (`tmp ? true : false`), and rejects non-`0`/`1` values via `good_bit_ = !(tmp & ~1)`. OpenDDS's overload skips exactly that contract.

The bug is network-reachable: `dds/DCPS/RTPS/Spdp.cpp:3254` deserializes a remote peer's SPDP `ParameterList` over `KIND_XCDR1` via the same `ser >> plist` -> `Parameter` -> `case 67u` -> `to_boolean` path.

## Fix

Mirror ACE's `read_boolean`: read the byte into a stack `Octet` (safe — `Octet` is `unsigned char`, any bit pattern is valid), normalize it into the `bool` reference, and — if the value is not `0`/`1` — mark construction as failed and return `false` so the generated caller takes its existing failure branch.

```cpp
ACE_INLINE bool
operator>>(Serializer& s, ACE_InputCDR::to_boolean x)
{
  ACE_CDR::Octet tmp = 0;
  s.buffer_read(reinterpret_cast<char*>(&tmp), boolean_cdr_size, s.swap_bytes());
  if (!s.good_bit()) {
    return false;
  }
  if (tmp & ~ACE_CDR::Octet(1)) {
    x.ref_ = tmp != 0;
    s.set_construction_status(Serializer::ElementConstructionFailure);
    return false;
  }
  x.ref_ = tmp != 0;
  return true;
}
```

Why this shape:

- **Read into an `Octet`, not the `bool`.** The UB is the load of `0xFF` into a `bool`. Routing through an `unsigned char` makes the load always-defined.
- **Normalize even on failure** (`x.ref_ = tmp != 0`). Callers that ignore the return value never see a trap representation. Matches ACE's `x = tmp ? true : false`.
- **Return `false` + set `ElementConstructionFailure`.** The generated code at `RtpsCoreTypeSupportImpl.cpp:13828-13834` already handles a `false` return by setting `ElementConstructionFailure` and returning `false` from the `Parameter` deserializer; setting it here too is belt-and-suspenders and mirrors how `to_string` reports `BoundConstructionFailure` for its own validation failures. No new API surface is needed — `set_construction_status` (`Serializer.h:662`) and the `ConstructionStatus` enum (`Serializer.h:654-657`) already exist.
- **`~ACE_CDR::Octet(1)` mask** is the exact check ACE uses, so behavior matches the upstream parent.

This overload is the single chokepoint for *every* boolean deserialization in OpenDDS (the IDL compiler emits `>> to_boolean` for every boolean field), so fixing it here fixes all boolean sites; no generated-code regeneration is required.

## Verification
### Before

```
$ UBSAN_OPTIONS=halt_on_error=1 ./poc
RtpsCoreTypeSupportImpl.cpp:13829:30: runtime error: load of value 255, which is not a valid value for type 'ACE_CDR::Boolean' (aka 'bool')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
RtpsCoreTypeSupportImpl.cpp:13829:30 in ... expects_inline_qos
```

### After

```
$ UBSAN_OPTIONS=halt_on_error=1 ./poc
$ echo $?
0
```

The boolean read returns `false`, the `Parameter` deserializer returns `false` from `case 67u`, `ParameterList` deserialization fails gracefully, and the UBSan diagnostic disappears (clean exit, no sanitizer errors).

In-range booleans (`0x00`, `0x01`) are unchanged: `buffer_read` succeeds, the mask check passes, and `x.ref_` is set to `false`/`true` exactly as before.

### Test results

Rebuilt the library with the OpenDDS security/sanitizer configuration (`OPENDDS_SECURITY=ON`, ASan+UBSan, clang) and reran the reproducer against the patched `Serializer.inl`. The UBSan crash no longer fires; valid booleans deserialize identically.