### PR TITLE
Honor ignore_member_names for unions

### DIFF
--- a/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -847,12 +847,6 @@ bool TypeAssignability::assignable_union(const MinimalTypeObject& ta,
       for (unsigned k = 0; k < label_seq_b.length(); ++k) {
         for (unsigned t = 0; t < label_seq_a.length(); ++t) {
           if (label_seq_b.members[k] == label_seq_a.members[t]) {
-            if (name_hash_equal(ta.union_type.member_seq[j].detail.name_hash,
-                                tb.union_type.member_seq[i].detail.name_hash) &&
-                ta.union_type.member_seq[j].common.member_id !=
-                tb.union_type.member_seq[i].common.member_id) {
-              return false;
-            }
             const TypeIdentifier& ti_a = ta.union_type.member_seq[j].common.type_id;
             const TypeIdentifier& ti_b = tb.union_type.member_seq[i].common.type_id;
             if (!assignable(ti_a, ti_b)) {

--- a/tests/unit-tests/dds/DCPS/XTypes/TypeAssignability.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/TypeAssignability.cpp
@@ -3818,6 +3818,40 @@ TEST(dds_DCPS_XTypes_TypeAssignability, UnionTypeTest_Assignable)
   EXPECT_TRUE(test_imn.assignable(TypeObject(MinimalTypeObject(a_imn)),
                                   TypeObject(MinimalTypeObject(b_imn))));
 
+  // Members with matching names and labels but different IDs are assignable
+  // only when member names are ignored.
+  MinimalUnionType a_reordered, b_reordered;
+  a_reordered.union_flags = IS_APPENDABLE;
+  b_reordered.union_flags = IS_APPENDABLE;
+  a_reordered.discriminator.common.type_id = TypeIdentifier(TK_UINT32);
+  b_reordered.discriminator.common.type_id = TypeIdentifier(TK_UINT32);
+  MinimalUnionMember ma_reordered_1(
+    CommonUnionMember(1, UnionMemberFlag(), TypeIdentifier(TK_INT16),
+                      UnionCaseLabelSeq().append(1)),
+    MinimalMemberDetail("m1"));
+  MinimalUnionMember ma_reordered_2(
+    CommonUnionMember(2, UnionMemberFlag(), TypeIdentifier(TK_INT32),
+                      UnionCaseLabelSeq().append(2)),
+    MinimalMemberDetail("m2"));
+  MinimalUnionMember mb_reordered_1(
+    CommonUnionMember(1, UnionMemberFlag(), TypeIdentifier(TK_INT32),
+                      UnionCaseLabelSeq().append(2)),
+    MinimalMemberDetail("m2"));
+  MinimalUnionMember mb_reordered_2(
+    CommonUnionMember(2, UnionMemberFlag(), TypeIdentifier(TK_INT16),
+                      UnionCaseLabelSeq().append(1)),
+    MinimalMemberDetail("m1"));
+  a_reordered.member_seq.append(ma_reordered_1).append(ma_reordered_2);
+  b_reordered.member_seq.append(mb_reordered_1).append(mb_reordered_2);
+  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(a_reordered)),
+                               TypeObject(MinimalTypeObject(b_reordered))));
+  EXPECT_FALSE(test.assignable(TypeObject(MinimalTypeObject(b_reordered)),
+                               TypeObject(MinimalTypeObject(a_reordered))));
+  EXPECT_TRUE(test_imn.assignable(TypeObject(MinimalTypeObject(a_reordered)),
+                                  TypeObject(MinimalTypeObject(b_reordered))));
+  EXPECT_TRUE(test_imn.assignable(TypeObject(MinimalTypeObject(b_reordered)),
+                                  TypeObject(MinimalTypeObject(a_reordered))));
+
   // Non-default labels in T2 that select some member in T1
   MinimalUnionType a2, b2;
   a2.union_flags = IS_MUTABLE;


### PR DESCRIPTION
### Motivation

Union assignability incorrectly rejected compatible unions with different member IDs even when ignore_member_names was enabled.

### Description of changes

Remove the redundant unconditional union member-name/ID check (the earlier check at lines 802-826 is correctly gated on ignore_member_names) and add regression coverage for assignability with ignore_member_names enabled and disabled.
