### PR TITLE
XCDR Deserialization Hardening

### DIFF
--- a/dds/DCPS/SafetyProfileSequences.cpp
+++ b/dds/DCPS/SafetyProfileSequences.cpp
@@ -55,7 +55,7 @@ bool operator>>(Serializer& strm, CORBASeq::BooleanSeq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, boolean_cdr_size, boolean_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -107,7 +107,7 @@ bool operator>>(Serializer& strm, CORBASeq::CharSeq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, char8_cdr_size, char8_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -160,7 +160,7 @@ bool operator>>(Serializer& strm, CORBASeq::DoubleSeq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, float64_cdr_size, float64_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -212,7 +212,7 @@ bool operator>>(Serializer& strm, CORBASeq::FloatSeq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, float32_cdr_size, float32_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -264,7 +264,7 @@ bool operator>>(Serializer& strm, CORBASeq::Int8Seq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, int8_cdr_size, int8_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -317,7 +317,7 @@ bool operator>>(Serializer& strm, CORBASeq::LongDoubleSeq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, float128_cdr_size, float128_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -370,7 +370,7 @@ bool operator>>(Serializer& strm, CORBASeq::LongLongSeq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, int64_cdr_size, int64_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -422,7 +422,7 @@ bool operator>>(Serializer& strm, CORBASeq::LongSeq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, int32_cdr_size, int32_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -474,7 +474,7 @@ bool operator>>(Serializer& strm, CORBASeq::OctetSeq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, byte_cdr_size, byte_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -526,7 +526,7 @@ bool operator>>(Serializer& strm, CORBASeq::ShortSeq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, int16_cdr_size, int16_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -600,12 +600,17 @@ bool operator>>(Serializer& strm, CORBASeq::StringSeq& seq)
       return false;
     }
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size,
+    encoding.xcdr_version() == Encoding::XCDR_VERSION_2, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
   const size_t end_of_seq = strm.rpos() + total_size;
   CORBA::ULong length;
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, uint32_cdr_size, uint32_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -682,7 +687,7 @@ bool operator>>(Serializer& strm, CORBASeq::UInt8Seq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, uint8_cdr_size, uint8_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -735,7 +740,7 @@ bool operator>>(Serializer& strm, CORBASeq::ULongLongSeq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, uint64_cdr_size, uint64_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -787,7 +792,7 @@ bool operator>>(Serializer& strm, CORBASeq::ULongSeq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, uint32_cdr_size, uint32_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }
@@ -839,7 +844,7 @@ bool operator>>(Serializer& strm, CORBASeq::UShortSeq& seq)
   if (!(strm >> length)) {
     return false;
   }
-  if (length > strm.length()) {
+  if (!strm.check_size(length, uint16_cdr_size, uint16_cdr_size)) {
     if (DCPS_debug_level >= 8) {
       ACE_DEBUG((LM_DEBUG, ACE_TEXT("(%P|%t) Invalid sequence length (%u)\n"), length));
     }

--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -178,6 +178,7 @@ Serializer::ScopedReadLimit::ScopedReadLimit(Serializer& ser, size_t size,
   , enabled_(enabled)
   , skip_remainder_(skip_remainder)
   , valid_(false)
+  , finished_(false)
 {
   if (!enabled_) {
     valid_ = ser.good_bit_;
@@ -195,7 +196,7 @@ Serializer::ScopedReadLimit::ScopedReadLimit(Serializer& ser, size_t size,
 
 Serializer::ScopedReadLimit::~ScopedReadLimit()
 {
-  if (enabled_ && skip_remainder_ && valid_ && ser_.good_bit_) {
+  if (!finished_ && enabled_ && skip_remainder_ && valid_ && ser_.good_bit_) {
     skip_to_end();
   }
   ser_.read_limit_ = previous_limit_;
@@ -209,6 +210,18 @@ size_t Serializer::ScopedReadLimit::remaining() const
 bool Serializer::ScopedReadLimit::skip_to_end()
 {
   return enabled_ && valid_ && ser_.good_bit_ && ser_.skip(remaining());
+}
+
+bool Serializer::ScopedReadLimit::finish()
+{
+  if (finished_) {
+    return valid_ && ser_.good_bit_;
+  }
+  const bool result = valid_ && ser_.good_bit_ &&
+    (!enabled_ || !skip_remainder_ || skip_to_end());
+  ser_.read_limit_ = previous_limit_;
+  finished_ = true;
+  return result;
 }
 
 Serializer::ScopedAlignmentContext::ScopedAlignmentContext(Serializer& ser, size_t min_read)

--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -184,13 +184,33 @@ Serializer::ScopedReadLimit::ScopedReadLimit(Serializer& ser, size_t size,
     valid_ = ser.good_bit_;
     return;
   }
+  install(size);
+}
+
+Serializer::ScopedReadLimit::ScopedReadLimit(Serializer& ser)
+  : ser_(ser)
+  , previous_limit_(ser.read_limit_)
+  , end_(ser.rpos_)
+  , enabled_(true)
+  , skip_remainder_(true)
+  , valid_(false)
+  , finished_(false)
+{
+  size_t size = 0;
+  if (ser.read_delimiter(size)) {
+    install(size);
+  }
+}
+
+void Serializer::ScopedReadLimit::install(size_t size)
+{
   const size_t max = (std::numeric_limits<size_t>::max)();
-  if (ser.good_bit_ && size <= ser.length() && size <= max - ser.rpos_) {
-    end_ = ser.rpos_ + size;
-    ser.read_limit_ = end_;
+  if (ser_.good_bit_ && size <= ser_.length() && size <= max - ser_.rpos_) {
+    end_ = ser_.rpos_ + size;
+    ser_.read_limit_ = end_;
     valid_ = true;
   } else {
-    ser.good_bit_ = false;
+    ser_.good_bit_ = false;
   }
 }
 

--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -244,6 +244,19 @@ bool Serializer::ScopedReadLimit::finish()
   return result;
 }
 
+bool Serializer::ScopedReadLimit::reset(size_t size)
+{
+  if (finished_) {
+    return false;
+  }
+  ser_.read_limit_ = previous_limit_;
+  enabled_ = true;
+  end_ = ser_.rpos_;
+  valid_ = false;
+  install(size);
+  return valid_;
+}
+
 Serializer::ScopedAlignmentContext::ScopedAlignmentContext(Serializer& ser, size_t min_read)
   : ser_(ser)
   , max_align_(ser.encoding().max_align())

--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -560,6 +560,9 @@ ACE_Message_Block* Serializer::trim(size_t n) const
 
 bool Serializer::read_parameter_id(unsigned& id, size_t& size, bool& must_understand)
 {
+  id = 0;
+  size = 0;
+  must_understand = false;
   const Encoding::XcdrVersion xcdr = encoding().xcdr_version();
   if (xcdr == Encoding::XCDR_VERSION_1) {
     // Get the "short" id and size
@@ -638,6 +641,13 @@ bool Serializer::read_parameter_id(unsigned& id, size_t& size, bool& must_unders
       }
     }
     id = emheader & 0xfffffff;
+  }
+
+  // A member that claims more bytes than remain in the (possibly limited) input
+  // is malformed regardless of what the caller does with it next.
+  if (size > length()) {
+    good_bit_ = false;
+    return false;
   }
 
   return true;

--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -22,6 +22,7 @@
 #include <ace/Log_Msg.h>
 
 #include <cstdlib>
+#include <limits>
 
 OPENDDS_BEGIN_VERSIONED_NAMESPACE_DECL
 
@@ -128,6 +129,7 @@ Serializer::Serializer(ACE_Message_Block* chain, const Encoding& enc)
   , align_rshift_(0)
   , align_wshift_(0)
   , rpos_(0)
+  , read_limit_((std::numeric_limits<size_t>::max)())
   , wpos_(0)
 {
   encoding(enc);
@@ -142,6 +144,7 @@ Serializer::Serializer(ACE_Message_Block* chain, Encoding::Kind kind,
   , align_rshift_(0)
   , align_wshift_(0)
   , rpos_(0)
+  , read_limit_((std::numeric_limits<size_t>::max)())
   , wpos_(0)
 {
   encoding(Encoding(kind, endianness));
@@ -156,6 +159,7 @@ Serializer::Serializer(ACE_Message_Block* chain,
   , align_rshift_(0)
   , align_wshift_(0)
   , rpos_(0)
+  , read_limit_((std::numeric_limits<size_t>::max)())
   , wpos_(0)
 {
   encoding(Encoding(kind, swap_bytes));
@@ -164,6 +168,47 @@ Serializer::Serializer(ACE_Message_Block* chain,
 
 Serializer::~Serializer()
 {
+}
+
+Serializer::ScopedReadLimit::ScopedReadLimit(Serializer& ser, size_t size,
+                                             bool enabled, bool skip_remainder)
+  : ser_(ser)
+  , previous_limit_(ser.read_limit_)
+  , end_(ser.rpos_)
+  , enabled_(enabled)
+  , skip_remainder_(skip_remainder)
+  , valid_(false)
+{
+  if (!enabled_) {
+    valid_ = ser.good_bit_;
+    return;
+  }
+  const size_t max = (std::numeric_limits<size_t>::max)();
+  if (ser.good_bit_ && size <= ser.length() && size <= max - ser.rpos_) {
+    end_ = ser.rpos_ + size;
+    ser.read_limit_ = end_;
+    valid_ = true;
+  } else {
+    ser.good_bit_ = false;
+  }
+}
+
+Serializer::ScopedReadLimit::~ScopedReadLimit()
+{
+  if (enabled_ && skip_remainder_ && valid_ && ser_.good_bit_) {
+    skip_to_end();
+  }
+  ser_.read_limit_ = previous_limit_;
+}
+
+size_t Serializer::ScopedReadLimit::remaining() const
+{
+  return enabled_ && valid_ && ser_.rpos_ <= end_ ? end_ - ser_.rpos_ : 0;
+}
+
+bool Serializer::ScopedReadLimit::skip_to_end()
+{
+  return enabled_ && valid_ && ser_.good_bit_ && ser_.skip(remaining());
 }
 
 Serializer::ScopedAlignmentContext::ScopedAlignmentContext(Serializer& ser, size_t min_read)
@@ -405,6 +450,10 @@ Serializer::read_string(ACE_CDR::WChar*& dest,
   //
   ACE_CDR::ULong length = 0;
   if (current_ && bytecount <= current_->total_length()) {
+    if (bytecount % char16_cdr_size) {
+      good_bit_ = false;
+      return 0;
+    }
     length = bytecount / char16_cdr_size;
     dest = str_alloc(length);
 
@@ -496,13 +545,17 @@ bool Serializer::read_parameter_id(unsigned& id, size_t& size, bool& must_unders
 
     // If extended, get the "long" id and size
     if (short_id == pid_extended) {
+      if (short_size < 8u) {
+        good_bit_ = false;
+        return false;
+      }
       ACE_CDR::ULong emheader, long_size;
       if (!(*this >> emheader) || !(*this >> long_size)) {
         return false;
       }
       const unsigned short_size_left = short_size - 8u;
-      if (short_size_left) {
-        skip(short_size_left);
+      if (short_size_left && !skip(short_size_left)) {
+        return false;
       }
       id = emheader & MEMBER_ID_MASK;
       size = long_size;
@@ -536,13 +589,18 @@ bool Serializer::read_parameter_id(unsigned& id, size_t& size, bool& must_unders
         size = next_int;
         break;
       case 5:
-        size = uint32_cdr_size + next_int;
-        break;
       case 6:
-        size = uint32_cdr_size + next_int * 4;
-        break;
       case 7:
-        size = uint32_cdr_size + next_int * 8;
+        {
+          const size_t multiplier = lc == 5 ? 1u : lc == 6 ? 4u : 8u;
+          const size_t next = next_int;
+          const size_t max = (std::numeric_limits<size_t>::max)();
+          if (next > (max - uint32_cdr_size) / multiplier) {
+            good_bit_ = false;
+            return false;
+          }
+          size = uint32_cdr_size + next * multiplier;
+        }
         break;
       }
     }

--- a/dds/DCPS/Serializer.cpp
+++ b/dds/DCPS/Serializer.cpp
@@ -415,9 +415,11 @@ Serializer::read_string(ACE_CDR::Char*& dest,
   //
   // NOTE: Maintain the ACE implementation where the length check is
   //       done here before the allocation even though it will be
-  //       checked during the actual read as well.
+  //       checked during the actual read as well.  Bound by length()
+  //       (not total_length()) so an oversized length inside a
+  //       read-limited region is rejected before allocating.
   //
-  if (current_ && length <= current_->total_length()) {
+  if (current_ && length <= this->length()) {
 
     dest = str_alloc(length - 1);
 
@@ -495,7 +497,7 @@ Serializer::read_string(ACE_CDR::WChar*& dest,
   //       checked during the actual read as well.
   //
   ACE_CDR::ULong length = 0;
-  if (current_ && bytecount <= current_->total_length()) {
+  if (current_ && bytecount <= this->length()) {
     if (bytecount % char16_cdr_size) {
       good_bit_ = false;
       return 0;
@@ -654,13 +656,6 @@ bool Serializer::read_parameter_id(unsigned& id, size_t& size, bool& must_unders
       }
     }
     id = emheader & 0xfffffff;
-  }
-
-  // A member that claims more bytes than remain in the (possibly limited) input
-  // is malformed regardless of what the caller does with it next.
-  if (size > length()) {
-    good_bit_ = false;
-    return false;
   }
 
   return true;

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -356,7 +356,14 @@ public:
    */
   bool check_size(size_t count, size_t element_size, size_t element_alignment = 1);
 
-  /// Permanently narrow the active read region starting at the current position.
+  /**
+   * Narrow the active read region to @a size bytes starting at the current
+   * position.  Unlike ScopedReadLimit this is not restored automatically: the
+   * limit stays in effect until it is widened by a later rdstate() restore or
+   * the Serializer is re-initialized.  Callers that narrow the limit for a
+   * self-contained read and then continue reading the enclosing object are
+   * responsible for saving and restoring rdstate() themselves.
+   */
   bool set_read_limit(size_t size);
 
   typedef ACE_CDR::Char* (*StrAllocate)(ACE_CDR::ULong);
@@ -697,6 +704,14 @@ public:
    * Restrict reads to a nested region of the input stream.  The limit starts
    * at the current read position and is restored when this object is
    * destroyed.  Reads, skips, and alignment cannot cross the active limit.
+   *
+   * With @c skip_remainder, any bytes left in the region are consumed when the
+   * object is destroyed (or by an explicit finish()), leaving the stream
+   * positioned just past the region; this is how appendable/mutable trailing
+   * data is tolerated.  With @c enabled false the object is an inert pass-
+   * through, for call sites that only sometimes have a delimited region.
+   * finish() applies the skip and restores the limit early, before the caller
+   * reads whatever follows the region (such as a parameter-list sentinel).
    */
   class OpenDDS_Dcps_Export ScopedReadLimit {
   public:

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -349,6 +349,16 @@ public:
   /// Number of bytes left to read in message block chain
   size_t length() const;
 
+  /**
+   * Verify that an array-like value fits in the remaining input before its
+   * destination container is allocated.  This accounts for the alignment of
+   * the first element and rejects size_t multiplication overflow.
+   */
+  bool check_size(size_t count, size_t element_size, size_t element_alignment = 1);
+
+  /// Permanently narrow the active read region starting at the current position.
+  bool set_read_limit(size_t size);
+
   typedef ACE_CDR::Char* (*StrAllocate)(ACE_CDR::ULong);
   typedef void (*StrFree)(ACE_CDR::Char*);
   typedef ACE_CDR::WChar* (*WStrAllocate)(ACE_CDR::ULong);
@@ -683,6 +693,33 @@ public:
     const size_t wblock_;
   };
 
+  /**
+   * Restrict reads to a nested region of the input stream.  The limit starts
+   * at the current read position and is restored when this object is
+   * destroyed.  Reads, skips, and alignment cannot cross the active limit.
+   */
+  class OpenDDS_Dcps_Export ScopedReadLimit {
+  public:
+    ScopedReadLimit(Serializer& ser, size_t size, bool enabled = true,
+                    bool skip_remainder = false);
+    ~ScopedReadLimit();
+
+    bool valid() const { return valid_; }
+    size_t remaining() const;
+    bool skip_to_end();
+
+  private:
+    ScopedReadLimit(const ScopedReadLimit&);
+    ScopedReadLimit& operator=(const ScopedReadLimit&);
+
+    Serializer& ser_;
+    const size_t previous_limit_;
+    size_t end_;
+    const bool enabled_;
+    const bool skip_remainder_;
+    bool valid_;
+  };
+
   template <typename T>
   bool peek_helper(ACE_Message_Block* const block, size_t bytes, T& t)
   {
@@ -727,10 +764,12 @@ public:
   // This is used by DynamicData and must have all reading-related members of
   // of Serializer for DynamicData to work correctly.
   struct RdState {
-    explicit RdState(unsigned char shift = 0, size_t pos = 0)
-      : align_rshift(shift), rpos(pos) {}
+    explicit RdState(unsigned char shift = 0, size_t pos = 0,
+                     size_t limit = (std::numeric_limits<size_t>::max)())
+      : align_rshift(shift), rpos(pos), read_limit(limit) {}
     unsigned char align_rshift;
     size_t rpos;
+    size_t read_limit;
   };
 
   RdState rdstate() const;
@@ -812,6 +851,9 @@ private:
 
   /// Logical reading position of the stream.
   size_t rpos_;
+
+  /// Absolute logical position beyond which reads are not permitted.
+  size_t read_limit_;
 
   /// Logical writing position of the stream.
   size_t wpos_;

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -707,6 +707,7 @@ public:
     bool valid() const { return valid_; }
     size_t remaining() const;
     bool skip_to_end();
+    bool finish();
 
   private:
     ScopedReadLimit(const ScopedReadLimit&);
@@ -718,6 +719,7 @@ public:
     const bool enabled_;
     const bool skip_remainder_;
     bool valid_;
+    bool finished_;
   };
 
   template <typename T>

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -702,6 +702,17 @@ public:
   public:
     ScopedReadLimit(Serializer& ser, size_t size, bool enabled = true,
                     bool skip_remainder = false);
+
+    /**
+     * Read an XCDR2 delimiter (DHEADER) from @a ser and restrict subsequent
+     * reads to the region it describes.  Equivalent to reading the delimiter
+     * and then constructing with skip_remainder enabled: any bytes left in the
+     * region when this object is destroyed are skipped, leaving the stream
+     * positioned after the delimited object.  valid() is false if the delimiter
+     * could not be read or its size exceeds the remaining input.
+     */
+    explicit ScopedReadLimit(Serializer& ser);
+
     ~ScopedReadLimit();
 
     bool valid() const { return valid_; }
@@ -712,6 +723,10 @@ public:
   private:
     ScopedReadLimit(const ScopedReadLimit&);
     ScopedReadLimit& operator=(const ScopedReadLimit&);
+
+    /// Bound reads to @a size bytes starting at the current position, or clear
+    /// the stream's good bit if that does not fit in the remaining input.
+    void install(size_t size);
 
     Serializer& ser_;
     const size_t previous_limit_;

--- a/dds/DCPS/Serializer.h
+++ b/dds/DCPS/Serializer.h
@@ -735,6 +735,15 @@ public:
     bool skip_to_end();
     bool finish();
 
+    /**
+     * (Re)arm the limit to @a size bytes starting at the current position,
+     * discarding any narrowing this object had already applied.  Intended for
+     * "construct inert, then bound once the member size is known" flows: build
+     * with enabled == false, read the parameter-id/length, then call reset().
+     * Returns valid().
+     */
+    bool reset(size_t size);
+
   private:
     ScopedReadLimit(const ScopedReadLimit&);
     ScopedReadLimit& operator=(const ScopedReadLimit&);
@@ -746,7 +755,7 @@ public:
     Serializer& ser_;
     const size_t previous_limit_;
     size_t end_;
-    const bool enabled_;
+    bool enabled_;
     const bool skip_remainder_;
     bool valid_;
     bool finished_;

--- a/dds/DCPS/Serializer.inl
+++ b/dds/DCPS/Serializer.inl
@@ -266,6 +266,10 @@ Serializer::doread(char* dest, size_t size, bool swap, size_t offset)
 ACE_INLINE void
 Serializer::buffer_read(char* dest, size_t size, bool swap)
 {
+  if (size > length()) {
+    good_bit_ = false;
+    return;
+  }
   size_t offset = 0;
 
   while (size > offset) {
@@ -398,17 +402,65 @@ Serializer::good_bit() const
 ACE_INLINE size_t
 Serializer::length() const
 {
-  return good_bit_ && current_ ? current_->total_length() : 0;
+  if (!good_bit_ || !current_ || rpos_ > read_limit_) {
+    return 0;
+  }
+  return (std::min)(current_->total_length(), read_limit_ - rpos_);
+}
+
+ACE_INLINE bool
+Serializer::check_size(size_t count, size_t element_size, size_t element_alignment)
+{
+  const size_t max = (std::numeric_limits<size_t>::max)();
+  if (count && element_size > max / count) {
+    good_bit_ = false;
+    return false;
+  }
+
+  size_t padding = 0;
+  if (alignment() && element_alignment > 1 && current_) {
+    element_alignment = (std::min)(element_alignment, encoding().max_align());
+    padding = (element_alignment - reinterpret_cast<size_t>(current_->rd_ptr()) +
+      align_rshift_) % element_alignment;
+  }
+  const size_t bytes = count * element_size;
+  if (padding > length() || bytes > length() - padding) {
+    good_bit_ = false;
+    return false;
+  }
+  return true;
+}
+
+ACE_INLINE bool
+Serializer::set_read_limit(size_t size)
+{
+  const size_t max = (std::numeric_limits<size_t>::max)();
+  if (!good_bit_ || size > length() || size > max - rpos_) {
+    good_bit_ = false;
+    return false;
+  }
+  read_limit_ = rpos_ + size;
+  return true;
 }
 
 ACE_INLINE bool
 Serializer::skip(size_t n, int size)
 {
+  if (size < 0 || (n && static_cast<size_t>(size) >
+      (std::numeric_limits<size_t>::max)() / n)) {
+    good_bit_ = false;
+    return false;
+  }
   if (size > 1 && !align_r((std::min)(size_t(size), encoding().max_align()))) {
     return false;
   }
 
-  for (size_t len = n * static_cast<size_t>(size); len;) {
+  const size_t total = n * static_cast<size_t>(size);
+  if (total > length()) {
+    good_bit_ = false;
+    return false;
+  }
+  for (size_t len = total; len;) {
     if (!current_) {
       good_bit_ = false;
       return false;
@@ -425,7 +477,7 @@ Serializer::skip(size_t n, int size)
   }
 
   if (good_bit_) {
-    rpos_ += n * static_cast<size_t>(size);
+    rpos_ += total;
   }
   return good_bit();
 }
@@ -440,6 +492,10 @@ ACE_INLINE void
 Serializer::read_array(char* x, size_t size,
                        ACE_CDR::ULong length, bool swap)
 {
+  if (length && size > (std::numeric_limits<size_t>::max)() / length) {
+    good_bit_ = false;
+    return;
+  }
   if (!swap || size == 1) {
     //
     // No swap, copy direct.  This silently corrupts the data if there is
@@ -494,8 +550,15 @@ Serializer::write_array(const char* x, size_t size,
 ACE_INLINE bool
 Serializer::read_boolean_array(ACE_CDR::Boolean* x, ACE_CDR::ULong length)
 {
-  read_array(reinterpret_cast<char*>(x), boolean_cdr_size, length);
-  return good_bit();
+  for (ACE_CDR::ULong i = 0; i < length; ++i) {
+    ACE_CDR::Octet value = 0;
+    buffer_read(reinterpret_cast<char*>(&value), boolean_cdr_size, false);
+    if (!good_bit()) {
+      return false;
+    }
+    x[i] = value != 0;
+  }
+  return true;
 }
 
 ACE_INLINE bool
@@ -876,6 +939,10 @@ bool Serializer::read_delimiter(size_t& size)
   if (encoding().xcdr_version() == Encoding::XCDR_VERSION_2) {
     ACE_CDR::ULong dheader;
     if (*this >> dheader) {
+      if (dheader > length()) {
+        good_bit_ = false;
+        return false;
+      }
       size = dheader;
       return true;
     }
@@ -1327,8 +1394,13 @@ operator>>(Serializer& s, long double& x)
 ACE_INLINE bool
 operator>>(Serializer& s, ACE_InputCDR::to_boolean x)
 {
-  s.buffer_read(reinterpret_cast<char*>(&x.ref_), boolean_cdr_size, s.swap_bytes());
-  return s.good_bit();
+  ACE_CDR::Octet value = 0;
+  s.buffer_read(reinterpret_cast<char*>(&value), boolean_cdr_size, false);
+  if (s.good_bit()) {
+    x.ref_ = value != 0;
+    return true;
+  }
+  return false;
 }
 
 ACE_INLINE bool
@@ -1734,7 +1806,7 @@ void Serializer::set_construction_status(ConstructionStatus cs)
 ACE_INLINE
 Serializer::RdState Serializer::rdstate() const
 {
-  RdState state(align_rshift_, rpos_);
+  RdState state(align_rshift_, rpos_, read_limit_);
   return state;
 }
 
@@ -1743,6 +1815,7 @@ void Serializer::rdstate(const RdState& state)
 {
   align_rshift_ = state.align_rshift;
   rpos_ = state.rpos;
+  read_limit_ = state.read_limit;
 }
 
 } // namespace DCPS

--- a/dds/DCPS/Serializer.inl
+++ b/dds/DCPS/Serializer.inl
@@ -417,6 +417,8 @@ Serializer::check_size(size_t count, size_t element_size, size_t element_alignme
     return false;
   }
 
+  // Bytes of alignment padding align_r() would insert before the first element;
+  // this must use the same formula as align_r() to stay in sync with it.
   size_t padding = 0;
   if (alignment() && element_alignment > 1 && current_) {
     element_alignment = (std::min)(element_alignment, encoding().max_align());

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -559,6 +559,10 @@ bool DynamicDataXcdrReadImpl::get_struct_item_count()
       }
       return false;
     }
+    DCPS::Serializer::ScopedReadLimit read_limit(strm_, dheader, true, true);
+    if (!read_limit.valid()) {
+      return false;
+    }
 
     const size_t end_of_struct = xcdr1 ? 0 : strm_.rpos() + dheader;
     while (xcdr1 || strm_.rpos() < end_of_struct) {
@@ -766,6 +770,10 @@ DDS::UInt32 DynamicDataXcdrReadImpl::get_item_count()
         if (log_level >= LogLevel::Warning) {
           ACE_ERROR((LM_WARNING, "(%P|%t) WARNING: DynamicDataXcdrReadImpl::get_item_count: read delimiter failed\n"));
         }
+        return 0;
+      }
+      DCPS::Serializer::ScopedReadLimit read_limit(strm_, dheader, true, true);
+      if (!read_limit.valid()) {
         return 0;
       }
       const size_t end_of_map = strm_.rpos() + dheader;
@@ -1110,6 +1118,9 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_value_from_union(
     if (!strm_.read_parameter_id(member_id, member_size, must_understand)) {
       return DDS::RETCODE_ERROR;
     }
+    if (!strm_.set_read_limit(member_size)) {
+      return DDS::RETCODE_ERROR;
+    }
   }
 
   if (member_tk == MemberTypeKind) {
@@ -1259,6 +1270,9 @@ bool DynamicDataXcdrReadImpl::skip_to_map_entry(MemberId id, bool skip_key, size
     size_t dheader;
     ACE_CDR::ULong index;
     if (!strm_.read_delimiter(dheader) || !get_index_from_id(id, index, ACE_UINT32_MAX)) {
+      return false;
+    }
+    if (!strm_.set_read_limit(dheader)) {
       return false;
     }
     const size_t end_of_map = strm_.rpos() + dheader;
@@ -1777,6 +1791,10 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_complex_value(DDS::DynamicData_pt
             good = false;
             break;
           }
+          if (!strm_.set_read_limit(size)) {
+            good = false;
+            break;
+          }
         }
         CORBA::release(value);
         value = new DynamicDataXcdrReadImpl(strm_, disc_type, nested(extent_));
@@ -1794,6 +1812,10 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_complex_value(DDS::DynamicData_pt
         size_t size;
         bool must_understand;
         if (!strm_.read_parameter_id(mem_id, size, must_understand)) {
+          good = false;
+          break;
+        }
+        if (!strm_.set_read_limit(size)) {
           good = false;
           break;
         }
@@ -2255,6 +2277,9 @@ bool DynamicDataXcdrReadImpl::get_values_from_union(SequenceType& value, MemberI
     if (!strm_.read_parameter_id(member_id, member_size, must_understand)) {
       return false;
     }
+    if (!strm_.set_read_limit(member_size)) {
+      return false;
+    }
   }
 
   if (elem_tk == ElementTypeKind) {
@@ -2561,6 +2586,9 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::skip_to_struct_member(DDS::MemberDesc
       }
       return DDS::RETCODE_ERROR;
     }
+    if (xcdr2_appendable && !strm_.set_read_limit(dheader)) {
+      return DDS::RETCODE_ERROR;
+    }
     const size_t end_of_struct = strm_.rpos() + dheader;
 
     for (ACE_CDR::ULong i = 0; i < member_desc->index(); ++i) {
@@ -2631,6 +2659,9 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::skip_to_struct_member(DDS::MemberDesc
       }
       return DDS::RETCODE_ERROR;
     }
+    if (!strm_.set_read_limit(dheader)) {
+      return DDS::RETCODE_ERROR;
+    }
 
     const size_t end_of_struct = xcdr1 ? 0 : strm_.rpos() + dheader;
     while (true) {
@@ -2658,6 +2689,9 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::skip_to_struct_member(DDS::MemberDesc
       }
 
       if (member_id == id) {
+        if (!strm_.set_read_limit(member_size)) {
+          return DDS::RETCODE_ERROR;
+        }
         return DDS::RETCODE_OK;
       }
 
@@ -3035,12 +3069,15 @@ void DynamicDataXcdrReadImpl::release_chains()
 
 bool DynamicDataXcdrReadImpl::read_discriminator(const DDS::DynamicType_ptr disc_type, DDS::ExtensibilityKind union_ek, ACE_CDR::Long& label)
 {
+  size_t member_size = 0;
   if (union_ek == DDS::MUTABLE) {
     unsigned id;
-    size_t size;
     bool must_understand;
-    if (!strm_.read_parameter_id(id, size, must_understand)) { return false; }
+    if (!strm_.read_parameter_id(id, member_size, must_understand)) { return false; }
   }
+  DCPS::Serializer::ScopedReadLimit member_limit(strm_, member_size,
+    union_ek == DDS::MUTABLE, true);
+  if (!member_limit.valid()) { return false; }
 
   const TypeKind disc_tk = disc_type->get_kind();
   switch (disc_tk) {

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -559,7 +559,7 @@ bool DynamicDataXcdrReadImpl::get_struct_item_count()
       }
       return false;
     }
-    DCPS::Serializer::ScopedReadLimit read_limit(strm_, dheader, true, true);
+    DCPS::Serializer::ScopedReadLimit read_limit(strm_, dheader, !xcdr1, true);
     if (!read_limit.valid()) {
       return false;
     }
@@ -576,6 +576,9 @@ bool DynamicDataXcdrReadImpl::get_struct_item_count()
         return false;
       }
       if (xcdr1 && member_id == DCPS::Serializer::pid_list_end) {
+        if (member_size != 0) {
+          return false;
+        }
         break;
       }
       if (!strm_.skip(member_size)) {
@@ -1116,6 +1119,9 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_value_from_union(
     size_t member_size;
     bool must_understand;
     if (!strm_.read_parameter_id(member_id, member_size, must_understand)) {
+      return DDS::RETCODE_ERROR;
+    }
+    if (id == DISCRIMINATOR_ID && member_id != DISCRIMINATOR_SERIALIZED_ID) {
       return DDS::RETCODE_ERROR;
     }
     if (!strm_.set_read_limit(member_size)) {
@@ -1787,7 +1793,8 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_complex_value(DDS::DynamicData_pt
           unsigned disc_id;
           size_t size;
           bool must_understand;
-          if (!strm_.read_parameter_id(disc_id, size, must_understand)) {
+          if (!strm_.read_parameter_id(disc_id, size, must_understand) ||
+              disc_id != DISCRIMINATOR_SERIALIZED_ID) {
             good = false;
             break;
           }
@@ -2659,7 +2666,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::skip_to_struct_member(DDS::MemberDesc
       }
       return DDS::RETCODE_ERROR;
     }
-    if (!strm_.set_read_limit(dheader)) {
+    if (!xcdr1 && !strm_.set_read_limit(dheader)) {
       return DDS::RETCODE_ERROR;
     }
 
@@ -2685,7 +2692,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::skip_to_struct_member(DDS::MemberDesc
       }
 
       if (xcdr1 && member_id == DCPS::Serializer::pid_list_end) {
-        return DDS::RETCODE_NO_DATA;
+        return member_size == 0 ? DDS::RETCODE_NO_DATA : DDS::RETCODE_ERROR;
       }
 
       if (member_id == id) {
@@ -3073,7 +3080,8 @@ bool DynamicDataXcdrReadImpl::read_discriminator(const DDS::DynamicType_ptr disc
   if (union_ek == DDS::MUTABLE) {
     unsigned id;
     bool must_understand;
-    if (!strm_.read_parameter_id(id, member_size, must_understand)) { return false; }
+    if (!strm_.read_parameter_id(id, member_size, must_understand) ||
+        id != DISCRIMINATOR_SERIALIZED_ID) { return false; }
   }
   DCPS::Serializer::ScopedReadLimit member_limit(strm_, member_size,
     union_ek == DDS::MUTABLE, true);
@@ -3260,7 +3268,7 @@ bool DynamicDataXcdrReadImpl::skip_all()
         return false;
       }
       if (member_id == DCPS::Serializer::pid_list_end) {
-        return true;
+        return member_size == 0;
       }
       if (!strm_.skip(member_size)) {
         return false;

--- a/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -1114,6 +1114,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_value_from_union(
     return DDS::RETCODE_ERROR;
   }
 
+  DCPS::Serializer::ScopedReadLimit member_limit(strm_, 0, false);
   if (ek == DDS::MUTABLE) {
     unsigned member_id;
     size_t member_size;
@@ -1124,7 +1125,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_value_from_union(
     if (id == DISCRIMINATOR_ID && member_id != DISCRIMINATOR_SERIALIZED_ID) {
       return DDS::RETCODE_ERROR;
     }
-    if (!strm_.set_read_limit(member_size)) {
+    if (!member_limit.reset(member_size)) {
       return DDS::RETCODE_ERROR;
     }
   }
@@ -1278,6 +1279,9 @@ bool DynamicDataXcdrReadImpl::skip_to_map_entry(MemberId id, bool skip_key, size
     if (!strm_.read_delimiter(dheader) || !get_index_from_id(id, index, ACE_UINT32_MAX)) {
       return false;
     }
+    // The limit deliberately outlives this call: the caller reads the located
+    // entry next and must stay within the map's delimited region.  It is reset
+    // when the next ScopedChainManager re-initializes strm_.
     if (!strm_.set_read_limit(dheader)) {
       return false;
     }
@@ -1789,6 +1793,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_complex_value(DDS::DynamicData_pt
         }
 
         const DDS::DynamicType_var disc_type = get_base_type(type_desc_->discriminator_type());
+        DCPS::Serializer::ScopedReadLimit disc_limit(strm_, 0, false);
         if (ek == DDS::MUTABLE) {
           unsigned disc_id;
           size_t size;
@@ -1798,11 +1803,13 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_complex_value(DDS::DynamicData_pt
             good = false;
             break;
           }
-          if (!strm_.set_read_limit(size)) {
+          if (!disc_limit.reset(size)) {
             good = false;
             break;
           }
         }
+        // The nested reader below snapshots the (possibly narrowed) read limit
+        // at construction; disc_limit keeps it in place until then.
         CORBA::release(value);
         value = new DynamicDataXcdrReadImpl(strm_, disc_type, nested(extent_));
         break;
@@ -1814,6 +1821,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_complex_value(DDS::DynamicData_pt
         break;
       }
 
+      DCPS::Serializer::ScopedReadLimit member_limit(strm_, 0, false);
       if (ek == DDS::MUTABLE) {
         unsigned mem_id;
         size_t size;
@@ -1822,7 +1830,7 @@ DDS::ReturnCode_t DynamicDataXcdrReadImpl::get_complex_value(DDS::DynamicData_pt
           good = false;
           break;
         }
-        if (!strm_.set_read_limit(size)) {
+        if (!member_limit.reset(size)) {
           good = false;
           break;
         }
@@ -2277,6 +2285,7 @@ bool DynamicDataXcdrReadImpl::get_values_from_union(SequenceType& value, MemberI
     return false;
   }
 
+  DCPS::Serializer::ScopedReadLimit member_limit(strm_, 0, false);
   if (type_desc_->extensibility_kind() == DDS::MUTABLE) {
     unsigned member_id;
     size_t member_size;
@@ -2284,7 +2293,7 @@ bool DynamicDataXcdrReadImpl::get_values_from_union(SequenceType& value, MemberI
     if (!strm_.read_parameter_id(member_id, member_size, must_understand)) {
       return false;
     }
-    if (!strm_.set_read_limit(member_size)) {
+    if (!member_limit.reset(member_size)) {
       return false;
     }
   }
@@ -2581,6 +2590,10 @@ DDS::DynamicType_ptr DynamicDataXcdrReadImpl::type()
 
 DDS::ReturnCode_t DynamicDataXcdrReadImpl::skip_to_struct_member(DDS::MemberDescriptor* member_desc, MemberId id)
 {
+  // On RETCODE_OK this deliberately leaves strm_ read-limited to the located
+  // member (and, for a delimited struct, to the struct's DHEADER region): the
+  // caller reads that member next and must not run past it.  The limit is reset
+  // when the next ScopedChainManager re-initializes strm_.
   const DDS::ExtensibilityKind ek = type_desc_->extensibility_kind();
   if (ek == DDS::FINAL || ek == DDS::APPENDABLE) {
     size_t dheader = 0;

--- a/dds/DCPS/XTypes/TypeObject.cpp
+++ b/dds/DCPS/XTypes/TypeObject.cpp
@@ -1222,6 +1222,10 @@ bool read_empty_xcdr2_nonfinal(DCPS::Serializer& strm)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  DCPS::Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
   return strm.skip(total_size);
 }
 
@@ -1765,6 +1769,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteStructHeader& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -1802,6 +1810,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalStructHeader& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -2080,6 +2092,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteArrayType& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -2195,6 +2211,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteEnumeratedHeader& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -2229,6 +2249,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalEnumeratedHeader& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -2317,6 +2341,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteBitmaskType& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -2357,6 +2385,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalBitmaskType& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -2401,6 +2433,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteBitsetType& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -2441,6 +2477,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalBitsetType& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -2511,6 +2551,10 @@ bool operator>>(Serializer& strm, XTypes::TypeIdentifierWithSize& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -2556,6 +2600,10 @@ bool operator>>(Serializer& strm, XTypes::TypeIdentifierWithDependencies& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -2596,6 +2644,10 @@ bool operator>>(Serializer& strm, XTypes::AppliedAnnotation& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
   const bool ret = (strm >> stru.annotation_typeid)
@@ -2630,6 +2682,10 @@ bool operator>>(Serializer& strm, XTypes::AppliedBuiltinTypeAnnotations& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -2672,6 +2728,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteAliasBody& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -2710,6 +2770,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteAliasHeader& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -2745,6 +2809,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteAnnotationHeader& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -2788,6 +2856,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteAnnotationParameter& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -2826,6 +2898,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteArrayHeader& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -2867,6 +2943,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteBitfield& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -2906,6 +2986,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteBitflag& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -2941,6 +3025,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteBitsetHeader& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -2981,6 +3069,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteCollectionElement& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -3018,6 +3110,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteCollectionHeader& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -3061,6 +3157,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteDiscriminatorMember& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -3099,6 +3199,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteEnumeratedLiteral& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -3140,6 +3244,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteStructMember& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -3176,6 +3284,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteUnionHeader& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -3216,6 +3328,10 @@ bool operator>>(Serializer& strm, XTypes::CompleteUnionMember& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -3251,6 +3367,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalAliasBody& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -3330,6 +3450,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalAnnotationParameter& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -3366,6 +3490,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalArrayHeader& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -3409,6 +3537,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalBitfield& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -3446,6 +3578,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalBitflag& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -3502,6 +3638,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalCollectionElement& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -3536,6 +3676,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalCollectionHeader& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -3574,6 +3718,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalDiscriminatorMember& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -3610,6 +3758,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalEnumeratedLiteral& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -3651,6 +3803,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalStructMember& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -3686,6 +3842,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalUnionHeader& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -3724,6 +3884,10 @@ bool operator>>(Serializer& strm, XTypes::MinimalUnionMember& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -3962,6 +4126,10 @@ bool operator>>(Serializer& strm, XTypes::AppliedAnnotationParameter& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -4015,6 +4183,10 @@ bool operator>>(Serializer& strm, XTypes::AppliedBuiltinMemberAnnotations& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -4259,6 +4431,10 @@ bool operator>>(Serializer& strm, XTypes::CommonEnumeratedLiteral& stru)
 {
   size_t total_size = 0;
   if (!strm.read_delimiter(total_size)) {
+    return false;
+  }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
     return false;
   }
 
@@ -4616,6 +4792,10 @@ bool operator>>(Serializer& strm, XTypes::StronglyConnectedComponentId& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -4953,6 +5133,10 @@ bool operator>>(Serializer& ser, XTypes::TypeObject& type_object)
   if (!ser.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(ser, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   if (!(ser >> ACE_InputCDR::to_octet(type_object.kind))) {
     return false;
@@ -5046,6 +5230,10 @@ bool operator>>(Serializer& strm, XTypes::TypeInformation& stru)
   if (!strm.read_delimiter(total_size)) {
     return false;
   }
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
 
   const size_t start_pos = strm.rpos();
 
@@ -5059,6 +5247,10 @@ bool operator>>(Serializer& strm, XTypes::TypeInformation& stru)
 
     bool must_understand = false;
     if (!strm.read_parameter_id(member_id, field_size, must_understand)) {
+      return false;
+    }
+    Serializer::ScopedReadLimit member_limit(strm, field_size, true, true);
+    if (!member_limit.valid()) {
       return false;
     }
 

--- a/dds/DCPS/XTypes/TypeObject.cpp
+++ b/dds/DCPS/XTypes/TypeObject.cpp
@@ -1218,15 +1218,8 @@ bool write_empty_xcdr2_nonfinal(DCPS::Serializer& strm)
 
 bool read_empty_xcdr2_nonfinal(DCPS::Serializer& strm)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  DCPS::Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
-  if (!read_limit.valid()) {
-    return false;
-  }
-  return strm.skip(total_size);
+  DCPS::Serializer::ScopedReadLimit read_limit(strm);
+  return read_limit.valid() && read_limit.skip_to_end();
 }
 
 const char* typekind_to_string(TypeKind tk)
@@ -1765,23 +1758,14 @@ bool operator<<(Serializer& strm, const XTypes::CompleteStructHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteStructHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.base_type)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -1808,23 +1792,14 @@ bool operator<<(Serializer& strm, const XTypes::MinimalStructHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalStructHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.base_type)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2088,24 +2063,15 @@ bool operator<<(Serializer& strm, const XTypes::CompleteArrayType& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteArrayType& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   const bool ret = (strm >> stru.collection_flag)
     && (strm >> stru.header)
     && (strm >> stru.element);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2207,23 +2173,14 @@ bool operator<<(Serializer& strm, const XTypes::CompleteEnumeratedHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteEnumeratedHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2247,22 +2204,13 @@ bool operator<<(Serializer& strm, const XTypes::MinimalEnumeratedHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalEnumeratedHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2337,24 +2285,15 @@ bool operator<<(Serializer& strm, const XTypes::CompleteBitmaskType& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteBitmaskType& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   const bool ret = (strm >> stru.bitmask_flags)
     && (strm >> stru.header)
     && (strm >> stru.flag_seq);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2383,24 +2322,15 @@ bool operator<<(Serializer& strm, const XTypes::MinimalBitmaskType& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalBitmaskType& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   const bool ret = (strm >> stru.bitmask_flags)
     && (strm >> stru.header)
     && (strm >> stru.flag_seq);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2429,24 +2359,15 @@ bool operator<<(Serializer& strm, const XTypes::CompleteBitsetType& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteBitsetType& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   const bool ret = (strm >> stru.bitset_flags)
     && (strm >> stru.header)
     && (strm >> stru.field_seq);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2475,24 +2396,15 @@ bool operator<<(Serializer& strm, const XTypes::MinimalBitsetType& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalBitsetType& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   const bool ret = (strm >> stru.bitset_flags)
     && (strm >> stru.header)
     && (strm >> stru.field_seq);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2547,23 +2459,14 @@ bool operator<<(Serializer& strm, const NestedKeyOnly<const XTypes::TypeIdentifi
 
 bool operator>>(Serializer& strm, XTypes::TypeIdentifierWithSize& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.type_id)
     && (strm >> stru.typeobject_serialized_size);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2596,24 +2499,15 @@ bool operator<<(Serializer& strm, const XTypes::TypeIdentifierWithDependencies& 
 
 bool operator>>(Serializer& strm, XTypes::TypeIdentifierWithDependencies& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   const bool ret = (strm >> stru.typeid_with_size)
     && (strm >> stru.dependent_typeid_count)
     && (strm >> stru.dependent_typeids);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2640,22 +2534,13 @@ bool operator<<(Serializer& strm, const XTypes::AppliedAnnotation& stru)
 
 bool operator>>(Serializer& strm, XTypes::AppliedAnnotation& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
   const bool ret = (strm >> stru.annotation_typeid)
     && (strm >> stru.param_seq);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2680,22 +2565,13 @@ bool operator<<(Serializer& strm, const XTypes::AppliedBuiltinTypeAnnotations& s
 
 bool operator>>(Serializer& strm, XTypes::AppliedBuiltinTypeAnnotations& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.verbatim);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2724,24 +2600,15 @@ bool operator<<(Serializer& strm, const XTypes::CompleteAliasBody& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteAliasBody& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   const bool ret = (strm >> stru.common)
     && (strm >> stru.ann_builtin)
     && (strm >> stru.ann_custom);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2766,22 +2633,13 @@ bool operator<<(Serializer& strm, const XTypes::CompleteAliasHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteAliasHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2807,22 +2665,13 @@ bool operator<<(Serializer& strm, const XTypes::CompleteAnnotationHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteAnnotationHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> Serializer::ToBoundedString<char>(stru.annotation_name, TYPE_NAME_MAX_LENGTH));
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2852,24 +2701,15 @@ bool operator<<(Serializer& strm, const XTypes::CompleteAnnotationParameter& str
 
 bool operator>>(Serializer& strm, XTypes::CompleteAnnotationParameter& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   const bool ret = (strm >> stru.common)
     && (strm >> Serializer::ToBoundedString<char>(stru.name, MEMBER_NAME_MAX_LENGTH))
     && (strm >> stru.default_value);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2896,23 +2736,14 @@ bool operator<<(Serializer& strm, const XTypes::CompleteArrayHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteArrayHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2939,23 +2770,14 @@ bool operator<<(Serializer& strm, const XTypes::CompleteBitfield& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteBitfield& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -2982,23 +2804,14 @@ bool operator<<(Serializer& strm, const XTypes::CompleteBitflag& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteBitflag& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3023,22 +2836,13 @@ bool operator<<(Serializer& strm, const XTypes::CompleteBitsetHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteBitsetHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3065,23 +2869,14 @@ bool operator<<(Serializer& strm, const XTypes::CompleteCollectionElement& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteCollectionElement& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3108,23 +2903,14 @@ bool operator<<(Serializer& strm, const XTypes::CompleteCollectionHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteCollectionHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3153,24 +2939,15 @@ bool operator<<(Serializer& strm, const XTypes::CompleteDiscriminatorMember& str
 
 bool operator>>(Serializer& strm, XTypes::CompleteDiscriminatorMember& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   const bool ret = (strm >> stru.common)
     && (strm >> stru.ann_builtin)
     && (strm >> stru.ann_custom);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3197,23 +2974,14 @@ bool operator<<(Serializer& strm, const XTypes::CompleteEnumeratedLiteral& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteEnumeratedLiteral& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3240,23 +3008,13 @@ bool operator<<(Serializer& strm, const XTypes::CompleteStructMember& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteStructMember& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
-
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
 
   return ret;
 }
@@ -3282,22 +3040,13 @@ bool operator<<(Serializer& strm, const XTypes::CompleteUnionHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteUnionHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3324,23 +3073,14 @@ bool operator<<(Serializer& strm, const XTypes::CompleteUnionMember& stru)
 
 bool operator>>(Serializer& strm, XTypes::CompleteUnionMember& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3365,22 +3105,13 @@ bool operator<<(Serializer& strm, const XTypes::MinimalAliasBody& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalAliasBody& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3446,24 +3177,15 @@ bool operator<<(Serializer& strm, const XTypes::MinimalAnnotationParameter& stru
 bool operator>>(Serializer& strm, XTypes::MinimalAnnotationParameter& stru)
 {
   XTypes::NameHash_forany stru_name_hash(const_cast<XTypes::NameHash_slice*>(stru.name_hash));
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   const bool ret = (strm >> stru.common)
     && (strm >> stru_name_hash)
     && (strm >> stru.default_value);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3488,22 +3210,13 @@ bool operator<<(Serializer& strm, const XTypes::MinimalArrayHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalArrayHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3533,23 +3246,14 @@ bool operator<<(Serializer& strm, const XTypes::MinimalBitfield& stru)
 bool operator>>(Serializer& strm, XTypes::MinimalBitfield& stru)
 {
   XTypes::NameHash_forany stru_name_hash(const_cast<XTypes::NameHash_slice*>(stru.name_hash));
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru_name_hash);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3576,23 +3280,14 @@ bool operator<<(Serializer& strm, const XTypes::MinimalBitflag& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalBitflag& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3634,22 +3329,13 @@ bool operator<<(Serializer& strm, const XTypes::MinimalCollectionElement& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalCollectionElement& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3674,22 +3360,13 @@ bool operator<<(Serializer& strm, const XTypes::MinimalCollectionHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalCollectionHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3714,22 +3391,13 @@ bool operator<<(Serializer& strm, const XTypes::MinimalDiscriminatorMember& stru
 
 bool operator>>(Serializer& strm, XTypes::MinimalDiscriminatorMember& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3756,23 +3424,14 @@ bool operator<<(Serializer& strm, const XTypes::MinimalEnumeratedLiteral& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalEnumeratedLiteral& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3799,23 +3458,14 @@ bool operator<<(Serializer& strm, const XTypes::MinimalStructMember& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalStructMember& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3840,22 +3490,13 @@ bool operator<<(Serializer& strm, const XTypes::MinimalUnionHeader& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalUnionHeader& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -3882,23 +3523,14 @@ bool operator<<(Serializer& strm, const XTypes::MinimalUnionMember& stru)
 
 bool operator>>(Serializer& strm, XTypes::MinimalUnionMember& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.common)
     && (strm >> stru.detail);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -4122,24 +3754,15 @@ bool operator<<(Serializer& strm, const XTypes::AppliedAnnotationParameter& stru
 
 bool operator>>(Serializer& strm, XTypes::AppliedAnnotationParameter& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   XTypes::NameHash_forany stru_paramname_hash(const_cast<XTypes::NameHash_slice*>(stru.paramname_hash));
   const bool ret = (strm >> stru_paramname_hash)
     && (strm >> stru.value);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -4181,25 +3804,16 @@ bool operator<<(Serializer& strm, const XTypes::AppliedBuiltinMemberAnnotations&
 
 bool operator>>(Serializer& strm, XTypes::AppliedBuiltinMemberAnnotations& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   const bool ret = (strm >> stru.unit)
     && (strm >> stru.min)
     && (strm >> stru.max)
     && (strm >> stru.hash_id);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -4429,23 +4043,14 @@ bool operator<<(Serializer& strm, const XTypes::CommonEnumeratedLiteral& stru)
 
 bool operator>>(Serializer& strm, XTypes::CommonEnumeratedLiteral& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   const bool ret = (strm >> stru.value)
     && (strm >> stru.flags);
 
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
   return ret;
 }
 
@@ -4788,26 +4393,16 @@ bool operator<<(Serializer& strm, const XTypes::StronglyConnectedComponentId& st
 
 bool operator>>(Serializer& strm, XTypes::StronglyConnectedComponentId& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
-
-  const size_t start_pos = strm.rpos();
 
   // appendable, but no need to handle truncated streams since
   // this struct is defined in the spec with the following members:
   const bool ret = (strm >> stru.sc_component_id)
     && (strm >> stru.scc_length)
     && (strm >> stru.scc_index);
-
-  if (ret && strm.rpos() - start_pos < total_size) {
-    strm.skip(total_size - strm.rpos() + start_pos);
-  }
 
   return ret;
 }
@@ -5129,11 +4724,7 @@ bool operator<<(Serializer& ser, const XTypes::TypeObject& type_object)
 
 bool operator>>(Serializer& ser, XTypes::TypeObject& type_object)
 {
-  size_t total_size = 0;
-  if (!ser.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(ser, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(ser);
   if (!read_limit.valid()) {
     return false;
   }
@@ -5226,25 +4817,14 @@ bool operator<<(Serializer& strm, const XTypes::TypeInformation& stru)
 
 bool operator>>(Serializer& strm, XTypes::TypeInformation& stru)
 {
-  size_t total_size = 0;
-  if (!strm.read_delimiter(total_size)) {
-    return false;
-  }
-  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  Serializer::ScopedReadLimit read_limit(strm);
   if (!read_limit.valid()) {
     return false;
   }
 
-  const size_t start_pos = strm.rpos();
-
   unsigned member_id = 0;
   size_t field_size = 0;
-  while (true) {
-
-    if (strm.rpos() - start_pos >= total_size) {
-      return true;
-    }
-
+  while (read_limit.remaining() != 0) {
     bool must_understand = false;
     if (!strm.read_parameter_id(member_id, field_size, must_understand)) {
       return false;
@@ -5278,7 +4858,7 @@ bool operator>>(Serializer& strm, XTypes::TypeInformation& stru)
       break;
     }
   }
-  return false;
+  return true;
 }
 
 

--- a/dds/DCPS/XTypes/TypeObject.h
+++ b/dds/DCPS/XTypes/TypeObject.h
@@ -3508,13 +3508,18 @@ bool operator>>(Serializer& strm, XTypes::Sequence<T>& seq)
     return false;
   }
 
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
+
   const size_t end_of_seq = strm.rpos() + total_size;
   ACE_CDR::ULong length;
   if (!(strm >> length)) {
     return false;
   }
 
-  if (length > strm.length()) {
+  if (!strm.check_size(length, 1u)) {
     // if encoded incorrectly, the first 4 bytes of the elements were read
     // as if they were the length - this may end up being larger than the
     // number of bytes remaining in the Serializer
@@ -3550,13 +3555,18 @@ bool operator>>(Serializer& strm, NestedKeyOnly<XTypes::Sequence<T> >& seq)
     return false;
   }
 
+  Serializer::ScopedReadLimit read_limit(strm, total_size, true, true);
+  if (!read_limit.valid()) {
+    return false;
+  }
+
   const size_t end_of_seq = strm.rpos() + total_size;
   ACE_CDR::ULong length;
   if (!(strm >> length)) {
     return false;
   }
 
-  if (length > strm.length()) {
+  if (!strm.check_size(length, 1u)) {
     // if encoded incorrectly, the first 4 bytes of the elements were read
     // as if they were the length - this may end up being larger than the
     // number of bytes remaining in the Serializer

--- a/dds/idl/dds_generator.h
+++ b/dds/idl/dds_generator.h
@@ -835,7 +835,7 @@ void generateCaseBody(
   const bool mutable_union_read = namePrefix == std::string(">> mutable ");
   if (namePrefix == std::string(">> ") || mutable_union_read) {
     const char* const read_success = mutable_union_read
-      ? "strm.read_list_end_parameter_id()" : "true";
+      ? "member_limit.finish() && strm.read_list_end_parameter_id()" : "true";
     std::string brType = dds_generator::field_type_name(branch, branch->field_type());
     std::string forany;
     AST_Type* br = resolveActualType(branch->field_type());

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -262,6 +262,30 @@ namespace {
     }
   }
 
+  string getPrimitiveCdrSize(AST_Type* type)
+  {
+    switch (dynamic_cast<AST_PredefinedType*>(type)->pt()) {
+    case AST_PredefinedType::PT_long: return "int32_cdr_size";
+    case AST_PredefinedType::PT_ulong: return "uint32_cdr_size";
+    case AST_PredefinedType::PT_short: return "int16_cdr_size";
+    case AST_PredefinedType::PT_ushort: return "uint16_cdr_size";
+#if OPENDDS_HAS_EXPLICIT_INTS
+    case AST_PredefinedType::PT_int8: return "int8_cdr_size";
+    case AST_PredefinedType::PT_uint8: return "uint8_cdr_size";
+#endif
+    case AST_PredefinedType::PT_longlong: return "int64_cdr_size";
+    case AST_PredefinedType::PT_ulonglong: return "uint64_cdr_size";
+    case AST_PredefinedType::PT_float: return "float32_cdr_size";
+    case AST_PredefinedType::PT_double: return "float64_cdr_size";
+    case AST_PredefinedType::PT_longdouble: return "float128_cdr_size";
+    case AST_PredefinedType::PT_char: return "char8_cdr_size";
+    case AST_PredefinedType::PT_wchar: return "char16_cdr_size";
+    case AST_PredefinedType::PT_boolean: return "boolean_cdr_size";
+    case AST_PredefinedType::PT_octet: return "byte_cdr_size";
+    default: return "1u";
+    }
+  }
+
   string nameOfSeqHeader(AST_Type* elem)
   {
     string ser = getSerializerName(elem);
@@ -403,7 +427,7 @@ namespace {
         "  if (!(strm >> length)) {\n"
         "    return false;\n"
         "  }\n"
-        "  if (length > strm.length()) {\n"
+        "  if (!strm.check_size(length, 1u)) {\n"
         "    return false;\n"
         "  }\n"
         "  seq.length(length);\n"
@@ -698,7 +722,7 @@ namespace {
         marshal_generator::generate_dheader_code(
           "    if (!strm.read_delimiter(total_size)) {\n"
           "      return false;\n"
-          "    }\n", !primitive);
+          "    }\n", !primitive, true, "  ", true);
 
         if (!primitive) {
           be_global->impl_ << "  const size_t end_of_seq = strm.rpos() + total_size;\n";
@@ -706,9 +730,21 @@ namespace {
         be_global->impl_ <<
           "  CORBA::ULong length;\n"
           << streamAndCheck(">> length");
-        // The check here is to prevent very large sequences from being allocated.
+        // Validate a conservative lower bound before allocating the sequence.
+        // Primitive sequences use their exact fixed wire size.
+        std::string min_element_size = "1u";
+        std::string min_element_alignment = "1u";
+        if (elem_cls & CL_PRIMITIVE) {
+          min_element_size = min_element_alignment = getPrimitiveCdrSize(elem);
+        } else if (elem_cls & CL_ENUM) {
+          min_element_size = min_element_alignment = "int32_cdr_size";
+        } else if ((elem_cls & CL_STRING) || elem->node_type() == AST_Decl::NT_sequence ||
+                   elem->node_type() == AST_Decl::NT_map) {
+          min_element_size = min_element_alignment = "uint32_cdr_size";
+        }
         be_global->impl_ <<
-          "  if (length > strm.length()) {\n"
+          "  if (!strm.check_size(length, " << min_element_size << ", "
+          << min_element_alignment << ")) {\n"
           "    if (DCPS_debug_level >= 8) {\n"
           "      ACE_DEBUG((LM_DEBUG, ACE_TEXT(\"(%P|%t) Invalid sequence length (%u)\\n\"), length));\n"
           "    }\n"
@@ -1087,10 +1123,22 @@ namespace {
         "  DDS::UInt32 size = 0;\n" << // in bytes for DHeader, or in elements for Length
         streamAndCheck(">> size");
 
+      if (both_primitive) {
+        be_global->impl_ <<
+          "  if (!strm.check_size(size, " << getPrimitiveCdrSize(key) << " + "
+          << getPrimitiveCdrSize(val) << ")) {\n"
+          "    return false;\n"
+          "  }\n";
+      }
+
       if (!both_primitive) {
         be_global->impl_ <<
           "  const bool size_is_bytes = strm.encoding().xcdr_version() == Encoding::XCDR_VERSION_2;\n"
-          "  const std::size_t start = size_is_bytes ? strm.rpos() : 0u;\n";
+          "  const std::size_t start = size_is_bytes ? strm.rpos() : 0u;\n"
+          "  Serializer::ScopedReadLimit read_limit(strm, size, size_is_bytes, true);\n"
+          "  if (!read_limit.valid()) {\n"
+          "    return false;\n"
+          "  }\n";
       }
 
       const bool bounded = !map->unbounded(),
@@ -1342,7 +1390,7 @@ namespace {
       marshal_generator::generate_dheader_code(
         "    if (!strm.read_delimiter(total_size)) {\n"
         "      return false;\n"
-        "    }\n", !primitive);
+        "    }\n", !primitive, true, "  ", true);
 
       if (!primitive && (try_construct != tryconstructfailaction_use_default)) {
         be_global->impl_ << "  const size_t end_of_arr = strm.rpos() + total_size;\n";
@@ -2846,7 +2894,7 @@ namespace {
       marshal_generator::generate_dheader_code(
                                                "    if (!strm.read_delimiter(total_size)) {\n"
                                                "      return false;\n"
-                                               "    }\n", not_final);
+                                               "    }\n", not_final, true, "  ", true);
 
       if (not_final) {
         be_global->impl_ <<
@@ -2880,6 +2928,10 @@ namespace {
           "      }\n"
           "      if (encoding.xcdr_version() == Encoding::XCDR_VERSION_1 && member_id == Serializer::pid_list_end) {\n"
           "        return true;\n"
+          "      }\n"
+          "      Serializer::ScopedReadLimit member_limit(strm, field_size, true, true);\n"
+          "      if (!member_limit.valid()) {\n"
+          "        return false;\n"
           "      }\n"
           "      const size_t end_of_field = strm.rpos() + field_size;\n"
           "      ACE_UNUSED_ARG(end_of_field);\n"
@@ -3275,7 +3327,8 @@ namespace {
 
 
 void marshal_generator::generate_dheader_code(const std::string& code, bool dheader_required,
-                                              bool is_ser_func, const char* indent)
+                                              bool is_ser_func, const char* indent,
+                                              bool read_limit)
 {
   // DHeader appears on aggregated types that are mutable or appendable in XCDR2
   // DHeader also appears on ALL sequences/arrays/maps of non-primitives in XCDR2
@@ -3289,6 +3342,14 @@ void marshal_generator::generate_dheader_code(const std::string& code, bool dhea
       indents << "if (encoding.xcdr_version() == Encoding::XCDR_VERSION_2) {\n"
       << code <<
       indents << "}\n";
+    if (read_limit) {
+      be_global->impl_ <<
+        indents << "Serializer::ScopedReadLimit read_limit(strm, total_size,\n"
+        << indents << "  encoding.xcdr_version() == Encoding::XCDR_VERSION_2, true);\n"
+        << indents << "if (!read_limit.valid()) {\n"
+        << indents << "  return false;\n"
+        << indents << "}\n";
+    }
   }
 }
 
@@ -3480,6 +3541,14 @@ marshal_generator::gen_field_getValueFromSerialized(AST_Structure* node, const s
     "      if (!strm.read_delimiter(total_size)) {\n"
     "        throw std::runtime_error(\"Unable to reader delimiter in getValue\");\n"
     "      }\n", not_final, true, "    ");
+  if (not_final) {
+    be_global->impl_ <<
+      "    Serializer::ScopedReadLimit read_limit(strm, total_size,\n"
+      "      encoding.xcdr_version() == Encoding::XCDR_VERSION_2, true);\n"
+      "    if (!read_limit.valid()) {\n"
+      "      throw std::runtime_error(\"Invalid delimiter size in getValue\");\n"
+      "    }\n";
+  }
   be_global->impl_ <<
     "    std::string base_field = field;\n"
     "    const size_t index = base_field.find('.');\n"
@@ -3511,6 +3580,10 @@ marshal_generator::gen_field_getValueFromSerialized(AST_Structure* node, const s
       "            member_id == Serializer::pid_list_end) {\n"
       "          throw std::runtime_error(\"Field \" + OPENDDS_STRING(field) + \" not "
       "valid for struct " << clazz << "\");\n"
+      "        }\n"
+      "        Serializer::ScopedReadLimit member_limit(strm, field_size, true, true);\n"
+      "        if (!member_limit.valid()) {\n"
+      "          throw std::runtime_error(\"Invalid member size in getValue\");\n"
       "        }\n"
       "        const size_t end_of_field = strm.rpos() + field_size;\n"
       "        ACE_UNUSED_ARG(end_of_field);\n"
@@ -3950,7 +4023,7 @@ namespace {
       marshal_generator::generate_dheader_code(
         "    if (!strm.read_delimiter(total_size)) {\n"
         "      return false;\n"
-        "    }\n", not_final);
+        "    }\n", not_final, true, "  ", true);
 
       if (has_key) {
         if (exten == extensibilitykind_mutable) {
@@ -3960,6 +4033,10 @@ namespace {
             "  size_t field_size;\n"
             "  bool must_understand = false;\n"
             "  if (!strm.read_parameter_id(member_id, field_size, must_understand)) {\n"
+            "    return false;\n"
+            "  }\n"
+            "  Serializer::ScopedReadLimit member_limit(strm, field_size, true, true);\n"
+            "  if (!member_limit.valid()) {\n"
             "    return false;\n"
             "  }\n";
         }
@@ -4186,7 +4263,7 @@ bool marshal_generator::gen_union(AST_Union* node, UTL_ScopedName* name,
     marshal_generator::generate_dheader_code(
       "    if (!strm.read_delimiter(total_size)) {\n"
       "      return false;\n"
-      "    }\n", not_final);
+      "    }\n", not_final, true, "  ", true);
 
     if (exten == extensibilitykind_mutable) {
       // EMHEADER for discriminator
@@ -4200,7 +4277,15 @@ bool marshal_generator::gen_union(AST_Union* node, UTL_ScopedName* name,
       TryConstructFailAction try_construct = be_global->union_discriminator_try_construct(node);
       be_global->impl_ <<
         "  " << scoped(discriminator->name()) << " disc;\n"
-        "  if (!(strm >> disc)) {\n";
+        "  bool discriminator_ok = false;\n"
+        "  {\n"
+        "    Serializer::ScopedReadLimit member_limit(strm, field_size, true, true);\n"
+        "    if (!member_limit.valid()) {\n"
+        "      return false;\n"
+        "    }\n"
+        "    discriminator_ok = strm >> disc;\n"
+        "  }\n"
+        "  if (!discriminator_ok) {\n";
       if (try_construct == tryconstructfailaction_use_default) {
         be_global->impl_ <<
           "    set_default(uni);\n"
@@ -4232,6 +4317,10 @@ bool marshal_generator::gen_union(AST_Union* node, UTL_ScopedName* name,
 
       const char prefix[] =
         "    if (!strm.read_parameter_id(member_id, field_size, must_understand)) {\n"
+        "      return false;\n"
+        "    }\n"
+        "    Serializer::ScopedReadLimit member_limit(strm, field_size, true, true);\n"
+        "    if (!member_limit.valid()) {\n"
         "      return false;\n"
         "    }\n";
       if (generateSwitchForUnion(node, "disc", streamCommon, branches,

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -4273,6 +4273,9 @@ bool marshal_generator::gen_union(AST_Union* node, UTL_ScopedName* name,
         "  bool must_understand = false;\n"
         "  if (!strm.read_parameter_id(member_id, field_size, must_understand)) {\n"
         "    return false;\n"
+        "  }\n"
+        "  if (member_id != XTypes::DISCRIMINATOR_SERIALIZED_ID) {\n"
+        "    return false;\n"
         "  }\n";
       TryConstructFailAction try_construct = be_global->union_discriminator_try_construct(node);
       be_global->impl_ <<
@@ -4292,6 +4295,9 @@ bool marshal_generator::gen_union(AST_Union* node, UTL_ScopedName* name,
           "    if (!strm.read_parameter_id(member_id, field_size, must_understand)) {\n"
           "      return false;\n"
           "    }\n"
+          "    if (must_understand) {\n"
+          "      return false;\n"
+          "    }\n"
           "    if (!strm.skip(field_size) || !strm.read_list_end_parameter_id()) {\n"
           "      return false;\n"
           "    }\n"
@@ -4300,6 +4306,9 @@ bool marshal_generator::gen_union(AST_Union* node, UTL_ScopedName* name,
       } else {
         be_global->impl_ <<
           "    if (!strm.read_parameter_id(member_id, field_size, must_understand)) {\n"
+          "      return false;\n"
+          "    }\n"
+          "    if (must_understand) {\n"
           "      return false;\n"
           "    }\n"
           "    if (!strm.skip(field_size) || !strm.read_list_end_parameter_id()) {\n"

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -784,7 +784,9 @@ namespace {
             "  }\n";
           } else {
             be_global->impl_ <<
-              "  strm.read_" << getSerializerName(elem) << "_array(" << get_buffer << ", new_length);\n";
+              "  if (!strm.read_" << getSerializerName(elem) << "_array(" << get_buffer << ", new_length)) {\n"
+              "    return false;\n"
+              "  }\n";
           }
           be_global->impl_ <<
             "  if (new_length != length) {\n"

--- a/dds/idl/marshal_generator.cpp
+++ b/dds/idl/marshal_generator.cpp
@@ -262,9 +262,13 @@ namespace {
     }
   }
 
+  // Wire size of a primitive type as a *_cdr_size constant from Serializer.h.
+  // The caller must have already resolved typedefs and confirmed the type is a
+  // primitive (CL_PRIMITIVE); anything else is an internal error.
   string getPrimitiveCdrSize(AST_Type* type)
   {
-    switch (dynamic_cast<AST_PredefinedType*>(type)->pt()) {
+    AST_PredefinedType* const predef = dynamic_cast<AST_PredefinedType*>(type);
+    switch (predef ? predef->pt() : AST_PredefinedType::PT_void) {
     case AST_PredefinedType::PT_long: return "int32_cdr_size";
     case AST_PredefinedType::PT_ulong: return "uint32_cdr_size";
     case AST_PredefinedType::PT_short: return "int16_cdr_size";
@@ -282,7 +286,9 @@ namespace {
     case AST_PredefinedType::PT_wchar: return "char16_cdr_size";
     case AST_PredefinedType::PT_boolean: return "boolean_cdr_size";
     case AST_PredefinedType::PT_octet: return "byte_cdr_size";
-    default: return "1u";
+    default:
+      be_util::misc_error_and_abort("getPrimitiveCdrSize called with a non-primitive type", type);
+      return "1u";
     }
   }
 

--- a/dds/idl/marshal_generator.h
+++ b/dds/idl/marshal_generator.h
@@ -27,7 +27,8 @@ public:
                  const char* repoid);
 
   static void generate_dheader_code(const std::string& code, bool dheader_required,
-                                    bool is_ser_func = true, const char* indent = "  ");
+                                    bool is_ser_func = true, const char* indent = "  ",
+                                    bool read_limit = false);
 
   static void gen_field_getValueFromSerialized(AST_Structure* node, const std::string& clazz);
 

--- a/docs/news.d/5290.rst
+++ b/docs/news.d/5290.rst
@@ -1,0 +1,16 @@
+.. news-prs: 5290
+
+.. news-start-section: Security
+- Hardened XCDR1 and XCDR2 deserialization against malformed or inconsistent wire data that could otherwise cause excessive allocation, out-of-bounds reads, or undefined behavior:
+
+  - Deserialized Boolean values are normalized, so a Boolean wire byte other than 0 or 1 no longer produces an invalid ``bool`` (:ghissue:`5281`).
+  - Sequence and map element counts are validated against the remaining serialized size, accounting for element size and alignment, before any container is allocated (:ghissue:`5289`).
+  - XCDR2 ``DHEADER`` sizes, and XCDR1 and XCDR2 mutable member sizes, are enforced as hard read boundaries, so a delimited object or member that under-reports its size is rejected instead of over-reading into later data (:ghissue:`5287`).
+  - Malformed XCDR1 extended parameter headers, XCDR2 EMHEADER length codes, mutable-union discriminator IDs, and non-empty parameter-list-end sentinels are rejected.
+
+  Forward compatibility is preserved for unknown bitmask bits and, when member names are ignored, for compatible unions whose members use different IDs.
+
+  *Backwards Compatibility Note*: Readers will now reject some malformed samples and RTPS parameter lists that earlier versions accepted and delivered.
+  Well-formed data produced by OpenDDS or another conformant implementation is unaffected.
+
+.. news-end-section

--- a/tests/DCPS/Compiler/xcdr/xcdr.cpp
+++ b/tests/DCPS/Compiler/xcdr/xcdr.cpp
@@ -645,6 +645,26 @@ TEST(BasicTests, MutableXcdr12UnionLE)
   test_little_endian_union<MutableUnion, MutableXcdr2UnionExpectedLongLongBE>(UnionDisc::E_LONG_LONG_FIELD);
 }
 
+void expect_mutable_union_rejects_wrong_discriminator_id(const Encoding& encoding)
+{
+  ACE_Message_Block buffer(64);
+  Serializer writer(&buffer, encoding);
+  if (encoding.xcdr_version() == Encoding::XCDR_VERSION_2) {
+    ASSERT_TRUE(writer.write_delimiter(8));
+  }
+  ASSERT_TRUE(writer.write_parameter_id(99, 4));
+  ASSERT_TRUE(writer << UnionDisc::E_SHORT_FIELD);
+  MutableUnion result;
+  Serializer reader(&buffer, encoding);
+  EXPECT_FALSE(reader >> result);
+}
+
+TEST(BasicTests, MutableUnionRejectsWrongDiscriminatorId)
+{
+  expect_mutable_union_rejects_wrong_discriminator_id(xcdr1);
+  expect_mutable_union_rejects_wrong_discriminator_id(xcdr2);
+}
+
 // ---------- FinalUnion
 struct FinalUnionExpectedShortBE {
   STREAM_DATA

--- a/tests/DCPS/Compiler/xcdr/xcdr.cpp
+++ b/tests/DCPS/Compiler/xcdr/xcdr.cpp
@@ -30,6 +30,7 @@ using namespace OpenDDS::DCPS;
 using namespace OpenDDS::XTypes;
 
 const Encoding xcdr1(Encoding::KIND_XCDR1, ENDIAN_BIG);
+const Encoding xcdr1_le(Encoding::KIND_XCDR1, ENDIAN_LITTLE);
 const Encoding xcdr2(Encoding::KIND_XCDR2, ENDIAN_BIG);
 const Encoding xcdr2_le(Encoding::KIND_XCDR2, ENDIAN_LITTLE);
 
@@ -644,6 +645,72 @@ TEST(BasicTests, MutableXcdr12UnionLE)
   test_little_endian_union<MutableUnion, MutableXcdr2UnionExpectedLongLongBE>(UnionDisc::E_LONG_LONG_FIELD);
 }
 
+// XCDR1 mutable unions serialize as a PL_CDR parameter list: a 4-byte
+// {UShort id, UShort size} header (4-byte aligned) for the discriminator
+// (DISCRIMINATOR_SERIALIZED_ID == 0) and the selected branch, then the
+// PID_SENTINEL (0x3f02) terminator.  MutableUnion has no explicit @id, so its
+// branches take sequential ids short=0, long=1, octet=2, long_long=3.
+const unsigned char mutable_xcdr1_union_short_be[] = {
+  0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, // disc header + value (E_SHORT_FIELD)
+  0x00, 0x00, 0x00, 0x02, 0x7f, 0xff,             // short_field header + value
+  0x00, 0x00,                                     // pad to 4
+  0x3f, 0x02, 0x00, 0x00                          // sentinel
+};
+const unsigned char mutable_xcdr1_union_short_le[] = {
+  0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x02, 0x00, 0xff, 0x7f,
+  0x00, 0x00,
+  0x02, 0x3f, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_long_be[] = {
+  0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01, // disc header + value (E_LONG_FIELD)
+  0x00, 0x01, 0x00, 0x04, 0x7f, 0xff, 0xff, 0xff, // long_field header + value
+  0x3f, 0x02, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_long_le[] = {
+  0x00, 0x00, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00,
+  0x01, 0x00, 0x04, 0x00, 0xff, 0xff, 0xff, 0x7f,
+  0x02, 0x3f, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_octet_be[] = {
+  0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x02, // disc header + value (E_OCTET_FIELD)
+  0x00, 0x02, 0x00, 0x01, 0x01,                   // octet_field header + value
+  0x00, 0x00, 0x00,                               // pad to 4
+  0x3f, 0x02, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_octet_le[] = {
+  0x00, 0x00, 0x04, 0x00, 0x02, 0x00, 0x00, 0x00,
+  0x02, 0x00, 0x01, 0x00, 0x01,
+  0x00, 0x00, 0x00,
+  0x02, 0x3f, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_long_long_be[] = {
+  0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x03, // disc header + value (E_LONG_LONG_FIELD)
+  0x00, 0x03, 0x00, 0x08, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+  0x3f, 0x02, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_long_long_le[] = {
+  0x00, 0x00, 0x04, 0x00, 0x03, 0x00, 0x00, 0x00,
+  0x03, 0x00, 0x08, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f,
+  0x02, 0x3f, 0x00, 0x00
+};
+
+TEST(BasicTests, MutableXcdr1Union)
+{
+  baseline_checks_union<MutableUnion>(xcdr1, mutable_xcdr1_union_short_be, UnionDisc::E_SHORT_FIELD);
+  baseline_checks_union<MutableUnion>(xcdr1, mutable_xcdr1_union_long_be, UnionDisc::E_LONG_FIELD);
+  baseline_checks_union<MutableUnion>(xcdr1, mutable_xcdr1_union_octet_be, UnionDisc::E_OCTET_FIELD);
+  baseline_checks_union<MutableUnion>(xcdr1, mutable_xcdr1_union_long_long_be, UnionDisc::E_LONG_LONG_FIELD);
+}
+
+TEST(BasicTests, MutableXcdr1UnionLE)
+{
+  baseline_checks_union<MutableUnion>(xcdr1_le, mutable_xcdr1_union_short_le, UnionDisc::E_SHORT_FIELD);
+  baseline_checks_union<MutableUnion>(xcdr1_le, mutable_xcdr1_union_long_le, UnionDisc::E_LONG_FIELD);
+  baseline_checks_union<MutableUnion>(xcdr1_le, mutable_xcdr1_union_octet_le, UnionDisc::E_OCTET_FIELD);
+  baseline_checks_union<MutableUnion>(xcdr1_le, mutable_xcdr1_union_long_long_le, UnionDisc::E_LONG_LONG_FIELD);
+}
+
 void expect_mutable_union_rejects_wrong_discriminator_id(const Encoding& encoding)
 {
   ACE_Message_Block buffer(64);
@@ -662,6 +729,33 @@ TEST(BasicTests, MutableUnionRejectsWrongDiscriminatorId)
 {
   expect_mutable_union_rejects_wrong_discriminator_id(xcdr1);
   expect_mutable_union_rejects_wrong_discriminator_id(xcdr2);
+}
+
+// A mutable union carries exactly the discriminator and one selected branch;
+// the reader requires PID_SENTINEL immediately after the branch.  An extra
+// parameter in that position must fail the read even when it is not flagged
+// must_understand (and, all the more, when it is).
+void expect_mutable_xcdr1_union_trailing_parameter_rejected(bool must_understand)
+{
+  ACE_Message_Block buffer(64);
+  Serializer writer(&buffer, xcdr1);
+  ASSERT_TRUE(writer.write_parameter_id(DISCRIMINATOR_SERIALIZED_ID, uint32_cdr_size));
+  ASSERT_TRUE(writer << UnionDisc::E_SHORT_FIELD);
+  ASSERT_TRUE(writer.write_parameter_id(0, int16_cdr_size)); // short_field
+  ASSERT_TRUE(writer << ACE_CDR::Short(0x7fff));
+  ASSERT_TRUE(writer.write_parameter_id(0x63, uint32_cdr_size, must_understand));
+  ASSERT_TRUE(writer << ACE_CDR::ULong(0));
+  ASSERT_TRUE(writer.write_list_end_parameter_id());
+
+  MutableUnion result;
+  Serializer reader(&buffer, xcdr1);
+  EXPECT_FALSE(reader >> result);
+}
+
+TEST(BasicTests, MutableXcdr1UnionTrailingParameterRejected)
+{
+  expect_mutable_xcdr1_union_trailing_parameter_rejected(false);
+  expect_mutable_xcdr1_union_trailing_parameter_rejected(true);
 }
 
 void expect_bounded_sequence_length_exceeds_payload_rejected(const Encoding& encoding)
@@ -1387,6 +1481,113 @@ TEST(MutableTests, FromModifiedMutableUnionLE)
   test_little_endian_union<ModifiedMutableUnion, MutableUnion,
                            MutableUnionExpectedXcdr2LongBE>(UnionDisc::E_LONG_FIELD);
   // TODO (sonndinh): similarly, test try-construct of additional_field here
+}
+
+// ---------- MutableUnionWithExplicitIDs / ModifiedMutableUnion, XCDR1
+// Same PL_CDR layout as MutableUnion above, but the branch ids are the
+// explicit @id values: short=4, long=6, octet=8, long_long=10.  Both
+// MutableUnionWithExplicitIDs and ModifiedMutableUnion serialize these branches
+// identically, so the same expected bytes drive the schema-evolution round
+// trips (deserialization matches by discriminator label, not member id).
+const unsigned char mutable_xcdr1_union_eid_short_be[] = {
+  0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x04, 0x00, 0x02, 0x7f, 0xff,
+  0x00, 0x00,
+  0x3f, 0x02, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_eid_short_le[] = {
+  0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x04, 0x00, 0x02, 0x00, 0xff, 0x7f,
+  0x00, 0x00,
+  0x02, 0x3f, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_eid_long_be[] = {
+  0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01,
+  0x00, 0x06, 0x00, 0x04, 0x7f, 0xff, 0xff, 0xff,
+  0x3f, 0x02, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_eid_long_le[] = {
+  0x00, 0x00, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00,
+  0x06, 0x00, 0x04, 0x00, 0xff, 0xff, 0xff, 0x7f,
+  0x02, 0x3f, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_eid_octet_be[] = {
+  0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x02,
+  0x00, 0x08, 0x00, 0x01, 0x01,
+  0x00, 0x00, 0x00,
+  0x3f, 0x02, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_eid_octet_le[] = {
+  0x00, 0x00, 0x04, 0x00, 0x02, 0x00, 0x00, 0x00,
+  0x08, 0x00, 0x01, 0x00, 0x01,
+  0x00, 0x00, 0x00,
+  0x02, 0x3f, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_eid_long_long_be[] = {
+  0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x03,
+  0x00, 0x0a, 0x00, 0x08, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+  0x3f, 0x02, 0x00, 0x00
+};
+const unsigned char mutable_xcdr1_union_eid_long_long_le[] = {
+  0x00, 0x00, 0x04, 0x00, 0x03, 0x00, 0x00, 0x00,
+  0x0a, 0x00, 0x08, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f,
+  0x02, 0x3f, 0x00, 0x00
+};
+
+TEST(MutableTests, MutableXcdr1UnionWithExplicitIDs)
+{
+  baseline_checks_union<MutableUnionWithExplicitIDs>(
+    xcdr1, mutable_xcdr1_union_eid_short_be, UnionDisc::E_SHORT_FIELD);
+  baseline_checks_union<MutableUnionWithExplicitIDs>(
+    xcdr1, mutable_xcdr1_union_eid_long_be, UnionDisc::E_LONG_FIELD);
+  baseline_checks_union<MutableUnionWithExplicitIDs>(
+    xcdr1, mutable_xcdr1_union_eid_octet_be, UnionDisc::E_OCTET_FIELD);
+  baseline_checks_union<MutableUnionWithExplicitIDs>(
+    xcdr1, mutable_xcdr1_union_eid_long_long_be, UnionDisc::E_LONG_LONG_FIELD);
+}
+
+TEST(MutableTests, MutableXcdr1UnionWithExplicitIDsLE)
+{
+  baseline_checks_union<MutableUnionWithExplicitIDs>(
+    xcdr1_le, mutable_xcdr1_union_eid_short_le, UnionDisc::E_SHORT_FIELD);
+  baseline_checks_union<MutableUnionWithExplicitIDs>(
+    xcdr1_le, mutable_xcdr1_union_eid_long_le, UnionDisc::E_LONG_FIELD);
+  baseline_checks_union<MutableUnionWithExplicitIDs>(
+    xcdr1_le, mutable_xcdr1_union_eid_octet_le, UnionDisc::E_OCTET_FIELD);
+  baseline_checks_union<MutableUnionWithExplicitIDs>(
+    xcdr1_le, mutable_xcdr1_union_eid_long_long_le, UnionDisc::E_LONG_LONG_FIELD);
+}
+
+TEST(MutableTests, FromMutableUnionXcdr1)
+{
+  amalgam_serializer_test_union<MutableUnionWithExplicitIDs, ModifiedMutableUnion>(
+    xcdr1, mutable_xcdr1_union_eid_short_be, UnionDisc::E_SHORT_FIELD);
+  amalgam_serializer_test_union<MutableUnionWithExplicitIDs, ModifiedMutableUnion>(
+    xcdr1, mutable_xcdr1_union_eid_long_be, UnionDisc::E_LONG_FIELD);
+}
+
+TEST(MutableTests, FromMutableUnionXcdr1LE)
+{
+  amalgam_serializer_test_union<MutableUnionWithExplicitIDs, ModifiedMutableUnion>(
+    xcdr1_le, mutable_xcdr1_union_eid_short_le, UnionDisc::E_SHORT_FIELD);
+  amalgam_serializer_test_union<MutableUnionWithExplicitIDs, ModifiedMutableUnion>(
+    xcdr1_le, mutable_xcdr1_union_eid_long_le, UnionDisc::E_LONG_FIELD);
+}
+
+TEST(MutableTests, FromModifiedMutableUnionXcdr1)
+{
+  amalgam_serializer_test_union<ModifiedMutableUnion, MutableUnion>(
+    xcdr1, mutable_xcdr1_union_eid_short_be, UnionDisc::E_SHORT_FIELD);
+  amalgam_serializer_test_union<ModifiedMutableUnion, MutableUnion>(
+    xcdr1, mutable_xcdr1_union_eid_long_be, UnionDisc::E_LONG_FIELD);
+}
+
+TEST(MutableTests, FromModifiedMutableUnionXcdr1LE)
+{
+  amalgam_serializer_test_union<ModifiedMutableUnion, MutableUnion>(
+    xcdr1_le, mutable_xcdr1_union_eid_short_le, UnionDisc::E_SHORT_FIELD);
+  amalgam_serializer_test_union<ModifiedMutableUnion, MutableUnion>(
+    xcdr1_le, mutable_xcdr1_union_eid_long_le, UnionDisc::E_LONG_FIELD);
 }
 
 // ---------- ReorderedMutableStruct

--- a/tests/DCPS/Compiler/xcdr/xcdr.cpp
+++ b/tests/DCPS/Compiler/xcdr/xcdr.cpp
@@ -1,7 +1,6 @@
-// TODO: Add deserialization only tests that have unknown parameters with
-// must understand that cause an expected failure.
-// This should for generated deserialization code, but probably doesn't work with
-// DynamicData.
+// MutableUnknownMustUnderstandMemberRejected covers the generated-code case of
+// an unknown must_understand parameter causing an expected failure.
+// TODO: add the equivalent coverage for the DynamicData reader.
 
 #include "xcdrbasetypesTypeSupportImpl.h"
 #include "appendable_mixedTypeSupportImpl.h"
@@ -663,6 +662,66 @@ TEST(BasicTests, MutableUnionRejectsWrongDiscriminatorId)
 {
   expect_mutable_union_rejects_wrong_discriminator_id(xcdr1);
   expect_mutable_union_rejects_wrong_discriminator_id(xcdr2);
+}
+
+void expect_bounded_sequence_length_exceeds_payload_rejected(const Encoding& encoding)
+{
+  // values.length claims 5 elements but only 3 follow (issue #5289).  The wire
+  // form is the same for XCDR1 and XCDR2 (final struct, primitive sequence: no
+  // DHEADER in either).
+  const unsigned char cdr[] = {
+    0x00, 0x00, 0x00, 0x05, // length = 5
+    0x00, 0x00, 0x00, 0x3f, // 63
+    0x00, 0x00, 0x00, 0x40, // 64
+    0x00, 0x00, 0x00, 0x41  // 65
+  };
+  ACE_Message_Block mb(sizeof cdr);
+  ASSERT_EQ(0, mb.copy(reinterpret_cast<const char*>(cdr), sizeof cdr));
+  Serializer reader(&mb, encoding);
+  BoundedLongSeqStruct result;
+  EXPECT_FALSE(reader >> result);
+}
+
+TEST(BasicTests, BoundedSequenceLengthExceedsPayloadRejected)
+{
+  expect_bounded_sequence_length_exceeds_payload_rejected(xcdr1);
+  expect_bounded_sequence_length_exceeds_payload_rejected(xcdr2);
+}
+
+TEST(BasicTests, AppendableDheaderUnderReportRejected)
+{
+  // A truthful DHEADER that is then shrunk by one byte must be rejected rather
+  // than allowing fields to be read past it (issue #5287).
+  AppendableStruct value;
+  value.short_field(1);
+  value.long_field(2);
+  value.octet_field(3);
+  value.long_long_field(4);
+
+  ACE_Message_Block buffer(64);
+  Serializer writer(&buffer, xcdr2);
+  ASSERT_TRUE(writer << value);
+  ASSERT_GE(buffer.length(), size_t(4));
+  --buffer.rd_ptr()[3]; // low byte of the big-endian DHEADER
+
+  AppendableStruct result;
+  Serializer reader(&buffer, xcdr2);
+  EXPECT_FALSE(reader >> result);
+}
+
+TEST(BasicTests, MutableUnknownMustUnderstandMemberRejected)
+{
+  // An unrecognized member flagged must_understand must fail the read.  See the
+  // TODO at the top of this file.
+  ACE_Message_Block buffer(64);
+  Serializer writer(&buffer, xcdr2);
+  ASSERT_TRUE(writer.write_delimiter(uint32_cdr_size + uint32_cdr_size));
+  ASSERT_TRUE(writer.write_parameter_id(1000, uint32_cdr_size, true));
+  ASSERT_TRUE(writer << ACE_CDR::ULong(0));
+
+  MutableStruct result;
+  Serializer reader(&buffer, xcdr2);
+  EXPECT_FALSE(reader >> result);
 }
 
 // ---------- FinalUnion

--- a/tests/DCPS/Compiler/xcdr/xcdrbasetypes.idl
+++ b/tests/DCPS/Compiler/xcdr/xcdrbasetypes.idl
@@ -52,3 +52,8 @@ struct IdVsDeclOrder {
   @id(2) uint32 first_id2;
   @id(1) uint16 second_id1;
 };
+
+@final
+struct BoundedLongSeqStruct {
+  sequence<long, 5> values;
+};

--- a/tests/unit-tests/dds/DCPS/Serializer.cpp
+++ b/tests/unit-tests/dds/DCPS/Serializer.cpp
@@ -167,6 +167,190 @@ TEST(dds_DCPS_Serializer, Serializer_swap_bytes_endianness)
   EXPECT_EQ(ser.endianness(), ENDIAN_NONNATIVE);
 }
 
+TEST(dds_DCPS_Serializer, Serializer_read_boolean_normalizes)
+{
+  Message_Block_Ptr mb(new ACE_Message_Block(4));
+  const Encoding enc;
+  Serializer writer(mb.get(), enc);
+  const ACE_CDR::Octet input[] = {0, 1, 2, 255};
+  ASSERT_TRUE(writer.write_octet_array(input, 4));
+
+  Serializer reader(mb.get(), enc);
+  const ACE_CDR::Octet expected[] = {0, 1, 1, 1};
+  for (size_t i = 0; i < 4; ++i) {
+    ACE_CDR::Boolean value = false;
+    ASSERT_TRUE(reader >> ACE_InputCDR::to_boolean(value));
+    ACE_CDR::Octet representation = 0;
+    std::memcpy(&representation, &value, boolean_cdr_size);
+    EXPECT_EQ(expected[i], representation);
+  }
+}
+
+TEST(dds_DCPS_Serializer, Serializer_read_boolean_array_normalizes)
+{
+  Message_Block_Ptr mb(new ACE_Message_Block(4));
+  const Encoding enc;
+  Serializer writer(mb.get(), enc);
+  const ACE_CDR::Octet input[] = {0, 1, 2, 255};
+  ASSERT_TRUE(writer.write_octet_array(input, 4));
+
+  Serializer reader(mb.get(), enc);
+  ACE_CDR::Boolean values[4] = {};
+  ASSERT_TRUE(reader.read_boolean_array(values, 4));
+
+  const ACE_CDR::Octet expected[] = {0, 1, 1, 1};
+  ACE_CDR::Octet representations[4] = {};
+  std::memcpy(representations, values, sizeof values);
+  for (size_t i = 0; i < 4; ++i) {
+    EXPECT_EQ(expected[i], representations[i]);
+  }
+}
+
+TEST(dds_DCPS_Serializer, Serializer_scoped_read_limit_nested)
+{
+  Message_Block_Ptr mb(new ACE_Message_Block(8));
+  const Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
+  Serializer writer(mb.get(), enc);
+  const ACE_CDR::Octet input[] = {0, 1, 2, 3, 4, 5, 6, 7};
+  ASSERT_TRUE(writer.write_octet_array(input, 8));
+
+  Serializer reader(mb.get(), enc);
+  {
+    Serializer::ScopedReadLimit outer(reader, 6);
+    ASSERT_TRUE(outer.valid());
+    EXPECT_EQ(6u, reader.length());
+    ACE_CDR::Octet value[2];
+    ASSERT_TRUE(reader.read_octet_array(value, 2));
+    {
+      Serializer::ScopedReadLimit inner(reader, 2);
+      ASSERT_TRUE(inner.valid());
+      ASSERT_TRUE(reader.read_octet_array(value, 2));
+      EXPECT_EQ(0u, inner.remaining());
+    }
+    EXPECT_EQ(2u, outer.remaining());
+    ASSERT_TRUE(outer.skip_to_end());
+  }
+  EXPECT_EQ(2u, reader.length());
+  EXPECT_EQ(6u, reader.rpos());
+}
+
+TEST(dds_DCPS_Serializer, Serializer_scoped_read_limit_rejects_crossing)
+{
+  Message_Block_Ptr mb(new ACE_Message_Block(8));
+  const Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
+  Serializer writer(mb.get(), enc);
+  const ACE_CDR::Octet input[] = {0, 1, 2, 3, 4, 5, 6, 7};
+  ASSERT_TRUE(writer.write_octet_array(input, 8));
+
+  Serializer reader(mb.get(), enc);
+  Serializer::ScopedReadLimit limit(reader, 3);
+  ASSERT_TRUE(limit.valid());
+  ACE_CDR::ULong value = 0;
+  EXPECT_FALSE(reader >> value);
+  EXPECT_FALSE(reader.good_bit());
+  EXPECT_EQ(0u, reader.rpos());
+}
+
+TEST(dds_DCPS_Serializer, Serializer_scoped_read_limit_skips_remainder)
+{
+  Message_Block_Ptr mb(new ACE_Message_Block(4));
+  const Encoding enc;
+  Serializer writer(mb.get(), enc);
+  const ACE_CDR::Octet input[] = {0, 1, 2, 3};
+  ASSERT_TRUE(writer.write_octet_array(input, 4));
+
+  Serializer reader(mb.get(), enc);
+  {
+    Serializer::ScopedReadLimit limit(reader, 3, true, true);
+    ASSERT_TRUE(limit.valid());
+    ACE_CDR::Octet value = 0;
+    ASSERT_TRUE(reader >> ACE_InputCDR::to_octet(value));
+    EXPECT_EQ(0, value);
+  }
+  EXPECT_EQ(3u, reader.rpos());
+  EXPECT_EQ(1u, reader.length());
+}
+
+TEST(dds_DCPS_Serializer, Serializer_check_size)
+{
+  Message_Block_Ptr mb(new ACE_Message_Block(12));
+  const Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
+  Serializer writer(mb.get(), enc);
+  const ACE_CDR::Octet input[12] = {};
+  ASSERT_TRUE(writer.write_octet_array(input, 12));
+
+  Serializer reader(mb.get(), enc);
+  ACE_CDR::Octet value = 0;
+  ASSERT_TRUE(reader >> ACE_InputCDR::to_octet(value));
+  EXPECT_TRUE(reader.check_size(2, uint32_cdr_size, uint32_cdr_size));
+  EXPECT_FALSE(reader.check_size(3, uint32_cdr_size, uint32_cdr_size));
+  EXPECT_FALSE(reader.good_bit());
+}
+
+TEST(dds_DCPS_Serializer, Serializer_check_size_overflow)
+{
+  ACE_Message_Block mb(1);
+  const ACE_CDR::Octet value = 0;
+  ASSERT_EQ(0, mb.copy(reinterpret_cast<const char*>(&value), 1));
+  Serializer reader(&mb, Encoding());
+  EXPECT_FALSE(reader.check_size((std::numeric_limits<size_t>::max)(), 2));
+  EXPECT_FALSE(reader.good_bit());
+}
+
+TEST(dds_DCPS_Serializer, Serializer_read_limit_in_rdstate)
+{
+  Message_Block_Ptr mb(new ACE_Message_Block(8));
+  Serializer writer(mb.get(), Encoding());
+  const ACE_CDR::Octet input[8] = {};
+  ASSERT_TRUE(writer.write_octet_array(input, 8));
+
+  Serializer reader(mb.get(), Encoding());
+  const Serializer::RdState unrestricted = reader.rdstate();
+  ASSERT_TRUE(reader.set_read_limit(3));
+  const Serializer::RdState restricted = reader.rdstate();
+  EXPECT_EQ(3u, reader.length());
+
+  reader.rdstate(unrestricted);
+  EXPECT_EQ(8u, reader.length());
+  reader.rdstate(restricted);
+  EXPECT_EQ(3u, reader.length());
+}
+
+TEST(dds_DCPS_Serializer, Serializer_scoped_read_limit_rejects_skip)
+{
+  Message_Block_Ptr mb(new ACE_Message_Block(8));
+  const Encoding enc;
+  Serializer writer(mb.get(), enc);
+  const ACE_CDR::Octet input[] = {0, 1, 2, 3, 4, 5, 6, 7};
+  ASSERT_TRUE(writer.write_octet_array(input, 8));
+
+  Serializer reader(mb.get(), enc);
+  Serializer::ScopedReadLimit limit(reader, 3);
+  ASSERT_TRUE(limit.valid());
+  EXPECT_FALSE(reader.skip(4));
+  EXPECT_FALSE(reader.good_bit());
+  EXPECT_EQ(0u, reader.rpos());
+}
+
+TEST(dds_DCPS_Serializer, Serializer_scoped_read_limit_rejects_alignment)
+{
+  Message_Block_Ptr mb(new ACE_Message_Block(8));
+  const Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
+  Serializer writer(mb.get(), enc);
+  const ACE_CDR::Octet input[] = {0, 1, 2, 3, 4, 5, 6, 7};
+  ASSERT_TRUE(writer.write_octet_array(input, 8));
+
+  Serializer reader(mb.get(), enc);
+  Serializer::ScopedReadLimit limit(reader, 3);
+  ASSERT_TRUE(limit.valid());
+  ACE_CDR::Octet octet = 0;
+  ASSERT_TRUE(reader >> ACE_InputCDR::to_octet(octet));
+  ACE_CDR::ULong value = 0;
+  EXPECT_FALSE(reader >> value);
+  EXPECT_FALSE(reader.good_bit());
+  EXPECT_EQ(1u, reader.rpos());
+}
+
 TEST(dds_DCPS_Serializer, Serializer_align_context_basic_reference)
 {
   ACE_Message_Block amb(64);
@@ -532,6 +716,22 @@ TEST(dds_DCPS_Serializer, Serializer_test_bad_wstring)
   ASSERT_EQ(0, str);
 }
 
+TEST(dds_DCPS_Serializer, Serializer_test_odd_wstring_bytecount)
+{
+  Message_Block_Ptr amb(new ACE_Message_Block(7));
+  const Encoding enc(Encoding::KIND_XCDR1, ENDIAN_LITTLE);
+  Serializer ser_w(amb.get(), enc);
+  const ACE_CDR::Octet value[] = {0x41, 0, 0x42};
+  ASSERT_TRUE(ser_w << ACE_CDR::ULong(sizeof value));
+  ASSERT_TRUE(ser_w.write_octet_array(value, sizeof value));
+
+  Serializer ser(amb.get(), enc);
+  ACE_CDR::WChar* str = 0;
+  ASSERT_EQ(0u, ser.read_string(str));
+  ASSERT_FALSE(ser.good_bit());
+  ASSERT_EQ(0, str);
+}
+
 TEST(dds_DCPS_Serializer, Serializer_test_bad_string2)
 {
   static const ACE_CDR::Octet x[] = {1, 0, 0, 0, 1};
@@ -722,6 +922,38 @@ TEST(dds_DCPS_Serializer, parameter_id_xcdr1_serialized_size)
   serialized_size_list_end_parameter_id(enc, size, running_size,
                                         previous_header_extended);
   EXPECT_EQ(131124u, size);
+}
+
+TEST(dds_DCPS_Serializer, read_parameter_id_xcdr1_short_extended_header)
+{
+  const unsigned char xcdr[] = {
+    0x3f, 0x01, // PID_EXTENDED
+    0x00, 0x07  // Too short to contain the long ID and size
+  };
+  ACE_Message_Block mb(sizeof xcdr);
+  ASSERT_EQ(0, mb.copy(reinterpret_cast<const char*>(xcdr), sizeof xcdr));
+  const Encoding enc(Encoding::KIND_XCDR1, ENDIAN_BIG);
+  Serializer ser(&mb, enc);
+  unsigned id = 0;
+  size_t size = 0;
+  bool must_understand = false;
+  EXPECT_FALSE(ser.read_parameter_id(id, size, must_understand));
+  EXPECT_FALSE(ser.good_bit());
+}
+
+TEST(dds_DCPS_Serializer, read_delimiter_larger_than_input)
+{
+  const unsigned char xcdr[] = {
+    0x00, 0x00, 0x00, 0x05,
+    0x00, 0x00, 0x00, 0x00
+  };
+  ACE_Message_Block mb(sizeof xcdr);
+  ASSERT_EQ(0, mb.copy(reinterpret_cast<const char*>(xcdr), sizeof xcdr));
+  const Encoding enc(Encoding::KIND_XCDR2, ENDIAN_BIG);
+  Serializer ser(&mb, enc);
+  size_t size = 0;
+  EXPECT_FALSE(ser.read_delimiter(size));
+  EXPECT_FALSE(ser.good_bit());
 }
 
 namespace {

--- a/tests/unit-tests/dds/DCPS/Serializer.cpp
+++ b/tests/unit-tests/dds/DCPS/Serializer.cpp
@@ -1105,3 +1105,102 @@ TEST(dds_DCPS_Serializer, read_parameter_id_xcdr2_truncated_nextint)
     test_read_parameter_id_xcdr2_malformed(xcdr, sizeof(xcdr));
   }
 }
+
+namespace {
+  // Build a message block chain of `n` bytes from `xcdr`, split into `chunk`-byte
+  // links (0 == single block), mimicking the fragmented buffers the RTPS receive
+  // path hands to the Serializer.
+  ACE_Message_Block* chain_from(const unsigned char* xcdr, size_t n, size_t chunk)
+  {
+    if (chunk == 0 || chunk >= n) {
+      ACE_Message_Block* mb = new ACE_Message_Block(n ? n : 1);
+      mb->copy(reinterpret_cast<const char*>(xcdr), n);
+      return mb;
+    }
+    ACE_Message_Block* head = 0;
+    ACE_Message_Block* tail = 0;
+    for (size_t i = 0; i < n; i += chunk) {
+      const size_t len = (n - i < chunk) ? (n - i) : chunk;
+      ACE_Message_Block* mb = new ACE_Message_Block(len);
+      mb->copy(reinterpret_cast<const char*>(xcdr) + i, len);
+      if (!head) { head = tail = mb; } else { tail->cont(mb); tail = mb; }
+    }
+    return head;
+  }
+
+  // Walk an XCDR2 parameter list the way a mutable-struct/union reader does:
+  // read_parameter_id() then skip(size), until the reader reports end of stream,
+  // then call read_parameter_id() once more.  Returns the number of parameters
+  // consumed; sets `extra_ok` from the trailing call.  Must never crash.
+  int walk_parameter_ids_xcdr2(const unsigned char* xcdr, size_t n, Endianness endian,
+                               size_t chunk, bool& extra_ok)
+  {
+    const Encoding enc(Encoding::KIND_XCDR2, endian);
+    ACE_Message_Block* head = chain_from(xcdr, n, chunk);
+    Serializer ser(head, enc);
+    int count = 0;
+    for (;;) {
+      unsigned id = 0xdead;
+      size_t size = 0xdead;
+      bool must_understand = false;
+      if (!ser.read_parameter_id(id, size, must_understand)) {
+        break;
+      }
+      ++count;
+      if (!ser.skip(size)) {
+        break;
+      }
+    }
+    unsigned id = 0xdead;
+    size_t size = 0xdead;
+    bool must_understand = false;
+    extra_ok = ser.read_parameter_id(id, size, must_understand);
+    ACE_Message_Block::release(head);
+    return count;
+  }
+}
+
+// Regression test for GHSA-w6x3-92q6-jr7g: reading past the end of an XCDR2
+// parameter list must fail cleanly instead of dereferencing an exhausted
+// message-block chain in Serializer::peek() / peek_helper().  Exercised over
+// single and fragmented buffers and both endiannesses, plus a list whose final
+// bytes are a bare LCgt4 EMHEADER (which forces the peek() at end of stream).
+TEST(dds_DCPS_Serializer, read_parameter_id_xcdr2_walk_past_end)
+{
+  // Three well-formed members: LC=4 (4-byte body), LC=6 (nextint 1 => 4-byte
+  // body), LC=7 (nextint 1 => 8-byte body).  Nothing follows the last member.
+  const unsigned char be[] = {
+    0x40, 0x00, 0x00, 0x01,  0x00, 0x00, 0x00, 0x04,  0xde, 0xad, 0xbe, 0xef,
+    0x60, 0x00, 0x00, 0x02,  0x00, 0x00, 0x00, 0x01,  0x11, 0x22, 0x33, 0x44,
+    0x70, 0x00, 0x00, 0x03,  0x00, 0x00, 0x00, 0x01,
+    0x01, 0x02, 0x03, 0x04,  0x05, 0x06, 0x07, 0x08
+  };
+  const unsigned char le[] = {
+    0x01, 0x00, 0x00, 0x40,  0x04, 0x00, 0x00, 0x00,  0xde, 0xad, 0xbe, 0xef,
+    0x02, 0x00, 0x00, 0x60,  0x01, 0x00, 0x00, 0x00,  0x11, 0x22, 0x33, 0x44,
+    0x03, 0x00, 0x00, 0x70,  0x01, 0x00, 0x00, 0x00,
+    0x01, 0x02, 0x03, 0x04,  0x05, 0x06, 0x07, 0x08
+  };
+  const size_t chunks[] = {0, 1, 3, 4, 7};
+  for (size_t c = 0; c < sizeof(chunks) / sizeof(chunks[0]); ++c) {
+    bool extra_ok = true;
+    EXPECT_EQ(3, walk_parameter_ids_xcdr2(be, sizeof(be), ENDIAN_BIG, chunks[c], extra_ok));
+    EXPECT_FALSE(extra_ok);
+    extra_ok = true;
+    EXPECT_EQ(3, walk_parameter_ids_xcdr2(le, sizeof(le), ENDIAN_LITTLE, chunks[c], extra_ok));
+    EXPECT_FALSE(extra_ok);
+  }
+
+  // List that ends on a bare LC=5 EMHEADER: the first read_parameter_id()
+  // consumes it and then peek()s for the nextint with the stream exhausted.
+  const unsigned char trailing_emheader[] = {
+    0x40, 0x00, 0x00, 0x01,  0x00, 0x00, 0x00, 0x04,  0xde, 0xad, 0xbe, 0xef,
+    0x50, 0x00, 0x00, 0x02
+  };
+  for (size_t c = 0; c < sizeof(chunks) / sizeof(chunks[0]); ++c) {
+    bool extra_ok = true;
+    EXPECT_EQ(1, walk_parameter_ids_xcdr2(trailing_emheader, sizeof(trailing_emheader),
+                                          ENDIAN_BIG, chunks[c], extra_ok));
+    EXPECT_FALSE(extra_ok);
+  }
+}

--- a/tests/unit-tests/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
+++ b/tests/unit-tests/dds/DCPS/XTypes/DynamicDataXcdrReadImpl.cpp
@@ -2044,7 +2044,7 @@ TEST(dds_DCPS_XTypes_DynamicDataXcdrReadImpl, Appendable_ReadSequenceFromStruct)
   DDS::DynamicType_var dt = tls.complete_to_dynamic(it->second.complete, DCPS::GUID_t());
 
   unsigned char sequence_struct[] = {
-    0x00,0x00,0x00,0xe8, // dheader
+    0x00,0x00,0x00,0xea, // dheader (234 = the 234 content bytes that follow)
     0,0,0,12, 0,0,0,2, 0,0,0,1, 0,0,0,2, // +16=16 my_enums
     0,0,0,3, 0,0,0,3, 0,0,0,4, 0,0,0,5, // +16=32 int_32s
     0,0,0,2, 0,0,0,10, 0,0,0,11, // +12=44 uint_32s
@@ -2064,7 +2064,7 @@ TEST(dds_DCPS_XTypes_DynamicDataXcdrReadImpl, Appendable_ReadSequenceFromStruct)
     (0),(0), 0,0,0,1, 1, // +(2)+5=185 bool_s
     (0),(0),(0), 0,0,0,12, 0,0,0,1, 0,0,0,4, 'a','b','c','\0', // +(3)+16=204 str_s
     0,0,0,26, 0,0,0,2, 0,0,0,6, 0,0x64,0,0x65,0,0x66,(0),(0),
-    0,0,0,6, 0,0x67,0,0x68,0,0x69 // +16+(2)+10=232 wstr_s
+    0,0,0,6, 0,0x67,0,0x68,0,0x69 // +18+(2)+10=234 wstr_s
   };
   ACE_Message_Block msg(1024);
   msg.copy((const char*)sequence_struct, sizeof(sequence_struct));
@@ -2925,7 +2925,7 @@ TEST(dds_DCPS_XTypes_DynamicDataXcdrReadImpl, Final_ReadSequenceFromStruct)
     (0),(0), 0,0,0,1, 1, // +(2)+5=185 bool_s
     (0),(0),(0), 0,0,0,12, 0,0,0,1, 0,0,0,4, 'a','b','c','\0', // +(3)+16=204 str_s
     0,0,0,26, 0,0,0,2, 0,0,0,6, 0,0x64,0,0x65,0,0x66,(0),(0),
-    0,0,0,6, 0,0x67,0,0x68,0,0x69 // +16+(2)+10=232 wstr_s
+    0,0,0,6, 0,0x67,0,0x68,0,0x69 // +18+(2)+10=234 wstr_s
   };
   ACE_Message_Block msg(1024);
   msg.copy((const char*)sequence_struct, sizeof(sequence_struct));
@@ -3387,7 +3387,7 @@ TEST(dds_DCPS_XTypes_DynamicDataXcdrReadImpl, Final_ImplicitNestedKeyOnly)
   EXPECT_TRUE(dt);
 
   const unsigned char expected_cdr[] = {
-    0x20,0x00,0x00,0x01, // Dheader of inner
+    0x00,0x00,0x00,0x04, // Dheader of inner (appendable): one long follows
     0x00,0x00,0xee,0xff //l
   };
   ACE_Message_Block msg(32);


### PR DESCRIPTION
### Motivation

Harden XCDR1 and XCDR2 deserialization against malformed or inconsistent wire data that could cause excessive allocation, boundary over-reads, invalid Boolean representations, or sanitizer failures.

### Description of changes

- Normalize deserialized Boolean values so a wire byte other than 0 or 1 cannot produce an invalid `bool`.
- Validate sequence and map element counts against the remaining serialized size — accounting for element size and alignment — before allocating any container, and check the result of `read_<primitive>_array()` in the generated bounded-sequence reader.
- Enforce XCDR2 `DHEADER` sizes and XCDR1/XCDR2 mutable-member sizes as hard read boundaries through a `Serializer::ScopedReadLimit` helper; a delimited object or member that under-reports its size is now rejected instead of over-reading into later data. Bound the `read_string` pre-allocation check by the active limit.
- Reject malformed XCDR1 extended parameter headers, XCDR2 EMHEADER length codes, mutable-union discriminator IDs, and non-empty parameter-list-end sentinels.
- Preserve forward compatibility for unknown bitmask bits and, when member names are ignored, for compatible unions whose members use different IDs (see #5283).

Cleanup carried alongside the hardening:

- Add a one-argument `ScopedReadLimit(Serializer&)` that reads the XCDR2 delimiter and installs the limit; collapse ~65 near-identical `operator>>` prologues in `TypeObject.cpp` and drop the manual skip-to-end blocks it makes redundant.
- Add `ScopedReadLimit::reset()` and use it to scope the `DynamicData` mutable-member read limits with RAII.
- Regression tests for the malformed-input cases; correct two `DynamicDataXcdrReadImpl` test fixtures whose `DHEADER` values did not match their payloads (previously accepted only because the delimiter was unvalidated).

### Issues

Fixes #5281
Fixes #5287
Fixes #5289

Related, partially addressed: #5232 and #3133 (unchecked CDR extraction results — this PR fixes the generated bounded-primitive-sequence path, not the general sweep). #5288 (XCDR1 trailing bytes after a short sequence length) is intentionally out of scope: XCDR1 has no object framing, so it is a candidate for a future opt-in strict-decoding mode.
